### PR TITLE
chore: add dependabot config for uv and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary                                                                                                                                                                                                       
  - Adds .github/dependabot.yml with weekly updates for uv (Python deps) and github-actions
  - Groups updates per-ecosystem to minimize PR noise                                                                                                                                                              
                                                                                                                                                                                                                   
  ## Test plan                                                                                                                                                                                                     
  - [ ] Dependabot picks up config and opens grouped PRs on schedule **
