### PR TITLE
chore: add github issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,84 @@
+name: Bug report
+description: Report something that isn't working as expected
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please fill in as much
+        detail as you can — it speeds up triage.
+
+  - type: checkboxes
+    id: privacy
+    attributes:
+      label: Privacy check
+      description: |
+        MedMCP is used in clinical and research environments. Please confirm
+        before submitting.
+      options:
+        - label: I have not pasted any patient data, PHI, or sensitive imaging metadata in this report.
+          required: true
+        - label: I have searched existing issues to make sure this isn't a duplicate.
+          required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe what you did and what went wrong.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Run `just ...`
+        2. Type `...` into the chat
+        3. ...
+    validations:
+      required: true
+
+  - type: input
+    id: medmcp-version
+    attributes:
+      label: MedMCP version or commit
+      placeholder: e.g. 0.1.0 or commit sha
+    validations:
+      required: true
+
+  - type: input
+    id: model
+    attributes:
+      label: Model
+      placeholder: e.g. devstral-medmcp via Ollama
+    validations:
+      required: false
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      placeholder: |
+        - OS:
+        - Python:
+        - Ollama version:
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or error output
+      description: Paste any relevant terminal output. Will be auto-formatted as a code block.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,43 @@
+name: Feature request
+description: Suggest a new capability, tool, or workflow
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement. MedMCP grows through community
+        contributions — feature requests are welcome.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: |
+        Describe the use case, not just the proposed solution. What can't
+        you do today, and why does it matter?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How should it work? UI, CLI, tool name, expected behavior.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds, other tools, or alternate designs you thought about.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      options:
+        - label: I'd be willing to help implement this.
+          required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Summary
+<!-- One or two sentences: what changes and why. -->
+
+## Related issue
+<!-- e.g. Closes #123. Delete if N/A. -->
+
+## Test plan
+<!-- Bulleted checklist of how you (and reviewers) verified this works. -->
+- [ ]
+
+## Screenshots
+<!-- For UI changes. Delete if N/A. -->
+
+## Security & data handling
+<!-- Delete if N/A. Otherwise note: new tool surface, new network calls, new
+     file-write paths, anything that touches patient data, or anything that
+     expands what the agent can do without user approval. -->
+
+## Notes
+<!-- Optional: dependency churn, follow-ups, anything not obvious from the diff. -->


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                       
  Adds GitHub issue forms (bug report + feature request) and a pull request template so contributors get prompted for the right info.                                                                              
                                                                                                                                                                                                                   
  ## Why YAML issue forms instead of markdown templates                                                                                                                                                            
  Markdown templates are just an editable text blob with placeholder content — contributors can (and do) ignore the prompts, paste over the structure, or skip required info entirely. YAML issue forms render as a
   real UI with structured inputs:                                                                                                                                                                                 
                                                                                                                                                                                                                   
  - **Required fields are enforced.** Contributors can't submit a bug report without reproduction steps or a version number.
  - **The privacy checkbox is mandatory**, not just suggested. Given the clinical/research context, having "I have not pasted any patient data" be a hard gate (not a hopeful note in a markdown comment) is the   
  main reason for the choice.                               
  - **Stable field IDs** (e.g. `id: medmcp-version`) make the issues parseable by future automation — auto-labeling, auto-assignment, dedup checks.                                                                
  - **`render: shell`** on the logs field auto-wraps pasted output as a code block, so we get readable bug reports without coaching.
                                                                                                                                                                                                                   
  ## Test plan                                                                                                                                                                                                     
  - [x] After merge, click "New issue" on the repo and confirm both forms show up in the chooser.                                                                                                                  
  - [x] Open a new PR against main and confirm the template body pre-fills.                                                                                                                                        
  - [x] Try submitting a bug report with the privacy checkbox unchecked — should be blocked.      