### PR TITLE
fix: unwrap hardcoded line breaks in github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,16 +5,14 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to file a bug. Please fill in as much
-        detail as you can — it speeds up triage.
+        Thanks for taking the time to file a bug. Please fill in as much detail as you can — it speeds up triage.
 
   - type: checkboxes
     id: privacy
     attributes:
       label: Privacy check
       description: |
-        MedMCP is used in clinical and research environments. Please confirm
-        before submitting.
+        MedMCP is used in clinical and research environments. Please confirm before submitting.
       options:
         - label: I have not pasted any patient data, PHI, or sensitive imaging metadata in this report.
           required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -5,16 +5,14 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for suggesting an improvement. MedMCP grows through community
-        contributions — feature requests are welcome.
+        Thanks for suggesting an improvement. MedMCP grows through community contributions — feature requests are welcome.
 
   - type: textarea
     id: problem
     attributes:
       label: What problem does this solve?
       description: |
-        Describe the use case, not just the proposed solution. What can't
-        you do today, and why does it matter?
+        Describe the use case, not just the proposed solution. What can't you do today, and why does it matter?
     validations:
       required: true
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,9 +12,7 @@
 <!-- For UI changes. Delete if N/A. -->
 
 ## Security & data handling
-<!-- Delete if N/A. Otherwise note: new tool surface, new network calls, new
-     file-write paths, anything that touches patient data, or anything that
-     expands what the agent can do without user approval. -->
+<!-- Delete if N/A. Otherwise note: new tool surface, new network calls, new file-write paths, anything that touches patient data, or anything that expands what the agent can do without user approval. -->
 
 ## Notes
 <!-- Optional: dependency churn, follow-ups, anything not obvious from the diff. -->


### PR DESCRIPTION
Closes #2

## Summary
Removes the ~80-char hardcoded line breaks from the prose blocks in our issue forms and PR template. Markdown/GitHub already wraps text on render, so the hardcoded breaks just leaked through as awkward        
  mid-sentence newlines. 

## Related issue
Closes #2   

## Test plan
- [ ] After merge, open a new bug report and confirm the intro text reads as one paragraph without mid-sentence breaks                                                                                           
 - [ ] Same for feature_request and the PR template comment hints       
