### PR TITLE
 chore(tests): cover wire helpers, client routing, db, and dispatch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,3 +85,10 @@ quote-style = "double"
 include = ["src", "tests"]
 pythonVersion = "3.12"
 typeCheckingMode = "strict"
+
+[[tool.pyright.executionEnvironments]]
+root = "tests"
+reportPrivateUsage = "none"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/tests/test_frame_dispatch.py
+++ b/tests/test_frame_dispatch.py
@@ -1,0 +1,353 @@
+"""Tests for the ACP frame dispatch path.
+
+Covers ``_handle_tool_call``, ``_handle_tool_call_update``, and
+``_process_session_frame``. These functions touch ``cl.Step``, ``cl.Message``,
+and ``_client.respond``; all three are patched out with
+``unittest.mock.AsyncMock`` so the tests stay hermetic.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from medmcp.app import (
+    _handle_tool_call,
+    _handle_tool_call_update,
+    _process_session_frame,
+)
+
+# ── Helpers ────────────────────────────────────────────────
+
+
+def _make_step_mock() -> MagicMock:
+    """Build a ``cl.Step`` stand-in with awaitable ``send`` / ``update``."""
+    step = MagicMock(name="Step")
+    step.send = AsyncMock()
+    step.update = AsyncMock()
+    # name/input/output are plain attributes the dispatch code assigns to.
+    step.name = None
+    step.input = None
+    step.output = None
+    return step
+
+
+def _make_message_mock() -> MagicMock:
+    """Build a ``cl.Message`` stand-in with awaitable ``stream_token``."""
+    msg = MagicMock(name="Message")
+    msg.stream_token = AsyncMock()
+    msg.send = AsyncMock()
+    msg.update = AsyncMock()
+    return msg
+
+
+# ── _handle_tool_call ─────────────────────────────────────
+
+
+async def test_tool_call_creates_step_and_caches_info() -> None:
+    """A first ``tool_call`` event should construct a step and cache title/rawInput."""
+    step = _make_step_mock()
+    tool_steps: dict[str, Any] = {}
+    tool_call_info: dict[str, Any] = {}
+
+    with patch("medmcp.app.cl.Step", return_value=step) as step_ctor:
+        await _handle_tool_call(
+            {
+                "toolCallId": "tc1",
+                "title": "bash: ls",
+                "rawInput": {"cmd": "ls"},
+            },
+            tool_steps,
+            tool_call_info,
+            parent_id="p1",
+        )
+
+    # A new step was constructed with the right kwargs.
+    step_ctor.assert_called_once_with(name="bash: ls", type="tool", parent_id="p1")
+    # The cache holds both fields for later permission backfill.
+    assert tool_call_info["tc1"]["title"] == "bash: ls"
+    assert tool_call_info["tc1"]["rawInput"] == {"cmd": "ls"}
+    # The step was sent and its input is the indented JSON form.
+    step.send.assert_awaited_once()
+    assert step.input is not None
+    assert json.loads(step.input) == {"cmd": "ls"}
+    # And it was registered for dedup on the next event.
+    assert tool_steps["tc1"] is step
+
+
+async def test_tool_call_dedup_on_repeat_updates_existing_step() -> None:
+    """A second ``tool_call`` with the same id should update the existing step.
+
+    vibe-acp emits ``tool_call`` twice (first to announce the tool name, then
+    again with the resolved ``rawInput``). The second emission must NOT create
+    a duplicate UI step.
+    """
+    step = _make_step_mock()
+    tool_steps: dict[str, Any] = {}
+    tool_call_info: dict[str, Any] = {}
+
+    with patch("medmcp.app.cl.Step", return_value=step) as step_ctor:
+        # First emission: title only.
+        await _handle_tool_call(
+            {"toolCallId": "tc1", "title": "bash"},
+            tool_steps,
+            tool_call_info,
+            parent_id=None,
+        )
+        # Second emission: same id, with rawInput and refined title.
+        await _handle_tool_call(
+            {"toolCallId": "tc1", "title": "bash: ls", "rawInput": {"cmd": "ls"}},
+            tool_steps,
+            tool_call_info,
+            parent_id=None,
+        )
+
+    # Constructor only called once — the dedup branch took over.
+    step_ctor.assert_called_once()
+    # The existing step was updated, not replaced.
+    assert step.name == "bash: ls"
+    assert step.input is not None and json.loads(step.input) == {"cmd": "ls"}
+    step.update.assert_awaited()
+
+
+async def test_tool_call_falls_back_to_generic_title() -> None:
+    """A first ``tool_call`` with no title should use the generic ``"tool"`` label."""
+    step = _make_step_mock()
+    tool_steps: dict[str, Any] = {}
+    tool_call_info: dict[str, Any] = {}
+
+    with patch("medmcp.app.cl.Step", return_value=step) as step_ctor:
+        await _handle_tool_call(
+            {"toolCallId": "tc1"},
+            tool_steps,
+            tool_call_info,
+            parent_id=None,
+        )
+
+    step_ctor.assert_called_once_with(name="tool", type="tool", parent_id=None)
+
+
+# ── _handle_tool_call_update ──────────────────────────────
+
+
+async def test_tool_call_update_prefers_raw_output_over_text_blocks() -> None:
+    """When both ``rawOutput`` and content text are present, ``rawOutput`` wins."""
+    step = _make_step_mock()
+    tool_steps: dict[str, Any] = {"tc1": step}
+
+    await _handle_tool_call_update(
+        {
+            "toolCallId": "tc1",
+            "status": "completed",
+            "rawOutput": {"exit": 0},
+            "content": [
+                {"type": "content", "content": {"text": "stdout-text"}},
+            ],
+        },
+        tool_steps,
+    )
+
+    assert step.output is not None
+    assert json.loads(step.output) == {"exit": 0}
+    step.update.assert_awaited_once()
+
+
+async def test_tool_call_update_falls_back_to_text_blocks() -> None:
+    """Without ``rawOutput``, content text blocks should be joined into output."""
+    step = _make_step_mock()
+    tool_steps: dict[str, Any] = {"tc1": step}
+
+    await _handle_tool_call_update(
+        {
+            "toolCallId": "tc1",
+            "status": "completed",
+            "content": [
+                {"type": "content", "content": {"text": "line1"}},
+                {"type": "content", "content": {"text": "line2"}},
+            ],
+        },
+        tool_steps,
+    )
+
+    assert step.output == "line1\nline2"
+    step.update.assert_awaited_once()
+
+
+async def test_tool_call_update_only_finalizes_on_terminal_status() -> None:
+    """``step.update`` should only fire when status is ``completed`` or ``failed``."""
+    step = _make_step_mock()
+    tool_steps: dict[str, Any] = {"tc1": step}
+
+    await _handle_tool_call_update(
+        {"toolCallId": "tc1", "status": "in_progress", "rawOutput": "x"},
+        tool_steps,
+    )
+    step.update.assert_not_awaited()
+
+    await _handle_tool_call_update(
+        {"toolCallId": "tc1", "status": "completed", "rawOutput": "x"},
+        tool_steps,
+    )
+    assert step.update.await_count == 1
+
+    await _handle_tool_call_update(
+        {"toolCallId": "tc1", "status": "failed", "rawOutput": "x"},
+        tool_steps,
+    )
+    assert step.update.await_count == 2
+
+
+async def test_tool_call_update_ignores_unknown_tool_call_id() -> None:
+    """An update for a tool call we never registered should be a no-op."""
+    tool_steps: dict[str, Any] = {}
+    # Must not raise.
+    await _handle_tool_call_update(
+        {"toolCallId": "ghost", "status": "completed", "rawOutput": "x"},
+        tool_steps,
+    )
+
+
+# ── _process_session_frame ────────────────────────────────
+
+
+async def test_process_frame_streams_agent_message_chunk_text() -> None:
+    """A text agent_message_chunk should stream into the assistant message."""
+    msg = _make_message_mock()
+    getter = AsyncMock(return_value=msg)
+
+    await _process_session_frame(
+        {
+            "method": "session/update",
+            "params": {
+                "update": {
+                    "sessionUpdate": "agent_message_chunk",
+                    "content": {"type": "text", "text": "hello"},
+                }
+            },
+        },
+        assistant_msg_getter=getter,
+        tool_steps={},
+        tool_call_info={},
+        parent_id=None,
+    )
+
+    getter.assert_awaited_once()
+    msg.stream_token.assert_awaited_once_with("hello")
+
+
+async def test_process_frame_ignores_non_text_agent_message_chunk() -> None:
+    """A non-text content type should not trigger streaming.
+
+    The dispatcher must not crash on unknown content types — vibe-acp may emit
+    image or other content types we don't render today.
+    """
+    getter = AsyncMock()
+
+    await _process_session_frame(
+        {
+            "method": "session/update",
+            "params": {
+                "update": {
+                    "sessionUpdate": "agent_message_chunk",
+                    "content": {"type": "image", "url": "..."},
+                }
+            },
+        },
+        assistant_msg_getter=getter,
+        tool_steps={},
+        tool_call_info={},
+        parent_id=None,
+    )
+
+    getter.assert_not_awaited()
+
+
+async def test_process_frame_request_permission_backfills_from_cache() -> None:
+    """``request_permission`` should backfill title/rawInput from the tool_call cache.
+
+    vibe-acp's ``session/request_permission`` payload only carries
+    ``toolCallId`` — without backfill, the approval dialog would show
+    ``<unknown>`` and the user would have no idea what they're approving.
+    """
+    tool_call_info = {
+        "tc1": {"title": "bash: ls", "rawInput": {"cmd": "ls"}},
+    }
+
+    captured: dict[str, Any] = {}
+
+    async def fake_ask(tc: dict[str, Any], options: list[dict[str, Any]]) -> dict[str, Any]:
+        captured["tc"] = tc
+        captured["options"] = options
+        return {"outcome": "selected", "optionId": "approve"}
+
+    fake_respond = AsyncMock()
+
+    with (
+        patch("medmcp.app._ask_user_for_permission", side_effect=fake_ask),
+        patch("medmcp.app._client.respond", new=fake_respond),
+    ):
+        await _process_session_frame(
+            {
+                "method": "session/request_permission",
+                "id": 42,
+                "params": {
+                    "toolCall": {"toolCallId": "tc1"},
+                    "options": [{"optionId": "approve", "name": "Approve"}],
+                },
+            },
+            assistant_msg_getter=AsyncMock(),
+            tool_steps={},
+            tool_call_info=tool_call_info,
+            parent_id=None,
+        )
+
+    # title and rawInput were backfilled from the cache before being shown.
+    assert captured["tc"]["title"] == "bash: ls"
+    assert captured["tc"]["rawInput"] == {"cmd": "ls"}
+    # The response was sent back to vibe-acp under the original request id.
+    fake_respond.assert_awaited_once_with(
+        42, {"outcome": {"outcome": "selected", "optionId": "approve"}}
+    )
+
+
+async def test_process_frame_request_permission_ignores_non_int_id() -> None:
+    """A request_permission frame with a non-int id should be a silent no-op."""
+    fake_ask = AsyncMock()
+    fake_respond = AsyncMock()
+
+    with (
+        patch("medmcp.app._ask_user_for_permission", new=fake_ask),
+        patch("medmcp.app._client.respond", new=fake_respond),
+    ):
+        await _process_session_frame(
+            {
+                "method": "session/request_permission",
+                "id": "not-an-int",
+                "params": {"toolCall": {"toolCallId": "tc1"}, "options": []},
+            },
+            assistant_msg_getter=AsyncMock(),
+            tool_steps={},
+            tool_call_info={},
+            parent_id=None,
+        )
+
+    # Neither the prompt nor the response was sent.
+    fake_ask.assert_not_called()
+    fake_respond.assert_not_called()
+
+
+@pytest.mark.parametrize("method", ["session/something_else", "unrelated", None])
+async def test_process_frame_ignores_unknown_methods(method: str | None) -> None:
+    """Frames whose method we don't handle should be silent no-ops."""
+    getter = AsyncMock()
+    await _process_session_frame(
+        {"method": method, "params": {}},
+        assistant_msg_getter=getter,
+        tool_steps={},
+        tool_call_info={},
+        parent_id=None,
+    )
+    getter.assert_not_awaited()

