### PR TITLE
fix: add restrictions for bash calls

### DIFF
--- a/.vibe/config.toml
+++ b/.vibe/config.toml
@@ -137,3 +137,9 @@ codeignore_file = ".vibeignore"
 permission = "always"
 allowlist = []
 denylist = []
+
+[tools.bash]
+permission = "ask"
+allowlist = []
+denylist_standalone = []
+sensitive_patterns = ["sudo"]


### PR DESCRIPTION
## Summary
  - Add a `[tools.bash]` section to `.vibe/config.toml` so bash invocations default to `permission = "ask"` instead of inheriting permissive defaults.
  - Flag `sudo` as a sensitive pattern to ensure privilege-escalating commands are always surfaced for explicit approval.
  - Leave `allowlist` / `denylist_standalone` empty as a starting point for future tightening.


## Related issue
Closes #8 

## Test plan
  - [ ] Launch the agent and confirm bash commands prompt for approval.
  - [ ] Confirm a command containing `sudo` is flagged as sensitive.