### PR TITLE
Feature (UI): persist chat history with sqlite-backend thread

### DIFF
--- a/.chainlit/config.toml
+++ b/.chainlit/config.toml
@@ -108,7 +108,7 @@ name = "MedMCP"
 # default_chat_settings_open = false
 
 # Whether to prompt user confirmation on clicking 'New Chat'
-confirm_new_chat = true
+confirm_new_chat = false
 
 # Description of the assistant. This is used for HTML tags.
 # description = ""

--- a/.gitignore
+++ b/.gitignore
@@ -214,3 +214,5 @@ __marimo__/
 .vibe/logs/
 .vibe/vibehistory
 .vibe/trusted_folders.toml
+.vibe/medmcp_threads.db
+.vibe/medmcp_threads.db-journal

--- a/chainlit.md
+++ b/chainlit.md
@@ -1,1 +1,2 @@
-<!-- Intentionally empty. Chainlit treats an empty chainlit.md as "no welcome screen", which is what we want for MedMCP. If this file is deleted, Chainlit auto-regenerates a default marketing page on next startup (see chainlit/markdown.py:init_markdown) — don't do that. -->
+# MedMCP
+We wil add information on how to use this tool with a later PR.

--- a/justfile
+++ b/justfile
@@ -13,6 +13,8 @@ clean:
     rm -rf src/*.egg-info
     rm -f .coverage
     rm -f coverage.*
+
+clean-chats:
     rm -rf .vibe/logs
     rm -f .vibe/medmcp_threads.db
     rm -f .vibe/trusted_folders.toml

--- a/justfile
+++ b/justfile
@@ -13,6 +13,11 @@ clean:
     rm -rf src/*.egg-info
     rm -f .coverage
     rm -f coverage.*
+    rm -rf .vibe/logs
+    rm -f .vibe/medmcp_threads.db
+    rm -f .vibe/trusted_folders.toml
+    rm -rf .vibe/vibehistory
+    rm -f .env
 
 @install_uv:
 	if ! command -v uv >/dev/null 2>&1; then \
@@ -40,4 +45,4 @@ vibe *ARGS:
 
 # Launch the Chainlit web UI
 ui:
-    uv run chainlit run src/medmcp/app.py
+    @./scripts/run_ui.sh

--- a/justfile
+++ b/justfile
@@ -17,7 +17,6 @@ clean:
     rm -f .vibe/medmcp_threads.db
     rm -f .vibe/trusted_folders.toml
     rm -rf .vibe/vibehistory
-    rm -f .env
 
 @install_uv:
 	if ! command -v uv >/dev/null 2>&1; then \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ requires-python = ">=3.12"
 dependencies = [
     "chainlit>=2.0,<3",
     "mistral-vibe>=2.7,<3",
+    "sqlalchemy[asyncio]>=2.0,<3",
+    "aiosqlite>=0.20",
 ]
 
 [project.scripts]

--- a/scripts/run_ui.sh
+++ b/scripts/run_ui.sh
@@ -1,9 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Anchor to the repo root so `.env` lookups work regardless of where the
+# script is invoked from.
+cd "$(dirname "$0")/.."
+
 if ! grep -q '^CHAINLIT_AUTH_SECRET=' .env 2>/dev/null; then
     secret=$(uv run --quiet chainlit create-secret | grep '^CHAINLIT_AUTH_SECRET=')
     [ -n "$secret" ] || { echo "error: chainlit create-secret produced no CHAINLIT_AUTH_SECRET line" >&2; exit 1; }
+    # Ensure .env ends with a newline before appending so the new line doesn't
+    # concatenate onto an existing one. `tail -c1` + command substitution
+    # strips a trailing newline — if the result is non-empty, the last byte
+    # was not a newline, so we add one.
+    if [ -s .env ] && [ "$(tail -c1 .env)" ]; then
+        printf '\n' >> .env
+    fi
     printf '%s\n' "$secret" >> .env
 fi
 

--- a/scripts/run_ui.sh
+++ b/scripts/run_ui.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! grep -q '^CHAINLIT_AUTH_SECRET=' .env 2>/dev/null; then
+    secret=$(uv run --quiet chainlit create-secret | grep '^CHAINLIT_AUTH_SECRET=')
+    [ -n "$secret" ] || { echo "error: chainlit create-secret produced no CHAINLIT_AUTH_SECRET line" >&2; exit 1; }
+    printf '%s\n' "$secret" >> .env
+fi
+
+uv run --env-file .env chainlit run src/medmcp/app.py

--- a/src/medmcp/app.py
+++ b/src/medmcp/app.py
@@ -638,20 +638,10 @@ async def on_chat_start() -> None:
     session_id = cast("str", result["sessionId"])
     _set_session_id(session_id)
     _client.register_session(session_id)
-
-    # Persist the chainlit-thread → vibe-session mapping so on_chat_resume can
-    # find it. Chainlit creates the thread row on first message anyway; calling
-    # update_thread here upserts an empty thread with the metadata set so the
-    # mapping is recoverable even if the user never sends a message.
-    thread_id = cl_context.session.thread_id
-    data_layer = cast("Any", cl_get_data_layer())
-    if thread_id and data_layer is not None:
-        with contextlib.suppress(Exception):
-            await data_layer.update_thread(
-                thread_id=thread_id,
-                user_id=_persisted_user_id(),
-                metadata={"vibe_session_id": session_id},
-            )
+    # Persisting the chainlit-thread → vibe-session mapping is deferred until
+    # the first user message (see on_message). Doing it eagerly here would
+    # upsert an empty thread row on every F5, littering the sidebar with empty
+    # threads from refreshes that never produced a conversation.
 
 
 @cl.on_chat_resume  # pyright: ignore[reportUnknownMemberType]
@@ -697,6 +687,10 @@ async def on_chat_resume(thread: ThreadDict) -> None:
     # rather than in limbo.
     queue = _client.register_session(vibe_session_id)
     _set_session_id(vibe_session_id)
+    # Resumed threads already have the mapping in their metadata (that's how
+    # we found vibe_session_id), so flag this chat as already persisted to
+    # skip the lazy update_thread call in on_message.
+    cl.user_session.set("vibe_session_persisted", True)  # pyright: ignore[reportUnknownMemberType]
 
     resp = await _client.request(
         "session/load",
@@ -737,6 +731,22 @@ async def on_message(message: cl.Message) -> None:
     if session_id is None:
         await cl.Message(content="Session not initialized. Please refresh.").send()
         return
+
+    # Persist the chainlit-thread → vibe-session mapping on the first message
+    # of this chat. Done lazily (rather than in on_chat_start) so refreshes
+    # that never produce a conversation don't leave empty threads in the
+    # sidebar. Idempotent: gated by a per-chat flag in user_session.
+    if not cl.user_session.get("vibe_session_persisted"):  # pyright: ignore[reportUnknownMemberType]
+        thread_id = cl_context.session.thread_id
+        data_layer = cast("Any", cl_get_data_layer())
+        if thread_id and data_layer is not None:
+            with contextlib.suppress(Exception):
+                await data_layer.update_thread(
+                    thread_id=thread_id,
+                    user_id=_persisted_user_id(),
+                    metadata={"vibe_session_id": session_id},
+                )
+        cl.user_session.set("vibe_session_persisted", True)  # pyright: ignore[reportUnknownMemberType]
 
     queue = _client.get_session_queue(session_id)
     if queue is None:

--- a/src/medmcp/app.py
+++ b/src/medmcp/app.py
@@ -226,7 +226,13 @@ class VibeAcpClient:
             self._pending.clear()
 
     async def request(self, method: str, params: JsonDict | None = None) -> JsonDict:
-        """Send a JSON-RPC request and await its response."""
+        """Send a JSON-RPC request and await its response.
+
+        The ``try/finally`` around ``await fut`` guarantees the pending-request
+        entry is removed from ``_pending`` even if the awaiting task is
+        cancelled mid-flight (e.g. the user clicks Stop). Without it, cancelled
+        requests would leak entries into ``_pending`` forever.
+        """
         assert self.proc is not None and self.proc.stdin is not None
         loop = asyncio.get_running_loop()
         fut: asyncio.Future[JsonDict] = loop.create_future()
@@ -239,7 +245,10 @@ class VibeAcpClient:
                 msg["params"] = params
             self.proc.stdin.write(_encode(msg))
             await self.proc.stdin.drain()
-        return await fut
+        try:
+            return await fut
+        finally:
+            self._pending.pop(req_id, None)
 
     async def notify(self, method: str, params: JsonDict | None = None) -> None:
         """Send a JSON-RPC notification (no id, no response expected)."""
@@ -700,6 +709,12 @@ async def on_chat_resume(thread: ThreadDict) -> None:
 
     # Drain replay events. Chainlit already has the conversation in its own
     # data layer and renders it from there, so we just acknowledge and discard.
+    #
+    # Invariant: vibe-acp flushes all replay frames BEFORE writing the
+    # session/load response, so by the time we get here the reader task has
+    # already routed them into this queue. Do not change to ``await queue.get()``
+    # without verifying that invariant still holds — otherwise stale replay
+    # frames could leak into the next on_message.
     while not queue.empty():
         with contextlib.suppress(asyncio.QueueEmpty):
             queue.get_nowait()
@@ -824,6 +839,11 @@ async def on_message(message: cl.Message) -> None:
         # Chainlit cancels our task when the user clicks Stop or sends a new
         # message mid-stream. Tell vibe-acp to abort its agent loop too,
         # otherwise the next session/prompt is rejected as concurrent.
+        #
+        # Also cancel the in-flight prompt request so the ``try/finally`` in
+        # ``VibeAcpClient.request`` runs and pops its entry from ``_pending``.
+        if not prompt_fut.done():
+            prompt_fut.cancel()
         await _cancel_and_drain()
         raise
 

--- a/src/medmcp/app.py
+++ b/src/medmcp/app.py
@@ -1,7 +1,9 @@
 """Chainlit chat UI for MedMCP, backed by vibe-acp.
 
-Spawns vibe-acp as a subprocess and speaks JSON-RPC 2.0 over stdin/stdout.
+Spawns a single vibe-acp subprocess and speaks JSON-RPC 2.0 over stdin/stdout.
 This gives the UI full access to vibe's tool system (bash, read_file, grep, etc.)
+and lets multiple chats live side-by-side as independent ACP sessions on top of
+the same subprocess.
 
 Run with:  chainlit run src/medmcp/app.py -w
 
@@ -11,8 +13,11 @@ This app exposes vibe-acp's full tool surface (bash, write_file, search_replace,
 web_fetch, ...) through a chat box. The threat model assumes:
 
 1. The Chainlit server runs on localhost only and is reachable only by the
-   operator. There is no authentication. Do NOT bind to 0.0.0.0 or expose
-   port 8000 over a network without adding ``password_auth_callback`` first.
+   operator. There is no real authentication: the ``header_auth_callback``
+   below returns a fixed local user solely so Chainlit's data layer (which
+   requires a user identifier to scope threads) is happy. Do NOT bind to
+   0.0.0.0 or expose port 8000 over a network without replacing this with a
+   real auth callback.
 2. Every tool call is gated by an interactive ``cl.AskActionMessage`` permission
    prompt — see :func:`_ask_user_for_permission`. The user must click Approve
    before any side effect occurs. There is no auto-approval path. Do NOT change
@@ -22,6 +27,18 @@ web_fetch, ...) through a chat box. The threat model assumes:
 3. vibe-acp's own bash allowlist/denylist (``.vibe/config.toml``) is the second
    line of defense. Keep it current.
 4. Permission decisions are logged to stderr (the chainlit terminal) for audit.
+
+CHAT HISTORY
+============
+Chats are persisted in two places:
+
+- vibe-acp writes its own JSONL transcripts to ``.vibe/logs/session/`` (one
+  directory per session, with ``messages.jsonl`` and ``meta.json``). This is
+  the source of truth that vibe replays from on ``session/load``.
+- Chainlit's SQLAlchemy data layer writes a thin index of threads/steps to
+  ``.vibe/medmcp_threads.db`` (sqlite). This is what powers the sidebar in the
+  Chainlit UI and the chainlit thread_id ↔ vibe-acp session_id mapping (stored
+  in thread metadata under the ``vibe_session_id`` key).
 """
 
 from __future__ import annotations
@@ -31,12 +48,18 @@ import contextlib
 import json
 import logging
 import os
+import sqlite3
 import sys
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any, cast
 
 import chainlit as cl
 from chainlit.context import context as cl_context
+from chainlit.data import get_data_layer as cl_get_data_layer
+from chainlit.data.sql_alchemy import SQLAlchemyDataLayer
+from chainlit.types import ThreadDict
+from chainlit.user import User
 
 # A loose alias for parsed JSON-RPC payloads. The ACP protocol is too dynamic
 # to model exhaustively as TypedDicts, so we keep the wire format as
@@ -44,6 +67,7 @@ from chainlit.context import context as cl_context
 JsonDict = dict[str, Any]
 
 # ── Audit logger ───────────────────────────────────────────
+
 # Permission decisions are written to stderr so they show up in the chainlit
 # terminal. This is the only audit trail; do not silence it.
 _audit: logging.Logger = logging.getLogger("medmcp.audit")
@@ -57,17 +81,14 @@ if not _audit.handlers:
 # ── Configuration ──────────────────────────────────────────
 
 PROJECT_ROOT: str = str(Path(__file__).resolve().parent.parent.parent)
+VIBE_HOME: Path = Path(PROJECT_ROOT) / ".vibe"
+THREADS_DB_PATH: Path = VIBE_HOME / "medmcp_threads.db"
 
-# ── JSON-RPC helpers ───────────────────────────────────────
+# Single fixed user identity used by the data layer. There is no auth: this
+# exists only so chainlit's per-user thread scoping has a stable key.
+LOCAL_USER_ID: str = "local"
 
-_msg_id: int = 0
-
-
-def _next_id() -> int:
-    """Return a fresh, monotonically increasing JSON-RPC request id."""
-    global _msg_id
-    _msg_id += 1
-    return _msg_id
+# ── JSON-RPC wire helpers ──────────────────────────────────
 
 
 def _encode(msg: JsonDict) -> bytes:
@@ -78,40 +99,6 @@ def _encode(msg: JsonDict) -> bytes:
 def _rpc_response(req_id: int, result: JsonDict) -> bytes:
     """Build a JSON-RPC response payload for a given request id."""
     return _encode({"jsonrpc": "2.0", "id": req_id, "result": result})
-
-
-async def _send(
-    proc: asyncio.subprocess.Process,
-    method: str,
-    params: JsonDict | None = None,
-) -> int:
-    """Send a JSON-RPC request to ``proc`` and return its assigned id.
-
-    The subprocess must have been created with ``stdin=PIPE``; this is enforced
-    by an assertion to satisfy strict type checking.
-    """
-    assert proc.stdin is not None, "subprocess must be created with stdin=PIPE"
-    req_id = _next_id()
-    msg: JsonDict = {"jsonrpc": "2.0", "id": req_id, "method": method}
-    if params:
-        msg["params"] = params
-    proc.stdin.write(_encode(msg))
-    await proc.stdin.drain()
-    return req_id
-
-
-async def _notify(
-    proc: asyncio.subprocess.Process,
-    method: str,
-    params: JsonDict | None = None,
-) -> None:
-    """Send a JSON-RPC notification (no id, no response expected)."""
-    assert proc.stdin is not None, "subprocess must be created with stdin=PIPE"
-    msg: JsonDict = {"jsonrpc": "2.0", "method": method}
-    if params:
-        msg["params"] = params
-    proc.stdin.write(_encode(msg))
-    await proc.stdin.drain()
 
 
 async def _read_line(stdout: asyncio.StreamReader) -> JsonDict | None:
@@ -131,18 +118,313 @@ async def _read_line(stdout: asyncio.StreamReader) -> JsonDict | None:
             continue
         if isinstance(parsed, dict):
             return cast("JsonDict", parsed)
-        # JSON-RPC peers should only send objects at the top level; ignore arrays/scalars.
 
 
-async def _read_until_response(proc: asyncio.subprocess.Process, req_id: int) -> JsonDict:
-    """Read messages until we receive the response matching ``req_id``."""
-    assert proc.stdout is not None, "subprocess must be created with stdout=PIPE"
-    while True:
-        msg = await _read_line(proc.stdout)
-        if msg is None:
-            return {"error": "EOF"}
-        if msg.get("id") == req_id and ("result" in msg or "error" in msg):
-            return msg
+# ── vibe-acp client (one subprocess, many sessions) ───────
+class VibeAcpClient:
+    """Owns a single ``vibe-acp`` subprocess and demuxes JSON-RPC frames.
+
+    A long-running background reader task reads frames from the subprocess's
+    stdout and routes them in two directions:
+
+    - **Responses** (frames with an ``id`` and a ``result``/``error`` field) are
+      delivered to the ``asyncio.Future`` registered for that request id by
+      :meth:`request`.
+    - **Server-initiated frames** (notifications and ``session/request_permission``
+      requests) are routed to the per-session ``asyncio.Queue`` registered by
+      :meth:`register_session`. Frames that arrive *before* a queue is
+      registered for their session id are buffered in ``_limbo`` and flushed
+      when the session is registered — this matters because vibe-acp may emit
+      ``update_available_commands`` for a freshly-created session before our
+      ``new_session`` response has come back to the caller.
+
+    A single global ``_write_lock`` serializes writes to stdin so concurrent
+    callers cannot interleave bytes mid-frame.
+    """
+
+    def __init__(self) -> None:
+        """Build an unstarted client. Call :meth:`ensure_started` before use."""
+        self.proc: asyncio.subprocess.Process | None = None
+        self._next_id: int = 0
+        self._pending: dict[int, asyncio.Future[JsonDict]] = {}
+        self._sessions: dict[str, asyncio.Queue[JsonDict]] = {}
+        self._limbo: dict[str, list[JsonDict]] = {}
+        self._reader_task: asyncio.Task[None] | None = None
+        self._init_lock: asyncio.Lock = asyncio.Lock()
+        self._write_lock: asyncio.Lock = asyncio.Lock()
+        self._initialized: bool = False
+
+    async def ensure_started(self) -> None:
+        """Spawn vibe-acp on first use and run the ACP ``initialize`` handshake.
+
+        Subsequent calls are no-ops. The init lock makes this safe under
+        concurrent ``on_chat_start`` calls (e.g. multiple browser tabs).
+        """
+        async with self._init_lock:
+            if self._initialized:
+                return
+            self.proc = await asyncio.create_subprocess_exec(
+                "uv",
+                "run",
+                "vibe-acp",
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=PROJECT_ROOT,
+                env={**os.environ, "VIBE_HOME": str(VIBE_HOME)},
+            )
+            self._reader_task = asyncio.create_task(self._read_loop())
+            resp = await self.request(
+                "initialize",
+                {"protocol_version": 1, "client_capabilities": {}},
+            )
+            if "error" in resp:
+                raise RuntimeError(f"vibe-acp initialize failed: {resp['error']}")
+            self._initialized = True
+
+    async def _read_loop(self) -> None:
+        """Read JSON-RPC frames forever and route them.
+
+        On EOF or unexpected exception, fail every still-pending future so the
+        callers don't hang waiting for a response that will never come.
+        """
+        assert self.proc is not None and self.proc.stdout is not None
+        try:
+            while True:
+                msg = await _read_line(self.proc.stdout)
+                if msg is None:
+                    break
+                # Response to one of our outgoing requests
+                if "id" in msg and ("result" in msg or "error" in msg):
+                    raw_id = msg.get("id")
+                    if isinstance(raw_id, int):
+                        fut = self._pending.pop(raw_id, None)
+                        if fut is not None and not fut.done():
+                            fut.set_result(msg)
+                    continue
+                # Server-initiated: notification (no id) OR request (with id)
+                method = msg.get("method")
+                if not isinstance(method, str):
+                    continue
+                params = cast("JsonDict", msg.get("params") or {})
+                # Pydantic models in vibe-acp use camelCase aliases on the wire.
+                session_id_raw = params.get("sessionId") or params.get("session_id")
+                if not isinstance(session_id_raw, str):
+                    continue
+                session_id = session_id_raw
+                if session_id in self._sessions:
+                    await self._sessions[session_id].put(msg)
+                else:
+                    # Stash until register_session() catches up.
+                    self._limbo.setdefault(session_id, []).append(msg)
+        except Exception:
+            _audit.exception("vibe-acp reader crashed")
+        finally:
+            for fut in self._pending.values():
+                if not fut.done():
+                    fut.set_exception(ConnectionError("vibe-acp subprocess closed"))
+            self._pending.clear()
+
+    async def request(self, method: str, params: JsonDict | None = None) -> JsonDict:
+        """Send a JSON-RPC request and await its response."""
+        assert self.proc is not None and self.proc.stdin is not None
+        loop = asyncio.get_running_loop()
+        fut: asyncio.Future[JsonDict] = loop.create_future()
+        async with self._write_lock:
+            req_id = self._next_id
+            self._next_id += 1
+            self._pending[req_id] = fut
+            msg: JsonDict = {"jsonrpc": "2.0", "id": req_id, "method": method}
+            if params is not None:
+                msg["params"] = params
+            self.proc.stdin.write(_encode(msg))
+            await self.proc.stdin.drain()
+        return await fut
+
+    async def notify(self, method: str, params: JsonDict | None = None) -> None:
+        """Send a JSON-RPC notification (no id, no response expected)."""
+        assert self.proc is not None and self.proc.stdin is not None
+        async with self._write_lock:
+            msg: JsonDict = {"jsonrpc": "2.0", "method": method}
+            if params is not None:
+                msg["params"] = params
+            self.proc.stdin.write(_encode(msg))
+            await self.proc.stdin.drain()
+
+    async def respond(self, req_id: int, result: JsonDict) -> None:
+        """Send a JSON-RPC response for a server-initiated request."""
+        assert self.proc is not None and self.proc.stdin is not None
+        async with self._write_lock:
+            self.proc.stdin.write(_rpc_response(req_id, result))
+            await self.proc.stdin.drain()
+
+    def register_session(self, session_id: str) -> asyncio.Queue[JsonDict]:
+        """Create the per-session inbound queue and flush any limbo messages."""
+        queue: asyncio.Queue[JsonDict] = asyncio.Queue()
+        self._sessions[session_id] = queue
+        for buffered in self._limbo.pop(session_id, []):
+            queue.put_nowait(buffered)
+        return queue
+
+    def unregister_session(self, session_id: str) -> None:
+        """Drop the per-session queue. Does not affect the subprocess."""
+        self._sessions.pop(session_id, None)
+
+    def get_session_queue(self, session_id: str) -> asyncio.Queue[JsonDict] | None:
+        """Look up an existing per-session queue without creating one."""
+        return self._sessions.get(session_id)
+
+
+# Module-level singleton. Chainlit imports this file once at startup, but the
+# subprocess itself is started lazily on first chat to avoid blocking import.
+_client: VibeAcpClient = VibeAcpClient()
+
+
+# ── Chainlit data layer (sqlite under .vibe/) ─────────────
+
+
+def _bootstrap_threads_db(db_path: Path) -> None:
+    """Create the chainlit data-layer schema if it doesn't exist yet.
+
+    Chainlit's ``SQLAlchemyDataLayer`` does not auto-create tables; it just
+    runs raw SQL against whatever schema exists. We bootstrap the minimum
+    schema synchronously with stdlib sqlite3 (no async cost, runs once per
+    process) so the data layer factory below can return immediately.
+
+    The ``steps`` columns must cover every key that chainlit's
+    ``Step.to_dict()`` emits with a non-None default — the data layer's
+    ``create_step`` filters out ``None`` values but inserts everything else,
+    so a missing column silently fails every ``Step`` write (``type="run"``,
+    ``type="tool"``, ...). ``Message.to_dict()`` leaves ``command``/``modes``
+    at ``None`` by default, which is why user/assistant messages persist even
+    with a minimal schema but tool and on_message ``run`` steps do not —
+    breaking chat resume because assistant messages end up as children of a
+    run step that was never written.
+    """
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript("""
+            CREATE TABLE IF NOT EXISTS users (
+                "id" TEXT PRIMARY KEY,
+                "identifier" TEXT NOT NULL UNIQUE,
+                "metadata" TEXT NOT NULL DEFAULT '{}',
+                "createdAt" TEXT
+            );
+
+            CREATE TABLE IF NOT EXISTS threads (
+                "id" TEXT PRIMARY KEY,
+                "createdAt" TEXT,
+                "name" TEXT,
+                "userId" TEXT,
+                "userIdentifier" TEXT,
+                "tags" TEXT,
+                "metadata" TEXT
+            );
+
+            CREATE TABLE IF NOT EXISTS steps (
+                "id" TEXT PRIMARY KEY,
+                "name" TEXT,
+                "type" TEXT,
+                "threadId" TEXT NOT NULL,
+                "parentId" TEXT,
+                "streaming" BOOLEAN,
+                "waitForAnswer" BOOLEAN,
+                "isError" BOOLEAN,
+                "metadata" TEXT,
+                "tags" TEXT,
+                "input" TEXT,
+                "output" TEXT,
+                "createdAt" TEXT,
+                "start" TEXT,
+                "end" TEXT,
+                "generation" TEXT,
+                "showInput" TEXT,
+                "language" TEXT,
+                "defaultOpen" BOOLEAN,
+                "autoCollapse" BOOLEAN,
+                "command" TEXT,
+                "modes" TEXT
+            );
+
+            CREATE TABLE IF NOT EXISTS elements (
+                "id" TEXT PRIMARY KEY,
+                "threadId" TEXT,
+                "type" TEXT,
+                "url" TEXT,
+                "chainlitKey" TEXT,
+                "name" TEXT NOT NULL,
+                "display" TEXT,
+                "objectKey" TEXT,
+                "size" TEXT,
+                "page" INTEGER,
+                "language" TEXT,
+                "forId" TEXT,
+                "mime" TEXT,
+                "props" TEXT
+            );
+
+            CREATE TABLE IF NOT EXISTS feedbacks (
+                "id" TEXT PRIMARY KEY,
+                "forId" TEXT NOT NULL,
+                "threadId" TEXT,
+                "value" INTEGER NOT NULL,
+                "comment" TEXT
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_steps_threadId ON steps("threadId");
+            CREATE INDEX IF NOT EXISTS idx_elements_threadId ON elements("threadId");
+            CREATE INDEX IF NOT EXISTS idx_feedbacks_forId ON feedbacks("forId");
+        """)
+
+        # Migrate pre-existing databases that were created before the columns
+        # above were added. ``ALTER TABLE ADD COLUMN`` is idempotent-unfriendly
+        # in sqlite (no IF NOT EXISTS), so probe ``pragma_table_info`` first.
+        existing_cols = {
+            row[0] for row in conn.execute('SELECT name FROM pragma_table_info("steps")')
+        }
+        for col, col_type in (
+            ("defaultOpen", "BOOLEAN"),
+            ("autoCollapse", "BOOLEAN"),
+            ("command", "TEXT"),
+            ("modes", "TEXT"),
+        ):
+            if col not in existing_cols:
+                conn.execute(f'ALTER TABLE steps ADD COLUMN "{col}" {col_type}')
+
+        # Repair rows orphaned by the pre-fix schema: assistant messages whose
+        # ``parentId`` pointed at a ``run`` step that failed to insert. Promote
+        # them to top level so they render on chat resume instead of vanishing
+        # into a missing parent. Idempotent — a no-op once there are no
+        # dangling parent references.
+        conn.execute(
+            """
+            UPDATE steps
+               SET "parentId" = NULL
+             WHERE "parentId" IS NOT NULL
+               AND "parentId" NOT IN (SELECT "id" FROM steps)
+            """
+        )
+
+        conn.commit()
+
+
+@cl.header_auth_callback  # pyright: ignore[reportUnknownMemberType]
+async def header_auth_callback(_headers: object) -> User | None:
+    """Return a fixed local user so chainlit's data layer can scope threads.
+
+    There is no real authentication: every connection is treated as the same
+    operator regardless of headers. The threat model is that this app is
+    reachable only on localhost. See module docstring for the full security
+    model.
+    """
+    return User(identifier=LOCAL_USER_ID, metadata={"role": "local"})
+
+
+@cl.data_layer  # pyright: ignore[reportUnknownMemberType]
+def get_data_layer() -> SQLAlchemyDataLayer:
+    """Wire chainlit to a local sqlite database for thread persistence."""
+    _bootstrap_threads_db(THREADS_DB_PATH)
+    return SQLAlchemyDataLayer(conninfo=f"sqlite+aiosqlite:///{THREADS_DB_PATH}")
 
 
 # ── Permission UI ──────────────────────────────────────────
@@ -223,71 +505,20 @@ async def _ask_user_for_permission(tc: JsonDict, options: list[JsonDict]) -> Jso
 # ── Session helpers ────────────────────────────────────────
 
 
-def _get_session_state() -> tuple[asyncio.subprocess.Process | None, str | None]:
-    """Return the per-chat ``(vibe-acp process, ACP session id)`` pair.
-
-    The values are stored on Chainlit's per-user session by :func:`on_chat_start`.
-    Casts narrow Chainlit's untyped ``user_session.get`` return value.
-    """
-    proc = cast(
-        "asyncio.subprocess.Process | None",
-        cl.user_session.get("proc"),  # pyright: ignore[reportUnknownMemberType]
-    )
-    session_id = cast(
+def _get_session_id() -> str | None:
+    """Return the vibe-acp session id stashed on the current chainlit chat."""
+    return cast(
         "str | None",
-        cl.user_session.get("session_id"),  # pyright: ignore[reportUnknownMemberType]
+        cl.user_session.get("vibe_session_id"),  # pyright: ignore[reportUnknownMemberType]
     )
-    return proc, session_id
 
 
-def _set_session_state(key: str, value: object) -> None:
-    """Wrap ``cl.user_session.set`` so the untyped call is in one place."""
-    cl.user_session.set(key, value)  # pyright: ignore[reportUnknownMemberType]
+def _set_session_id(session_id: str) -> None:
+    """Stash the vibe-acp session id on the current chainlit chat."""
+    cl.user_session.set("vibe_session_id", session_id)  # pyright: ignore[reportUnknownMemberType]
 
 
-# ── Chainlit hooks ─────────────────────────────────────────
-
-
-@cl.on_chat_start  # pyright: ignore[reportUnknownMemberType]
-async def on_chat_start() -> None:
-    """Spawn vibe-acp and initialize a session with the local model."""
-    proc = await asyncio.create_subprocess_exec(
-        "uv",
-        "run",
-        "vibe-acp",
-        stdin=asyncio.subprocess.PIPE,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        cwd=PROJECT_ROOT,
-        env={**os.environ, "VIBE_HOME": str(Path(PROJECT_ROOT) / ".vibe")},
-    )
-    _set_session_state("proc", proc)
-
-    # 1. Initialize
-    init_id = await _send(
-        proc,
-        "initialize",
-        {"protocol_version": 1, "client_capabilities": {}},
-    )
-    resp = await _read_until_response(proc, init_id)
-    if "error" in resp:
-        await cl.Message(content=f"Failed to initialize vibe-acp: {resp}").send()
-        return
-
-    # 2. Create session
-    session_id_req = await _send(
-        proc,
-        "session/new",
-        {"cwd": PROJECT_ROOT, "mcp_servers": []},
-    )
-    resp = await _read_until_response(proc, session_id_req)
-    if "error" in resp:
-        await cl.Message(content=f"Failed to create session: {resp}").send()
-        return
-
-    result = cast("JsonDict", resp.get("result") or {})
-    session_id = cast("str", result["sessionId"])
-    _set_session_state("session_id", session_id)
+# ── Update rendering ──────────────────────────────────────
 
 
 def _stringify_raw(raw: object) -> str:
@@ -375,36 +606,127 @@ async def _handle_tool_call_update(update: JsonDict, tool_steps: dict[str, cl.St
         await step.update()
 
 
+# ── Chainlit hooks ─────────────────────────────────────────
+
+
+@cl.on_chat_start  # pyright: ignore[reportUnknownMemberType]
+async def on_chat_start() -> None:
+    """Create a fresh vibe-acp session for this chainlit thread.
+
+    The vibe-acp subprocess is shared across all chats; this only allocates a
+    new session id on top of it. The mapping from chainlit thread → vibe
+    session is persisted in thread metadata so :func:`on_chat_resume` can pick
+    it back up later.
+    """
+    await _client.ensure_started()
+
+    resp = await _client.request("session/new", {"cwd": PROJECT_ROOT, "mcp_servers": []})
+    if "error" in resp:
+        await cl.Message(content=f"Failed to create vibe-acp session: {resp['error']}").send()
+        return
+
+    result = cast("JsonDict", resp.get("result") or {})
+    session_id = cast("str", result["sessionId"])
+    _set_session_id(session_id)
+    _client.register_session(session_id)
+
+    # Persist the chainlit-thread → vibe-session mapping so on_chat_resume can
+    # find it. Chainlit creates the thread row on first message anyway; calling
+    # update_thread here upserts an empty thread with the metadata set so the
+    # mapping is recoverable even if the user never sends a message.
+    thread_id = cl_context.session.thread_id
+    data_layer = cast("Any", cl_get_data_layer())
+    if thread_id and data_layer is not None:
+        with contextlib.suppress(Exception):
+            await data_layer.update_thread(
+                thread_id=thread_id,
+                user_id=_persisted_user_id(),
+                metadata={"vibe_session_id": session_id},
+            )
+
+
+@cl.on_chat_resume  # pyright: ignore[reportUnknownMemberType]
+async def on_chat_resume(thread: ThreadDict) -> None:
+    """Reattach to a previously-persisted vibe-acp session.
+
+    Chainlit has already loaded thread state from its own data layer and is
+    rendering it from ``thread["steps"]``; we don't need to re-emit any chat
+    UI here. We just need to tell vibe-acp to load the session into memory so
+    the next prompt has the full context. vibe will replay the conversation
+    history at us via ``session/update`` events; we drain and discard them
+    because chainlit's persistence is the source of truth for the UI.
+    """
+    await _client.ensure_started()
+
+    # ThreadDict's typing carries Dict[Unknown, Unknown] for the metadata field,
+    # which infects any direct access. Cast to a plain dict[str, Any] once and
+    # operate on that.
+    thread_any = cast("dict[str, Any]", thread)
+    raw_metadata: object = thread_any.get("metadata") or {}
+    if isinstance(raw_metadata, str):
+        try:
+            raw_metadata = cast("object", json.loads(raw_metadata))
+        except json.JSONDecodeError:
+            raw_metadata = {}
+    metadata: dict[str, Any] = (
+        cast("dict[str, Any]", raw_metadata) if isinstance(raw_metadata, dict) else {}
+    )
+    vibe_session_id: object = metadata.get("vibe_session_id")
+
+    if not isinstance(vibe_session_id, str):
+        # Old thread without a mapping (or one created before this code shipped).
+        # Fall back to a fresh session so the UI is at least usable.
+        _audit.warning(
+            "resume: thread %s has no vibe_session_id; starting fresh",
+            thread_any.get("id"),
+        )
+        await on_chat_start()
+        return
+
+    # Pre-register the queue *before* sending session/load so any replay events
+    # that arrive while we're waiting for the response land in the queue
+    # rather than in limbo.
+    queue = _client.register_session(vibe_session_id)
+    _set_session_id(vibe_session_id)
+
+    resp = await _client.request(
+        "session/load",
+        {"cwd": PROJECT_ROOT, "session_id": vibe_session_id, "mcp_servers": []},
+    )
+    if "error" in resp:
+        _audit.warning("resume: session/load failed: %s", resp["error"])
+        await cl.Message(content=f"Could not reload previous session: {resp['error']}").send()
+        return
+
+    # Drain replay events. Chainlit already has the conversation in its own
+    # data layer and renders it from there, so we just acknowledge and discard.
+    while not queue.empty():
+        with contextlib.suppress(asyncio.QueueEmpty):
+            queue.get_nowait()
+
+
+def _persisted_user_id() -> str | None:
+    """Best-effort lookup of the persisted user row id for the current session."""
+    user = cl_context.session.user
+    if user is None:
+        return None
+    # PersistedUser has an ``id``; bare User does not. Either is acceptable to
+    # update_thread (it falls back to userIdentifier-only if user_id is None).
+    return getattr(user, "id", None)
+
+
 @cl.on_message  # pyright: ignore[reportUnknownMemberType]
 async def on_message(message: cl.Message) -> None:
     """Send a prompt to vibe-acp and stream the response back into the UI."""
-    proc, session_id = _get_session_state()
-
-    if proc is None or session_id is None:
+    session_id = _get_session_id()
+    if session_id is None:
         await cl.Message(content="Session not initialized. Please refresh.").send()
         return
 
-    assert proc.stdout is not None, "subprocess must be created with stdout=PIPE"
-
-    prompt_id = await _send(
-        proc,
-        "session/prompt",
-        {
-            "session_id": session_id,
-            "prompt": [{"type": "text", "text": message.content}],
-        },
-    )
-
-    async def _cancel_and_drain() -> None:
-        """Cancel any in-flight vibe-acp task for this session.
-
-        Used when our own asyncio task gets cancelled (Chainlit stop button or
-        the user sending a new message). Without this, vibe-acp keeps running
-        the previous agent loop and the next ``session/prompt`` gets rejected
-        with "Concurrent prompts are not supported yet".
-        """
-        with contextlib.suppress(Exception):
-            await _notify(proc, "session/cancel", {"session_id": session_id})
+    queue = _client.get_session_queue(session_id)
+    if queue is None:
+        # Defensive: a queue should always exist for an in-flight chat.
+        queue = _client.register_session(session_id)
 
     # Chainlit wraps each on_message handler in a parent Step(type="run").
     # We attach tool steps AND the assistant message as siblings of that run
@@ -413,8 +735,6 @@ async def on_message(message: cl.Message) -> None:
     run_step = cl_context.current_step
     parent_id: str | None = run_step.id if run_step else None
 
-    # Lazily create the assistant message on the first text chunk so it gets
-    # appended *after* any tool steps from this turn.
     assistant_msg: cl.Message | None = None
 
     async def _ensure_assistant_msg() -> cl.Message:
@@ -430,63 +750,75 @@ async def on_message(message: cl.Message) -> None:
     # payload only carries `toolCallId`, not the title or raw_input.
     tool_call_info: dict[str, JsonDict] = {}
 
+    # Send the prompt and get a future for its response. We then race the
+    # future against queue reads so session_update notifications and
+    # request_permission requests are interleaved with the agent loop.
+    prompt_fut = asyncio.ensure_future(
+        _client.request(
+            "session/prompt",
+            {
+                "session_id": session_id,
+                "prompt": [{"type": "text", "text": message.content}],
+            },
+        )
+    )
+
+    async def _cancel_and_drain() -> None:
+        """Tell vibe-acp to abort its agent loop on this session.
+
+        Used when our own asyncio task gets cancelled (Chainlit stop button or
+        the user sending a new message). Without this, vibe-acp keeps running
+        the previous agent loop and the next ``session/prompt`` gets rejected
+        with "Concurrent prompts are not supported yet".
+        """
+        with contextlib.suppress(Exception):
+            await _client.notify("session/cancel", {"session_id": session_id})
+
     try:
         while True:
-            msg = await _read_line(proc.stdout)
-            if msg is None:
-                break
+            # Wait for either the next inbound frame for this session or the
+            # prompt response. We can't just `await queue.get()` because the
+            # response future may resolve while the queue is empty.
+            get_task: asyncio.Task[JsonDict] = asyncio.ensure_future(queue.get())
+            done, _pending = await asyncio.wait(
+                {get_task, prompt_fut},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
 
-            # ── Response to our prompt (completion or error) ──
-            if msg.get("id") == prompt_id and ("result" in msg or "error" in msg):
-                if "error" in msg:
-                    err = cast("JsonDict", msg["error"])
+            if get_task in done:
+                msg = get_task.result()
+            else:
+                # Prompt finished. Cancel the queue read and drain anything
+                # already buffered (e.g. a final usage_update).
+                get_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError, BaseException):
+                    await get_task
+                while not queue.empty():
+                    with contextlib.suppress(asyncio.QueueEmpty):
+                        leftover = queue.get_nowait()
+                        await _process_session_frame(
+                            leftover,
+                            assistant_msg_getter=_ensure_assistant_msg,
+                            tool_steps=tool_steps,
+                            tool_call_info=tool_call_info,
+                            parent_id=parent_id,
+                        )
+                # Surface any error from the prompt response itself.
+                resp = prompt_fut.result()
+                if "error" in resp:
+                    err = cast("JsonDict", resp["error"])
                     target = await _ensure_assistant_msg()
                     err_msg = err.get("message", str(err))
                     await target.stream_token(f"\n\nError: {err_msg}")
                 break
 
-            method = msg.get("method")
-
-            # ── Notification: session/update ──
-            if method == "session/update":
-                params = cast("JsonDict", msg.get("params") or {})
-                update = cast("JsonDict", params.get("update") or {})
-                update_type = update.get("sessionUpdate")
-
-                if update_type == "agent_message_chunk":
-                    content = cast("JsonDict", update.get("content") or {})
-                    if content.get("type") == "text":
-                        target = await _ensure_assistant_msg()
-                        text = cast("str", content.get("text") or "")
-                        await target.stream_token(text)
-
-                elif update_type == "tool_call":
-                    await _handle_tool_call(update, tool_steps, tool_call_info, parent_id)
-
-                elif update_type == "tool_call_update":
-                    await _handle_tool_call_update(update, tool_steps)
-
-            # ── Server request: permission ──
-            elif method == "session/request_permission":
-                req_id_raw = msg.get("id")
-                if not isinstance(req_id_raw, int):
-                    continue  # cannot respond without a request id
-                req_id: int = req_id_raw
-                params = cast("JsonDict", msg.get("params") or {})
-                tc: JsonDict = dict(cast("JsonDict", params.get("toolCall") or {}))
-                options = cast("list[JsonDict]", params.get("options") or [])
-                # Backfill title/rawInput from the cached tool_call event,
-                # because request_permission only ships the toolCallId.
-                cached = tool_call_info.get(cast("str", tc.get("toolCallId") or ""), {})
-                for key in ("title", "rawInput"):
-                    if tc.get(key) is None and cached.get(key) is not None:
-                        tc[key] = cached[key]
-
-                outcome = await _ask_user_for_permission(tc, options)
-
-                assert proc.stdin is not None
-                proc.stdin.write(_rpc_response(req_id, {"outcome": outcome}))
-                await proc.stdin.drain()
+            await _process_session_frame(
+                msg,
+                assistant_msg_getter=_ensure_assistant_msg,
+                tool_steps=tool_steps,
+                tool_call_info=tool_call_info,
+                parent_id=parent_id,
+            )
 
     except asyncio.CancelledError:
         # Chainlit cancels our task when the user clicks Stop or sends a new
@@ -499,6 +831,59 @@ async def on_message(message: cl.Message) -> None:
         await assistant_msg.update()
 
 
+async def _process_session_frame(
+    msg: JsonDict,
+    *,
+    assistant_msg_getter: Callable[[], Awaitable[cl.Message]],
+    tool_steps: dict[str, cl.Step],
+    tool_call_info: dict[str, JsonDict],
+    parent_id: str | None,
+) -> None:
+    """Dispatch one inbound JSON-RPC frame from a session queue.
+
+    Handles both ``session/update`` notifications (text chunks, tool calls,
+    tool results) and ``session/request_permission`` server requests, which
+    must be answered with a JSON-RPC response carrying the original request id.
+    """
+    method = msg.get("method")
+
+    if method == "session/update":
+        params = cast("JsonDict", msg.get("params") or {})
+        update = cast("JsonDict", params.get("update") or {})
+        update_type = update.get("sessionUpdate")
+
+        if update_type == "agent_message_chunk":
+            content = cast("JsonDict", update.get("content") or {})
+            if content.get("type") == "text":
+                target = await assistant_msg_getter()
+                text = cast("str", content.get("text") or "")
+                await target.stream_token(text)
+
+        elif update_type == "tool_call":
+            await _handle_tool_call(update, tool_steps, tool_call_info, parent_id)
+
+        elif update_type == "tool_call_update":
+            await _handle_tool_call_update(update, tool_steps)
+
+    elif method == "session/request_permission":
+        req_id_raw = msg.get("id")
+        if not isinstance(req_id_raw, int):
+            return  # cannot respond without a request id
+        req_id: int = req_id_raw
+        params = cast("JsonDict", msg.get("params") or {})
+        tc: JsonDict = dict(cast("JsonDict", params.get("toolCall") or {}))
+        options = cast("list[JsonDict]", params.get("options") or [])
+        # Backfill title/rawInput from the cached tool_call event, because
+        # request_permission only ships the toolCallId.
+        cached = tool_call_info.get(cast("str", tc.get("toolCallId") or ""), {})
+        for key in ("title", "rawInput"):
+            if tc.get(key) is None and cached.get(key) is not None:
+                tc[key] = cached[key]
+
+        outcome = await _ask_user_for_permission(tc, options)
+        await _client.respond(req_id, {"outcome": outcome})
+
+
 @cl.on_stop  # pyright: ignore[reportUnknownMemberType]
 async def on_stop() -> None:
     """Forward Chainlit's stop button to vibe-acp's ``session/cancel``.
@@ -507,17 +892,22 @@ async def on_stop() -> None:
     agent loop — and the next user prompt fails with
     "Concurrent prompts are not supported yet".
     """
-    proc, session_id = _get_session_state()
-    if proc is None or session_id is None or proc.returncode is not None:
+    session_id = _get_session_id()
+    if session_id is None:
         return
     with contextlib.suppress(Exception):
-        await _notify(proc, "session/cancel", {"session_id": session_id})
+        await _client.notify("session/cancel", {"session_id": session_id})
 
 
 @cl.on_chat_end  # pyright: ignore[reportUnknownMemberType]
 async def on_chat_end() -> None:
-    """Clean up the vibe-acp subprocess when the chat thread ends."""
-    proc, _ = _get_session_state()
-    if proc is not None and proc.returncode is None:
-        proc.terminate()
-        await proc.wait()
+    """Detach the chat from its vibe-acp session queue.
+
+    The subprocess is shared across chats and stays alive; we only release the
+    inbound queue so its memory can be reclaimed. The vibe-acp session itself
+    remains in vibe's in-memory session table (and on disk under
+    ``.vibe/logs/session/``) so it can be resumed later via ``session/load``.
+    """
+    session_id = _get_session_id()
+    if session_id is not None:
+        _client.unregister_session(session_id)

--- a/uv.lock
+++ b/uv.lock
@@ -136,6 +136,15 @@ wheels = [
 ]
 
 [[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -776,6 +785,53 @@ wheels = [
 ]
 
 [[package]]
+name = "greenlet"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/94/a5935717b307d7c71fe877b52b884c6af707d2d2090db118a03fbd799369/greenlet-3.4.0.tar.gz", hash = "sha256:f50a96b64dafd6169e595a5c56c9146ef80333e67d4476a65a9c55f400fc22ff", size = 195913, upload-time = "2026-04-08T17:08:00.863Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/8b/3669ad3b3f247a791b2b4aceb3aa5a31f5f6817bf547e4e1ff712338145a/greenlet-3.4.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:1a54a921561dd9518d31d2d3db4d7f80e589083063ab4d3e2e950756ef809e1a", size = 286902, upload-time = "2026-04-08T15:52:12.138Z" },
+    { url = "https://files.pythonhosted.org/packages/38/3e/3c0e19b82900873e2d8469b590a6c4b3dfd2b316d0591f1c26b38a4879a5/greenlet-3.4.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16dec271460a9a2b154e3b1c2fa1050ce6280878430320e85e08c166772e3f97", size = 606099, upload-time = "2026-04-08T16:24:38.408Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/33/99fef65e7754fc76a4ed14794074c38c9ed3394a5bd129d7f61b705f3168/greenlet-3.4.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:90036ce224ed6fe75508c1907a77e4540176dcf0744473627785dd519c6f9996", size = 618837, upload-time = "2026-04-08T16:30:58.298Z" },
+    { url = "https://files.pythonhosted.org/packages/44/57/eae2cac10421feae6c0987e3dc106c6d86262b1cb379e171b017aba893a6/greenlet-3.4.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6f0def07ec9a71d72315cf26c061aceee53b306c36ed38c35caba952ea1b319d", size = 624901, upload-time = "2026-04-08T16:40:38.981Z" },
+    { url = "https://files.pythonhosted.org/packages/36/f7/229f3aed6948faa20e0616a0b8568da22e365ede6a54d7d369058b128afd/greenlet-3.4.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a1c4f6b453006efb8310affb2d132832e9bbb4fc01ce6df6b70d810d38f1f6dc", size = 615062, upload-time = "2026-04-08T15:56:33.766Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/8a/0e73c9b94f31d1cc257fe79a0eff621674141cdae7d6d00f40de378a1e42/greenlet-3.4.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:0e1254cf0cbaa17b04320c3a78575f29f3c161ef38f59c977108f19ffddaf077", size = 423927, upload-time = "2026-04-08T16:43:05.293Z" },
+    { url = "https://files.pythonhosted.org/packages/08/97/d988180011aa40135c46cd0d0cf01dd97f7162bae14139b4a3ef54889ba5/greenlet-3.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9b2d9a138ffa0e306d0e2b72976d2fb10b97e690d40ab36a472acaab0838e2de", size = 1573511, upload-time = "2026-04-08T16:26:20.058Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/0f/a5a26fe152fb3d12e6a474181f6e9848283504d0afd095f353d85726374b/greenlet-3.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8424683caf46eb0eb6f626cb95e008e8cc30d0cb675bdfa48200925c79b38a08", size = 1640396, upload-time = "2026-04-08T15:57:30.88Z" },
+    { url = "https://files.pythonhosted.org/packages/42/cf/bb2c32d9a100e36ee9f6e38fad6b1e082b8184010cb06259b49e1266ca01/greenlet-3.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:a0a53fb071531d003b075c444014ff8f8b1a9898d36bb88abd9ac7b3524648a2", size = 238892, upload-time = "2026-04-08T17:03:10.094Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/47/6c41314bac56e71436ce551c7fbe3cc830ed857e6aa9708dbb9c65142eb6/greenlet-3.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:f38b81880ba28f232f1f675893a39cf7b6db25b31cc0a09bb50787ecf957e85e", size = 235599, upload-time = "2026-04-08T15:52:54.3Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/75/7e9cd1126a1e1f0cd67b0eda02e5221b28488d352684704a78ed505bd719/greenlet-3.4.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:43748988b097f9c6f09364f260741aa73c80747f63389824435c7a50bfdfd5c1", size = 285856, upload-time = "2026-04-08T15:52:45.82Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/c4/3e2df392e5cb199527c4d9dbcaa75c14edcc394b45040f0189f649631e3c/greenlet-3.4.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5566e4e2cd7a880e8c27618e3eab20f3494452d12fd5129edef7b2f7aa9a36d1", size = 610208, upload-time = "2026-04-08T16:24:39.674Z" },
+    { url = "https://files.pythonhosted.org/packages/da/af/750cdfda1d1bd30a6c28080245be8d0346e669a98fdbae7f4102aa95fff3/greenlet-3.4.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1054c5a3c78e2ab599d452f23f7adafef55062a783a8e241d24f3b633ba6ff82", size = 621269, upload-time = "2026-04-08T16:30:59.767Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/93/c8c508d68ba93232784bbc1b5474d92371f2897dfc6bc281b419f2e0d492/greenlet-3.4.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:98eedd1803353daf1cd9ef23eef23eda5a4d22f99b1f998d273a8b78b70dd47f", size = 628455, upload-time = "2026-04-08T16:40:40.698Z" },
+    { url = "https://files.pythonhosted.org/packages/54/78/0cbc693622cd54ebe25207efbb3a0eb07c2639cb8594f6e3aaaa0bb077a8/greenlet-3.4.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f82cb6cddc27dd81c96b1506f4aa7def15070c3b2a67d4e46fd19016aacce6cf", size = 617549, upload-time = "2026-04-08T15:56:34.893Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/46/cfaaa0ade435a60550fd83d07dfd5c41f873a01da17ede5c4cade0b9bab8/greenlet-3.4.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:b7857e2202aae67bc5725e0c1f6403c20a8ff46094ece015e7d474f5f7020b55", size = 426238, upload-time = "2026-04-08T16:43:06.865Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/c0/8966767de01343c1ff47e8b855dc78e7d1a8ed2b7b9c83576a57e289f81d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:227a46251ecba4ff46ae742bc5ce95c91d5aceb4b02f885487aff269c127a729", size = 1575310, upload-time = "2026-04-08T16:26:21.671Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/38/bcdc71ba05e9a5fda87f63ffc2abcd1f15693b659346df994a48c968003d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5b99e87be7eba788dd5b75ba1cde5639edffdec5f91fe0d734a249535ec3408c", size = 1640435, upload-time = "2026-04-08T15:57:32.572Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/c2/19b664b7173b9e4ef5f77e8cef9f14c20ec7fce7920dc1ccd7afd955d093/greenlet-3.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:849f8bc17acd6295fcb5de8e46d55cc0e52381c56eaf50a2afd258e97bc65940", size = 238760, upload-time = "2026-04-08T17:04:03.878Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/96/795619651d39c7fbd809a522f881aa6f0ead504cc8201c3a5b789dfaef99/greenlet-3.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:9390ad88b652b1903814eaabd629ca184db15e0eeb6fe8a390bbf8b9106ae15a", size = 235498, upload-time = "2026-04-08T17:05:00.584Z" },
+    { url = "https://files.pythonhosted.org/packages/78/02/bde66806e8f169cf90b14d02c500c44cdbe02c8e224c9c67bafd1b8cadd1/greenlet-3.4.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:10a07aca6babdd18c16a3f4f8880acfffc2b88dfe431ad6aa5f5740759d7d75e", size = 286291, upload-time = "2026-04-08T17:09:34.307Z" },
+    { url = "https://files.pythonhosted.org/packages/05/1f/39da1c336a87d47c58352fb8a78541ce63d63ae57c5b9dae1fe02801bbc2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:076e21040b3a917d3ce4ad68fb5c3c6b32f1405616c4a57aa83120979649bd3d", size = 656749, upload-time = "2026-04-08T16:24:41.721Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/6c/90ee29a4ee27af7aa2e2ec408799eeb69ee3fcc5abcecac6ddd07a5cd0f2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e82689eea4a237e530bb5cb41b180ef81fa2160e1f89422a67be7d90da67f615", size = 669084, upload-time = "2026-04-08T16:31:01.372Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/4a/74078d3936712cff6d3c91a930016f476ce4198d84e224fe6d81d3e02880/greenlet-3.4.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:06c2d3b89e0c62ba50bd7adf491b14f39da9e7e701647cb7b9ff4c99bee04b19", size = 673405, upload-time = "2026-04-08T16:40:42.527Z" },
+    { url = "https://files.pythonhosted.org/packages/07/49/d4cad6e5381a50947bb973d2f6cf6592621451b09368b8c20d9b8af49c5b/greenlet-3.4.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4df3b0b2289ec686d3c821a5fee44259c05cfe824dd5e6e12c8e5f5df23085cf", size = 665621, upload-time = "2026-04-08T15:56:35.995Z" },
+    { url = "https://files.pythonhosted.org/packages/79/3e/df8a83ab894751bc31e1106fdfaa80ca9753222f106b04de93faaa55feb7/greenlet-3.4.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:070b8bac2ff3b4d9e0ff36a0d19e42103331d9737e8504747cd1e659f76297bd", size = 471670, upload-time = "2026-04-08T16:43:08.512Z" },
+    { url = "https://files.pythonhosted.org/packages/37/31/d1edd54f424761b5d47718822f506b435b6aab2f3f93b465441143ea5119/greenlet-3.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8bff29d586ea415688f4cec96a591fcc3bf762d046a796cdadc1fdb6e7f2d5bf", size = 1622259, upload-time = "2026-04-08T16:26:23.201Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c6/6d3f9cdcb21c4e12a79cb332579f1c6aa1af78eb68059c5a957c7812d95e/greenlet-3.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8a569c2fb840c53c13a2b8967c63621fafbd1a0e015b9c82f408c33d626a2fda", size = 1686916, upload-time = "2026-04-08T15:57:34.282Z" },
+    { url = "https://files.pythonhosted.org/packages/63/45/c1ca4a1ad975de4727e52d3ffe641ae23e1d7a8ffaa8ff7a0477e1827b92/greenlet-3.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:207ba5b97ea8b0b60eb43ffcacf26969dd83726095161d676aac03ff913ee50d", size = 239821, upload-time = "2026-04-08T17:03:48.423Z" },
+    { url = "https://files.pythonhosted.org/packages/71/c4/6f621023364d7e85a4769c014c8982f98053246d142420e0328980933ceb/greenlet-3.4.0-cp314-cp314-win_arm64.whl", hash = "sha256:f8296d4e2b92af34ebde81085a01690f26a51eb9ac09a0fcadb331eb36dbc802", size = 236932, upload-time = "2026-04-08T17:04:33.551Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/8f/18d72b629783f5e8d045a76f5325c1e938e659a9e4da79c7dcd10169a48d/greenlet-3.4.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:d70012e51df2dbbccfaf63a40aaf9b40c8bed37c3e3a38751c926301ce538ece", size = 294681, upload-time = "2026-04-08T15:52:35.778Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ad/5fa86ec46769c4153820d58a04062285b3b9e10ba3d461ee257b68dcbf53/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a58bec0751f43068cd40cff31bb3ca02ad6000b3a51ca81367af4eb5abc480c8", size = 658899, upload-time = "2026-04-08T16:24:43.32Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f0/4e8174ca0e87ae748c409f055a1ba161038c43cc0a5a6f1433a26ac2e5bf/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:05fa0803561028f4b2e3b490ee41216a842eaee11aed004cc343a996d9523aa2", size = 665284, upload-time = "2026-04-08T16:31:02.833Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/92/466b0d9afd44b8af623139a3599d651c7564fa4152f25f117e1ee5949ffb/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c4cd56a9eb7a6444edbc19062f7b6fbc8f287c663b946e3171d899693b1c19fa", size = 665872, upload-time = "2026-04-08T16:40:43.912Z" },
+    { url = "https://files.pythonhosted.org/packages/19/da/991cf7cd33662e2df92a1274b7eb4d61769294d38a1bba8a45f31364845e/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e60d38719cb80b3ab5e85f9f1aed4960acfde09868af6762ccb27b260d68f4ed", size = 661861, upload-time = "2026-04-08T15:56:37.269Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/14/3395a7ef3e260de0325152ddfe19dffb3e49fe10873b94654352b53ad48e/greenlet-3.4.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:1f85f204c4d54134ae850d401fa435c89cd667d5ce9dc567571776b45941af72", size = 489237, upload-time = "2026-04-08T16:43:09.993Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c5/6c2c708e14db3d9caea4b459d8464f58c32047451142fe2cfd90e7458f41/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f50c804733b43eded05ae694691c9aa68bca7d0a867d67d4a3f514742a2d53f", size = 1622182, upload-time = "2026-04-08T16:26:24.777Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/4c/50c5fed19378e11a29fabab1f6be39ea95358f4a0a07e115a51ca93385d8/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2d4f0635dc4aa638cda4b2f5a07ae9a2cff9280327b581a3fcb6f317b4fbc38a", size = 1685050, upload-time = "2026-04-08T15:57:36.453Z" },
+    { url = "https://files.pythonhosted.org/packages/db/72/85ae954d734703ab48e622c59d4ce35d77ce840c265814af9c078cacc7aa/greenlet-3.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1a4a48f24681300c640f143ba7c404270e1ebbbcf34331d7104a4ff40f8ea705", size = 245554, upload-time = "2026-04-08T17:03:50.044Z" },
+]
+
+[[package]]
 name = "grpcio"
 version = "1.80.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1207,8 +1263,10 @@ name = "medmcp"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "aiosqlite" },
     { name = "chainlit" },
     { name = "mistral-vibe" },
+    { name = "sqlalchemy", extra = ["asyncio"] },
 ]
 
 [package.dev-dependencies]
@@ -1231,8 +1289,10 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiosqlite", specifier = ">=0.20" },
     { name = "chainlit", specifier = ">=2.0,<3" },
     { name = "mistral-vibe", specifier = ">=2.7,<3" },
+    { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0,<3" },
 ]
 
 [package.metadata.requires-dev]
@@ -2873,6 +2933,57 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+]
+
+[[package]]
+name = "sqlalchemy"
+version = "2.0.49"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/45/461788f35e0364a8da7bda51a1fe1b09762d0c32f12f63727998d85a873b/sqlalchemy-2.0.49.tar.gz", hash = "sha256:d15950a57a210e36dd4cec1aac22787e2a4d57ba9318233e2ef8b2daf9ff2d5f", size = 9898221, upload-time = "2026-04-03T16:38:11.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/b3/2de412451330756aaaa72d27131db6dde23995efe62c941184e15242a5fa/sqlalchemy-2.0.49-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4bbccb45260e4ff1b7db0be80a9025bb1e6698bdb808b83fff0000f7a90b2c0b", size = 2157681, upload-time = "2026-04-03T16:53:07.132Z" },
+    { url = "https://files.pythonhosted.org/packages/50/84/b2a56e2105bd11ebf9f0b93abddd748e1a78d592819099359aa98134a8bf/sqlalchemy-2.0.49-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fb37f15714ec2652d574f021d479e78cd4eb9d04396dca36568fdfffb3487982", size = 3338976, upload-time = "2026-04-03T17:07:40Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fa/65fcae2ed62f84ab72cf89536c7c3217a156e71a2c111b1305ab6f0690e2/sqlalchemy-2.0.49-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3bb9ec6436a820a4c006aad1ac351f12de2f2dbdaad171692ee457a02429b672", size = 3351937, upload-time = "2026-04-03T17:12:23.374Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/2f/6fd118563572a7fe475925742eb6b3443b2250e346a0cc27d8d408e73773/sqlalchemy-2.0.49-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8d6efc136f44a7e8bc8088507eaabbb8c2b55b3dbb63fe102c690da0ddebe55e", size = 3281646, upload-time = "2026-04-03T17:07:41.949Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/d7/410f4a007c65275b9cf82354adb4bb8ba587b176d0a6ee99caa16fe638f8/sqlalchemy-2.0.49-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e06e617e3d4fd9e51d385dfe45b077a41e9d1b033a7702551e3278ac597dc750", size = 3316695, upload-time = "2026-04-03T17:12:25.642Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/95/81f594aa60ded13273a844539041ccf1e66c5a7bed0a8e27810a3b52d522/sqlalchemy-2.0.49-cp312-cp312-win32.whl", hash = "sha256:83101a6930332b87653886c01d1ee7e294b1fe46a07dd9a2d2b4f91bcc88eec0", size = 2117483, upload-time = "2026-04-03T17:05:40.896Z" },
+    { url = "https://files.pythonhosted.org/packages/47/9e/fd90114059175cac64e4fafa9bf3ac20584384d66de40793ae2e2f26f3bb/sqlalchemy-2.0.49-cp312-cp312-win_amd64.whl", hash = "sha256:618a308215b6cececb6240b9abde545e3acdabac7ae3e1d4e666896bf5ba44b4", size = 2144494, upload-time = "2026-04-03T17:05:42.282Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/81/81755f50eb2478eaf2049728491d4ea4f416c1eb013338682173259efa09/sqlalchemy-2.0.49-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:df2d441bacf97022e81ad047e1597552eb3f83ca8a8f1a1fdd43cd7fe3898120", size = 2154547, upload-time = "2026-04-03T16:53:08.64Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/bc/3494270da80811d08bcfa247404292428c4fe16294932bce5593f215cad9/sqlalchemy-2.0.49-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8e20e511dc15265fb433571391ba313e10dd8ea7e509d51686a51313b4ac01a2", size = 3280782, upload-time = "2026-04-03T17:07:43.508Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/f5/038741f5e747a5f6ea3e72487211579d8cbea5eb9827a9cbd61d0108c4bd/sqlalchemy-2.0.49-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:47604cb2159f8bbd5a1ab48a714557156320f20871ee64d550d8bf2683d980d3", size = 3297156, upload-time = "2026-04-03T17:12:27.697Z" },
+    { url = "https://files.pythonhosted.org/packages/88/50/a6af0ff9dc954b43a65ca9b5367334e45d99684c90a3d3413fc19a02d43c/sqlalchemy-2.0.49-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:22d8798819f86720bc646ab015baff5ea4c971d68121cb36e2ebc2ee43ead2b7", size = 3228832, upload-time = "2026-04-03T17:07:45.38Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/d1/5f6bdad8de0bf546fc74370939621396515e0cdb9067402d6ba1b8afbe9a/sqlalchemy-2.0.49-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9b1c058c171b739e7c330760044803099c7fff11511e3ab3573e5327116a9c33", size = 3267000, upload-time = "2026-04-03T17:12:29.657Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/30/ad62227b4a9819a5e1c6abff77c0f614fa7c9326e5a3bdbee90f7139382b/sqlalchemy-2.0.49-cp313-cp313-win32.whl", hash = "sha256:a143af2ea6672f2af3f44ed8f9cd020e9cc34c56f0e8db12019d5d9ecf41cb3b", size = 2115641, upload-time = "2026-04-03T17:05:43.989Z" },
+    { url = "https://files.pythonhosted.org/packages/17/3a/7215b1b7d6d49dc9a87211be44562077f5f04f9bb5a59552c1c8e2d98173/sqlalchemy-2.0.49-cp313-cp313-win_amd64.whl", hash = "sha256:12b04d1db2663b421fe072d638a138460a51d5a862403295671c4f3987fb9148", size = 2141498, upload-time = "2026-04-03T17:05:45.7Z" },
+    { url = "https://files.pythonhosted.org/packages/28/4b/52a0cb2687a9cd1648252bb257be5a1ba2c2ded20ba695c65756a55a15a4/sqlalchemy-2.0.49-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:24bd94bb301ec672d8f0623eba9226cc90d775d25a0c92b5f8e4965d7f3a1518", size = 3560807, upload-time = "2026-04-03T16:58:31.666Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d8/fda95459204877eed0458550d6c7c64c98cc50c2d8d618026737de9ed41a/sqlalchemy-2.0.49-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a51d3db74ba489266ef55c7a4534eb0b8db9a326553df481c11e5d7660c8364d", size = 3527481, upload-time = "2026-04-03T17:06:00.155Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0a/2aac8b78ac6487240cf7afef8f203ca783e8796002dc0cf65c4ee99ff8bb/sqlalchemy-2.0.49-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:55250fe61d6ebfd6934a272ee16ef1244e0f16b7af6cd18ab5b1fc9f08631db0", size = 3468565, upload-time = "2026-04-03T16:58:33.414Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/3d/ce71cfa82c50a373fd2148b3c870be05027155ce791dc9a5dcf439790b8b/sqlalchemy-2.0.49-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:46796877b47034b559a593d7e4b549aba151dae73f9e78212a3478161c12ab08", size = 3477769, upload-time = "2026-04-03T17:06:02.787Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e8/0a9f5c1f7c6f9ca480319bf57c2d7423f08d31445974167a27d14483c948/sqlalchemy-2.0.49-cp313-cp313t-win32.whl", hash = "sha256:9c4969a86e41454f2858256c39bdfb966a20961e9b58bf8749b65abf447e9a8d", size = 2143319, upload-time = "2026-04-03T17:02:04.328Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/51/fb5240729fbec73006e137c4f7a7918ffd583ab08921e6ff81a999d6517a/sqlalchemy-2.0.49-cp313-cp313t-win_amd64.whl", hash = "sha256:b9870d15ef00e4d0559ae10ee5bc71b654d1f20076dbe8bc7ed19b4c0625ceba", size = 2175104, upload-time = "2026-04-03T17:02:05.989Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/bf28f618c0a9597d14e0b9ee7d1e0622faff738d44fe986ee287cdf1b8d0/sqlalchemy-2.0.49-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:233088b4b99ebcbc5258c755a097aa52fbf90727a03a5a80781c4b9c54347a2e", size = 2156356, upload-time = "2026-04-03T16:53:09.914Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a7/5f476227576cb8644650eff68cc35fa837d3802b997465c96b8340ced1e2/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:57ca426a48eb2c682dae8204cd89ea8ab7031e2675120a47924fabc7caacbc2a", size = 3276486, upload-time = "2026-04-03T17:07:46.9Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/84/efc7c0bf3a1c5eef81d397f6fddac855becdbb11cb38ff957888603014a7/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:685e93e9c8f399b0c96a624799820176312f5ceef958c0f88215af4013d29066", size = 3281479, upload-time = "2026-04-03T17:12:32.226Z" },
+    { url = "https://files.pythonhosted.org/packages/91/68/bb406fa4257099c67bd75f3f2261b129c63204b9155de0d450b37f004698/sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9e0400fa22f79acc334d9a6b185dc00a44a8e6578aa7e12d0ddcd8434152b187", size = 3226269, upload-time = "2026-04-03T17:07:48.678Z" },
+    { url = "https://files.pythonhosted.org/packages/67/84/acb56c00cca9f251f437cb49e718e14f7687505749ea9255d7bd8158a6df/sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a05977bffe9bffd2229f477fa75eabe3192b1b05f408961d1bebff8d1cd4d401", size = 3248260, upload-time = "2026-04-03T17:12:34.381Z" },
+    { url = "https://files.pythonhosted.org/packages/56/19/6a20ea25606d1efd7bd1862149bb2a22d1451c3f851d23d887969201633f/sqlalchemy-2.0.49-cp314-cp314-win32.whl", hash = "sha256:0f2fa354ba106eafff2c14b0cc51f22801d1e8b2e4149342023bd6f0955de5f5", size = 2118463, upload-time = "2026-04-03T17:05:47.093Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4f/8297e4ed88e80baa1f5aa3c484a0ee29ef3c69c7582f206c916973b75057/sqlalchemy-2.0.49-cp314-cp314-win_amd64.whl", hash = "sha256:77641d299179c37b89cf2343ca9972c88bb6eef0d5fc504a2f86afd15cd5adf5", size = 2144204, upload-time = "2026-04-03T17:05:48.694Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/33/95e7216df810c706e0cd3655a778604bbd319ed4f43333127d465a46862d/sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c1dc3368794d522f43914e03312202523cc89692f5389c32bea0233924f8d977", size = 3565474, upload-time = "2026-04-03T16:58:35.128Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/a4/ed7b18d8ccf7f954a83af6bb73866f5bc6f5636f44c7731fbb741f72cc4f/sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c821c47ecfe05cc32140dcf8dc6fd5d21971c86dbd56eabfe5ba07a64910c01", size = 3530567, upload-time = "2026-04-03T17:06:04.587Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a3/20faa869c7e21a827c4a2a42b41353a54b0f9f5e96df5087629c306df71e/sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9c04bff9a5335eb95c6ecf1c117576a0aa560def274876fd156cfe5510fccc61", size = 3474282, upload-time = "2026-04-03T16:58:37.131Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/50/276b9a007aa0764304ad467eceb70b04822dc32092492ee5f322d559a4dc/sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7f605a456948c35260e7b2a39f8952a26f077fd25653c37740ed186b90aaa68a", size = 3480406, upload-time = "2026-04-03T17:06:07.176Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/c3/c80fcdb41905a2df650c2a3e0337198b6848876e63d66fe9188ef9003d24/sqlalchemy-2.0.49-cp314-cp314t-win32.whl", hash = "sha256:6270d717b11c5476b0cbb21eedc8d4dbb7d1a956fd6c15a23e96f197a6193158", size = 2149151, upload-time = "2026-04-03T17:02:07.281Z" },
+    { url = "https://files.pythonhosted.org/packages/05/52/9f1a62feab6ed368aff068524ff414f26a6daebc7361861035ae00b05530/sqlalchemy-2.0.49-cp314-cp314t-win_amd64.whl", hash = "sha256:275424295f4256fd301744b8f335cff367825d270f155d522b30c7bf49903ee7", size = 2184178, upload-time = "2026-04-03T17:02:08.623Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/30/8519fdde58a7bdf155b714359791ad1dc018b47d60269d5d160d311fdc36/sqlalchemy-2.0.49-py3-none-any.whl", hash = "sha256:ec44cfa7ef1a728e88ad41674de50f6db8cfdb3e2af84af86e0041aaf02d43d0", size = 1942158, upload-time = "2026-04-03T16:53:44.135Z" },
+]
+
+[package.optional-dependencies]
+asyncio = [
+    { name = "greenlet" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Refactor the Chainlit UI to keep one vibe-acp subprocess alive and run each chat as an independent ACP session, then add a Chainlit SQLAlchemy data layer (sqlite at `.vibe/medmcp_threads.db`) so threads survive restarts and show up in the sidebar.

## Related issue
Closes #4 

## Test plan
- [x] `just ui` cold-starts and writes `CHAINLIT_AUTH_SECRET` to `.env` on first run                                                         
- [x] `just ui` on a second run reuses the existing secret (no duplicate lines in `.env`)                                                    
- [x] Start a new chat, send a few messages with at least one tool-permission prompt, refresh the browser - the thread reappears in the sidebar with full history                                                                                                                    
- [x] Open a persisted thread and send a follow-up message — vibe-acp resumes via `session/load` and the new turn is appended                
- ~~[ ] Run two threads side-by-side and confirm their messages do not bleed into each other (single subprocess, separate sessions)~~  -> concurrent chats not supported          
- [x] `just clean` removes `.vibe/medmcp_threads.db` and the journal file                                                                    
- [x] Permission prompts still gate every tool call; denying still blocks the side effect  

## Security & data handling
- Adds a `header_auth_callback` that returns a fixed `local` user. This is **not** real auth — it exists only so the data layer's per-user scoping has a stable key. The localhost-only threat model is unchanged and is now called out explicitly in the module docstring.             
- New on-disk artifact: `.vibe/medmcp_threads.db` (sqlite) stores thread/step metadata and the chainlit thread_id <-> vibe-acp session_id mapping. vibe-acp's JSONL transcripts under `.vibe/logs/session/` remain the source of truth and are what gets replayed on `session/load`.   
- Both new paths are gitignored and wiped by `just clean`.
- No new tool surface, no new network calls, no change to the permission-prompt path.  

## Notes
- New deps: `sqlalchemy[asyncio]` and `aiosqlite`.                                                                                           
- `scripts/run_ui.sh` is the new entry point for `just ui`; it shells out to `chainlit create-secret` once and then `uv run --env-file .env chainlit run …`.                                                                                                                             
- Follow-up worth considering: a real `password_auth_callback`