--- a/tests/test_read_line.py
+++ b/tests/test_read_line.py
@@ -1,0 +1,54 @@
+"""Tests for ``_read_line``: the JSON-RPC frame parser used by ``VibeAcpClient``.
+
+These tests use a real :class:`asyncio.StreamReader` driven via
+``feed_data``/``feed_eof``, so we get end-to-end exercise of the actual code
+path the subprocess reader hits in production.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from medmcp.app import _read_line
+
+
+def _make_reader(payload: bytes, *, eof: bool = True) -> asyncio.StreamReader:
+    """Build a primed :class:`asyncio.StreamReader` for tests."""
+    reader = asyncio.StreamReader()
+    reader.feed_data(payload)
+    if eof:
+        reader.feed_eof()
+    return reader
+
+
+async def test_read_line_returns_dict_for_clean_json() -> None:
+    """A single well-formed JSON line should round-trip into a dict."""
+    reader = _make_reader(b'{"jsonrpc":"2.0","id":1,"result":{}}\n')
+    msg = await _read_line(reader)
+    assert msg == {"jsonrpc": "2.0", "id": 1, "result": {}}
+
+
+async def test_read_line_returns_none_on_eof() -> None:
+    """EOF without any data should yield ``None``, not raise."""
+    reader = _make_reader(b"")
+    assert await _read_line(reader) is None
+
+
+async def test_read_line_skips_non_json_noise() -> None:
+    """Non-JSON log noise on stdout should be skipped, not propagated."""
+    reader = _make_reader(b'plain log line\n{"valid":true}\n')
+    msg = await _read_line(reader)
+    assert msg == {"valid": True}
+
+
+async def test_read_line_skips_non_dict_json_values() -> None:
+    """Bare numbers / strings / arrays are not JSON-RPC frames; skip them."""
+    reader = _make_reader(b'42\n"hi"\n[1,2]\n{"ok":1}\n')
+    msg = await _read_line(reader)
+    assert msg == {"ok": 1}
+
+
+async def test_read_line_returns_none_after_consuming_only_noise() -> None:
+    """If the stream contains only noise and then closes, we should get ``None``."""
+    reader = _make_reader(b"noise one\nnoise two\n")
+    assert await _read_line(reader) is None

--- a/tests/test_threads_db.py
+++ b/tests/test_threads_db.py
@@ -1,0 +1,220 @@
+"""Tests for ``_bootstrap_threads_db``: schema creation, migration, and repair.
+
+The function runs on every Chainlit server startup, so it needs to be
+idempotent, must add missing columns to pre-existing databases, and must repair
+rows orphaned by the pre-fix schema.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from medmcp.app import _bootstrap_threads_db
+
+
+def _columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    """Return the set of column names on ``table``."""
+    return {row[0] for row in conn.execute(f'SELECT name FROM pragma_table_info("{table}")')}
+
+
+def _tables(conn: sqlite3.Connection) -> set[str]:
+    """Return the set of user table names."""
+    return {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+
+
+def _indexes(conn: sqlite3.Connection) -> set[str]:
+    """Return the set of explicitly-named index names."""
+    return {
+        row[0]
+        for row in conn.execute("SELECT name FROM sqlite_master WHERE type='index'")
+        if row[0] is not None
+    }
+
+
+# ── Schema creation ───────────────────────────────────────
+
+
+def test_bootstrap_creates_all_expected_tables(tmp_path: Path) -> None:
+    """A fresh bootstrap should create every table the chainlit data layer needs."""
+    db_path = tmp_path / "threads.db"
+    _bootstrap_threads_db(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        tables = _tables(conn)
+
+    assert {"users", "threads", "steps", "elements", "feedbacks"}.issubset(tables)
+
+
+def test_bootstrap_steps_table_has_required_columns(tmp_path: Path) -> None:
+    """The ``steps`` table must include the columns chainlit's Step.to_dict() emits.
+
+    The bug fixed in app.py:303-311 was that missing columns silently dropped
+    every Step write. Pin the full set so a future schema edit can't regress
+    chat resume.
+    """
+    db_path = tmp_path / "threads.db"
+    _bootstrap_threads_db(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        cols = _columns(conn, "steps")
+
+    required = {
+        "id",
+        "name",
+        "type",
+        "threadId",
+        "parentId",
+        "streaming",
+        "waitForAnswer",
+        "isError",
+        "metadata",
+        "tags",
+        "input",
+        "output",
+        "createdAt",
+        "start",
+        "end",
+        "generation",
+        "showInput",
+        "language",
+        # The four columns the migration loop also adds — these are the ones
+        # whose absence broke tool/run step persistence.
+        "defaultOpen",
+        "autoCollapse",
+        "command",
+        "modes",
+    }
+    assert required.issubset(cols)
+
+
+def test_bootstrap_creates_indexes(tmp_path: Path) -> None:
+    """The expected per-thread indexes should exist after bootstrap."""
+    db_path = tmp_path / "threads.db"
+    _bootstrap_threads_db(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        idx = _indexes(conn)
+
+    assert {"idx_steps_threadId", "idx_elements_threadId", "idx_feedbacks_forId"}.issubset(idx)
+
+
+def test_bootstrap_creates_parent_directory(tmp_path: Path) -> None:
+    """A non-existent parent directory should be created, not raise."""
+    db_path = tmp_path / "nested" / "subdir" / "threads.db"
+    _bootstrap_threads_db(db_path)
+    assert db_path.exists()
+
+
+# ── Idempotency ────────────────────────────────────────────
+
+
+def test_bootstrap_is_idempotent(tmp_path: Path) -> None:
+    """Bootstrapping the same database twice must not raise."""
+    db_path = tmp_path / "threads.db"
+    _bootstrap_threads_db(db_path)
+    _bootstrap_threads_db(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        assert "steps" in _tables(conn)
+
+
+# ── Migration of pre-existing databases ────────────────────
+
+
+def test_bootstrap_migrates_old_steps_table(tmp_path: Path) -> None:
+    """A pre-existing ``steps`` table missing the new columns should be migrated."""
+    db_path = tmp_path / "old.db"
+    # Pre-create a ``steps`` table missing all four post-fix columns. The
+    # CREATE TABLE IF NOT EXISTS in bootstrap will keep this table as-is, so
+    # the migration loop is what has to add the columns.
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("""
+            CREATE TABLE steps (
+                "id" TEXT PRIMARY KEY,
+                "threadId" TEXT NOT NULL,
+                "parentId" TEXT
+            )
+        """)
+        conn.commit()
+
+    _bootstrap_threads_db(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        cols = _columns(conn, "steps")
+
+    for added in ("defaultOpen", "autoCollapse", "command", "modes"):
+        assert added in cols, f"migration did not add column {added}"
+
+
+def test_bootstrap_migration_is_idempotent_on_partial_old_schema(tmp_path: Path) -> None:
+    """Running the migration twice on an old schema should not raise.
+
+    sqlite's ``ALTER TABLE ADD COLUMN`` has no ``IF NOT EXISTS``, so if the
+    column probe regresses we'd get a duplicate-column error on the second run.
+    """
+    db_path = tmp_path / "old.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("""
+            CREATE TABLE steps (
+                "id" TEXT PRIMARY KEY,
+                "threadId" TEXT NOT NULL,
+                "parentId" TEXT,
+                "command" TEXT
+            )
+        """)
+        conn.commit()
+
+    _bootstrap_threads_db(db_path)
+    _bootstrap_threads_db(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        cols = _columns(conn, "steps")
+
+    assert {"command", "modes", "defaultOpen", "autoCollapse"}.issubset(cols)
+
+
+# ── Orphan repair ──────────────────────────────────────────
+
+
+def test_bootstrap_repairs_orphan_parent_id(tmp_path: Path) -> None:
+    """Rows whose ``parentId`` points at a missing row should be promoted to NULL."""
+    db_path = tmp_path / "threads.db"
+    _bootstrap_threads_db(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            'INSERT INTO steps ("id", "threadId", "parentId") VALUES (?, ?, ?)',
+            ("orphan", "t1", "missing-parent"),
+        )
+        conn.commit()
+
+    # Re-run bootstrap; the orphan repair should promote ``parentId`` to NULL.
+    _bootstrap_threads_db(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute('SELECT "parentId" FROM steps WHERE "id" = ?', ("orphan",)).fetchone()
+    assert row[0] is None
+
+
+def test_bootstrap_leaves_valid_parent_references_alone(tmp_path: Path) -> None:
+    """Rows with a valid ``parentId`` must NOT be touched by the orphan repair."""
+    db_path = tmp_path / "threads.db"
+    _bootstrap_threads_db(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            'INSERT INTO steps ("id", "threadId", "parentId") VALUES (?, ?, ?)',
+            ("parent", "t1", None),
+        )
+        conn.execute(
+            'INSERT INTO steps ("id", "threadId", "parentId") VALUES (?, ?, ?)',
+            ("child", "t1", "parent"),
+        )
+        conn.commit()
+
+    _bootstrap_threads_db(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute('SELECT "parentId" FROM steps WHERE "id" = ?', ("child",)).fetchone()
+    assert row[0] == "parent"

--- a/tests/test_vibe_client.py
+++ b/tests/test_vibe_client.py
@@ -1,0 +1,273 @@
+"""Tests for :class:`medmcp.app.VibeAcpClient` request/response routing.
+
+These tests bypass the real ``vibe-acp`` subprocess by attaching a fake
+``proc`` object whose ``stdin`` is an in-memory accumulator and whose ``stdout``
+is a real :class:`asyncio.StreamReader`. The reader task is started directly so
+the test can drive the wire protocol from both sides.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, cast
+
+import pytest
+
+from medmcp.app import VibeAcpClient
+
+# ── Fakes for the asyncio subprocess interface ────────────
+
+
+class _FakeStdin:
+    """In-memory replacement for ``proc.stdin``.
+
+    Records every ``write`` call as a parsed JSON-RPC frame so tests can assert
+    on what was sent without parsing bytes themselves.
+    """
+
+    def __init__(self) -> None:
+        self.frames: list[dict[str, Any]] = []
+        self.raw: bytes = b""
+
+    def write(self, data: bytes) -> None:
+        self.raw += data
+        # Frames are newline-delimited; one write may contain one frame.
+        for line in data.splitlines():
+            if not line:
+                continue
+            self.frames.append(json.loads(line.decode()))
+
+    async def drain(self) -> None:
+        return None
+
+
+class _FakeProc:
+    """Minimal stand-in for ``asyncio.subprocess.Process``."""
+
+    def __init__(self) -> None:
+        self.stdin = _FakeStdin()
+        self.stdout = asyncio.StreamReader()
+
+
+def _make_started_client() -> tuple[VibeAcpClient, _FakeProc, asyncio.Task[None]]:
+    """Build a client wired to a fake subprocess and start its read loop."""
+    client = VibeAcpClient()
+    proc = _FakeProc()
+    # The real ``ensure_started`` would create a subprocess and run an
+    # ``initialize`` handshake. We bypass it by attaching the fake proc and
+    # starting the reader directly.
+    client.proc = cast("Any", proc)
+    client._initialized = True
+    reader_task = asyncio.create_task(client._read_loop())
+    return client, proc, reader_task
+
+
+def _feed_response(proc: _FakeProc, req_id: int, result: dict[str, Any]) -> None:
+    """Feed a JSON-RPC response frame into the fake stdout."""
+    frame = {"jsonrpc": "2.0", "id": req_id, "result": result}
+    proc.stdout.feed_data((json.dumps(frame) + "\n").encode())
+
+
+def _feed_server_frame(proc: _FakeProc, frame: dict[str, Any]) -> None:
+    """Feed a server-initiated JSON-RPC frame (notification or request)."""
+    proc.stdout.feed_data((json.dumps(frame) + "\n").encode())
+
+
+async def _shutdown(proc: _FakeProc, reader_task: asyncio.Task[None]) -> None:
+    """Close the fake stdout and wait for the reader to exit cleanly."""
+    proc.stdout.feed_eof()
+    await reader_task
+
+
+# ── Request / response correlation ─────────────────────────
+
+
+async def test_request_response_correlation_out_of_order() -> None:
+    """Two in-flight requests should resolve to their matching responses."""
+    client, proc, reader_task = _make_started_client()
+    try:
+        fut_a = asyncio.ensure_future(client.request("foo"))
+        fut_b = asyncio.ensure_future(client.request("bar"))
+
+        # Let both requests be written to stdin and registered in _pending.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert len(proc.stdin.frames) == 2
+        id_a = proc.stdin.frames[0]["id"]
+        id_b = proc.stdin.frames[1]["id"]
+        assert id_a != id_b
+
+        # Deliver in reverse order.
+        _feed_response(proc, id_b, {"who": "bar"})
+        _feed_response(proc, id_a, {"who": "foo"})
+
+        resp_a = await fut_a
+        resp_b = await fut_b
+        assert resp_a["result"] == {"who": "foo"}
+        assert resp_b["result"] == {"who": "bar"}
+        assert client._pending == {}
+    finally:
+        await _shutdown(proc, reader_task)
+
+
+async def test_cancelled_request_clears_pending() -> None:
+    """Cancelling an in-flight ``request`` must not leak ``_pending`` entries."""
+    client, proc, reader_task = _make_started_client()
+    try:
+        task = asyncio.ensure_future(client.request("slow"))
+        # Let the request reach ``await fut``.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert len(client._pending) == 1
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert client._pending == {}
+    finally:
+        await _shutdown(proc, reader_task)
+
+
+# ── Notification path ─────────────────────────────────────
+
+
+async def test_notify_writes_no_id_and_no_pending() -> None:
+    """``notify`` should emit an id-less frame and never touch ``_pending``."""
+    client, proc, reader_task = _make_started_client()
+    try:
+        await client.notify("session/cancel", {"session_id": "s1"})
+        assert len(proc.stdin.frames) == 1
+        frame = proc.stdin.frames[0]
+        assert frame["method"] == "session/cancel"
+        assert "id" not in frame
+        assert frame["params"] == {"session_id": "s1"}
+        assert client._pending == {}
+    finally:
+        await _shutdown(proc, reader_task)
+
+
+# ── Session queue routing ─────────────────────────────────
+
+
+async def test_limbo_flush_on_register_session() -> None:
+    """Frames that arrive before ``register_session`` should land in limbo."""
+    client, proc, reader_task = _make_started_client()
+    try:
+        # Frame arrives BEFORE the session is registered.
+        _feed_server_frame(
+            proc,
+            {
+                "jsonrpc": "2.0",
+                "method": "session/update",
+                "params": {"sessionId": "abc", "update": {"sessionUpdate": "agent_message_chunk"}},
+            },
+        )
+        # Give the reader a chance to route it into limbo.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert "abc" in client._limbo
+        assert len(client._limbo["abc"]) == 1
+
+        queue = client.register_session("abc")
+        # Limbo should be drained and the queue should now hold the frame.
+        assert "abc" not in client._limbo
+        assert queue.qsize() == 1
+        buffered = queue.get_nowait()
+        assert buffered["method"] == "session/update"
+    finally:
+        await _shutdown(proc, reader_task)
+
+
+async def test_register_unregister_session_isolation() -> None:
+    """Two sessions should receive their own frames; unregister doesn't affect peers."""
+    client, proc, reader_task = _make_started_client()
+    try:
+        queue_a = client.register_session("a")
+        queue_b = client.register_session("b")
+
+        _feed_server_frame(
+            proc,
+            {
+                "jsonrpc": "2.0",
+                "method": "session/update",
+                "params": {"sessionId": "a", "update": {"tag": "for-a"}},
+            },
+        )
+        _feed_server_frame(
+            proc,
+            {
+                "jsonrpc": "2.0",
+                "method": "session/update",
+                "params": {"sessionId": "b", "update": {"tag": "for-b"}},
+            },
+        )
+
+        msg_a = await asyncio.wait_for(queue_a.get(), timeout=1)
+        msg_b = await asyncio.wait_for(queue_b.get(), timeout=1)
+        assert msg_a["params"]["update"]["tag"] == "for-a"
+        assert msg_b["params"]["update"]["tag"] == "for-b"
+
+        client.unregister_session("a")
+        assert client.get_session_queue("a") is None
+        assert client.get_session_queue("b") is queue_b
+    finally:
+        await _shutdown(proc, reader_task)
+
+
+async def test_session_id_camel_and_snake_case() -> None:
+    """The dispatcher must accept both ``sessionId`` and ``session_id``."""
+    client, proc, reader_task = _make_started_client()
+    try:
+        queue = client.register_session("s1")
+
+        _feed_server_frame(
+            proc,
+            {
+                "jsonrpc": "2.0",
+                "method": "session/update",
+                "params": {"sessionId": "s1", "update": {"tag": "camel"}},
+            },
+        )
+        _feed_server_frame(
+            proc,
+            {
+                "jsonrpc": "2.0",
+                "method": "session/update",
+                "params": {"session_id": "s1", "update": {"tag": "snake"}},
+            },
+        )
+
+        first = await asyncio.wait_for(queue.get(), timeout=1)
+        second = await asyncio.wait_for(queue.get(), timeout=1)
+        tags = {first["params"]["update"]["tag"], second["params"]["update"]["tag"]}
+        assert tags == {"camel", "snake"}
+    finally:
+        await _shutdown(proc, reader_task)
+
+
+# ── Subprocess teardown semantics ─────────────────────────
+
+
+async def test_eof_fails_pending_with_connection_error() -> None:
+    """When the subprocess closes, every pending request should fail cleanly."""
+    client, proc, reader_task = _make_started_client()
+    try:
+        fut_a = asyncio.ensure_future(client.request("foo"))
+        fut_b = asyncio.ensure_future(client.request("bar"))
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert len(client._pending) == 2
+
+        proc.stdout.feed_eof()
+        await reader_task  # let the read loop drain and fail pendings
+
+        with pytest.raises(ConnectionError, match="vibe-acp subprocess closed"):
+            await fut_a
+        with pytest.raises(ConnectionError, match="vibe-acp subprocess closed"):
+            await fut_b
+        assert client._pending == {}
+    finally:
+        if not reader_task.done():
+            reader_task.cancel()

--- a/tests/test_wire_helpers.py
+++ b/tests/test_wire_helpers.py
@@ -1,0 +1,155 @@
+"""Tests for the pure wire-format and rendering helpers in :mod:`medmcp.app`.
+
+These functions have no I/O and no Chainlit dependencies, so they can be
+exercised with plain ``assert`` statements.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from medmcp.app import (
+    _encode,
+    _extract_text_blocks,
+    _format_permission_prompt,
+    _rpc_response,
+    _stringify_raw,
+)
+
+# ── _encode ────────────────────────────────────────────────
+
+
+def test_encode_round_trips_through_json() -> None:
+    """An encoded frame should decode back to the original dict."""
+    msg = {"jsonrpc": "2.0", "id": 1, "method": "foo", "params": {"x": 42}}
+    encoded = _encode(msg)
+    assert encoded.endswith(b"\n")
+    # Exactly one trailing newline — line-delimited protocol.
+    assert not encoded[:-1].endswith(b"\n")
+    assert json.loads(encoded.decode()) == msg
+
+
+# ── _rpc_response ──────────────────────────────────────────
+
+
+def test_rpc_response_shape() -> None:
+    """A response frame should carry jsonrpc, id, and result keys."""
+    frame = _rpc_response(7, {"ok": True})
+    decoded = json.loads(frame.decode())
+    assert decoded == {"jsonrpc": "2.0", "id": 7, "result": {"ok": True}}
+    assert frame.endswith(b"\n")
+
+
+# ── _stringify_raw ─────────────────────────────────────────
+
+
+def test_stringify_raw_passes_strings_through() -> None:
+    """A string input should come back unchanged, not double-encoded."""
+    assert _stringify_raw("hello") == "hello"
+
+
+def test_stringify_raw_indents_dicts() -> None:
+    """A dict input should come back as indented JSON."""
+    out = _stringify_raw({"a": 1, "b": [2, 3]})
+    # json.dumps with indent=2 always indents nested structures.
+    assert "\n" in out
+    assert json.loads(out) == {"a": 1, "b": [2, 3]}
+
+
+def test_stringify_raw_falls_back_for_unserializable() -> None:
+    """Non-JSON-serializable values should fall back to ``str()``, not raise."""
+
+    class Weird:
+        def __repr__(self) -> str:
+            return "<weird>"
+
+    weird = Weird()
+    # Must not raise.
+    out = _stringify_raw(weird)
+    assert out == "<weird>"
+
+
+# ── _extract_text_blocks ───────────────────────────────────
+
+
+def test_extract_text_blocks_returns_empty_for_non_list() -> None:
+    """Non-list inputs should yield an empty list, not raise."""
+    assert _extract_text_blocks(None) == []
+    assert _extract_text_blocks("not a list") == []
+    assert _extract_text_blocks({"not": "a list"}) == []
+
+
+def test_extract_text_blocks_pulls_text_from_valid_blocks() -> None:
+    """Well-formed content blocks should yield their inner text."""
+    content = [
+        {"type": "content", "content": {"text": "first"}},
+        {"type": "content", "content": {"text": "second"}},
+    ]
+    assert _extract_text_blocks(content) == ["first", "second"]
+
+
+def test_extract_text_blocks_skips_wrong_type() -> None:
+    """Blocks whose ``type`` is not ``content`` should be ignored."""
+    content = [
+        {"type": "image", "content": {"text": "ignored"}},
+        {"type": "content", "content": {"text": "kept"}},
+    ]
+    assert _extract_text_blocks(content) == ["kept"]
+
+
+def test_extract_text_blocks_skips_missing_or_malformed_inner() -> None:
+    """Inner ``content`` that isn't a dict or has no ``text`` should be skipped."""
+    content: list[Any] = [
+        {"type": "content", "content": "not a dict"},
+        {"type": "content", "content": {}},  # missing text key
+        {"type": "content", "content": {"text": 123}},  # wrong text type
+        {"type": "content", "content": {"text": "kept"}},
+        "not a dict at all",  # also exercised by the outer guard
+    ]
+    assert _extract_text_blocks(content) == ["kept"]
+
+
+# ── _format_permission_prompt ──────────────────────────────
+
+
+def test_format_permission_prompt_with_dict_raw_input() -> None:
+    """A dict ``rawInput`` should render inside a fenced ``json`` block."""
+    body = _format_permission_prompt({"title": "bash: ls", "rawInput": {"cmd": "ls"}})
+    assert "`bash: ls`" in body
+    assert "```json" in body
+    assert '"cmd": "ls"' in body
+
+
+def test_format_permission_prompt_with_string_raw_input() -> None:
+    """A string ``rawInput`` should be embedded verbatim, not re-encoded."""
+    body = _format_permission_prompt({"title": "bash: ls", "rawInput": "ls -la"})
+    assert "`bash: ls`" in body
+    assert "ls -la" in body
+    # No double-encoding into a JSON string literal.
+    assert '"ls -la"' not in body
+
+
+def test_format_permission_prompt_without_raw_input() -> None:
+    """Missing ``rawInput`` should produce no fenced block, no crash."""
+    body = _format_permission_prompt({"title": "bash: ls"})
+    assert "`bash: ls`" in body
+    assert "```" not in body
+
+
+def test_format_permission_prompt_with_unserializable_raw_input() -> None:
+    """An unserializable ``rawInput`` should fall back to ``str()``, not raise."""
+
+    class Weird:
+        def __repr__(self) -> str:
+            return "<weird>"
+
+    body = _format_permission_prompt({"title": "tool", "rawInput": Weird()})
+    assert "`tool`" in body
+    assert "<weird>" in body
+
+
+def test_format_permission_prompt_default_title() -> None:
+    """A missing title should fall back to a generic label."""
+    body = _format_permission_prompt({})
+    assert "`tool call`" in body


### PR DESCRIPTION
## Summary
- Brings the test suite from 1 smoke test to 50 unit tests covering the pure wire helpers, the `_read_line` parser, `VibeAcpClient` request routing and session demux, the `_bootstrap_threads_db` schema / migration / orphan repair path, and the ACP frame dispatch path (`_handle_tool_call`, `_handle_tool_call_update`, `_process_session_frame`).
- Tests are hermetic: no real `vibe-acp` subprocess, no real Chainlit, no network. The client tests use an in-memory `_FakeProc` with a real `asyncio.StreamReader`; the dispatch tests patch out `cl.Step` / `cl.Message` / `_ask_user_for_permission` / `_client.respond` with `unittest.mock`.
- Adds `asyncio_mode = "auto"` so async tests don't need per-test markers, and a per-directory pyright override that disables `reportPrivateUsage` under `tests/` (pinning private helpers like `_encode` and `_pending` is the whole point of these tests).