### PR TITLE
chore: add CI recipes to justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -3,17 +3,21 @@ set quiet := true
 default:
     @just --list
 
+# Remove caches and build artifacts
 clean:
     rm -rf .mypy_cache
     rm -rf .pytest_cache
+    rm -rf .ruff_cache
     rm -rf .tox
     rm -rf .venv
     rm -rf dist
+    rm -rf build
     rm -rf **/__pycache__
     rm -rf src/*.egg-info
     rm -f .coverage
     rm -f coverage.*
 
+# Remove local chat/session state under .vibe/
 clean-chats:
     rm -rf .vibe/logs
     rm -f .vibe/medmcp_threads.db
@@ -21,19 +25,49 @@ clean-chats:
     rm -rf .vibe/vibehistory
 
 @install_uv:
-	if ! command -v uv >/dev/null 2>&1; then \
-		echo "uv is not installed. Installing..."; \
-		curl -LsSf https://astral.sh/uv/install.sh | sh; \
-	else \
-	  echo "uv is available and ready to use..."; \
-	fi
+    if ! command -v uv >/dev/null 2>&1; then \
+        echo "uv is not installed. Installing..."; \
+        curl -LsSf https://astral.sh/uv/install.sh | sh; \
+    else \
+        echo "uv is available and ready to use..."; \
+    fi
 
+# Install Ollama via bundled script
 install_ollama:
     @./scripts/install_ollama.sh
 
+# Install uv + Ollama, sync dev environment, register pre-commit hooks
 setup: install_uv install_ollama
     uv sync
     uv run pre-commit install
+
+# Run every CI check locally (lint, format, typecheck, tests)
+check: lint format-check typecheck test
+
+# Lint with ruff
+lint:
+    uv run ruff check
+
+# Format code with ruff
+format:
+    uv run ruff format
+
+# Check formatting without writing changes
+format-check:
+    uv run ruff format --check
+
+# Strict type-checking with pyright
+typecheck:
+    uv run pyright
+
+# Run the pytest suite
+test *ARGS:
+    uv run pytest {{ARGS}}
+
+# Auto-fix lint findings and format
+fix:
+    uv run ruff check --fix
+    uv run ruff format
 
 # Pull base model and build custom devstral-medmcp (32k context)
 pull_model:

--- a/justfile
+++ b/justfile
@@ -1,5 +1,6 @@
 set quiet := true
 
+# Defaults to just --list
 default:
     @just --list
 
@@ -24,6 +25,7 @@ clean-chats:
     rm -f .vibe/trusted_folders.toml
     rm -rf .vibe/vibehistory
 
+# Install uv (only if just is installed via package manager)
 @install_uv:
     if ! command -v uv >/dev/null 2>&1; then \
         echo "uv is not installed. Installing..."; \


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                
  Ports the CI-oriented recipes (`check`, `lint`, `format`, `format-check`, `typecheck`, `test`, `fix`) from [`medmcp-template`](https://github.com/medmcp/medmcp-template)'s `justfile` into this repo so  
  the two diverge only on app-specific targets. The template was written after `medmcp-dev` and made more considered choices about the default Python scaffolding — this PR brings `medmcp-dev` in line.    
                                                                                                                                                                                                            
  ## Related issue                                                                                                                                                                                          
  N/A                                              

  ## Test plan                                     
  - [x] `just --list` parses and shows descriptions for every recipe                                  
  - [x] `just check` runs lint + format-check + typecheck + test end-to-end                           
  - [x] `just fix` auto-remediates a trivial ruff finding                                             
  - [ ] `just clean` removes `.ruff_cache` and `build/` alongside the existing targets                

  ## Security & data handling                      
  N/A — justfile-only change. No new tool surface, network calls, or file-write paths beyond what ruff/pyright/pytest already do locally.                                                                   

  ## Notes
  - All app-specific recipes (`vibe`, `ui`, `pull_model`, `install_ollama`, `clean-chats`) intentionally stay — they have no analog in the template.                                                        
  - Also normalizes `install_uv` indentation (mixed tabs/spaces → 4-space) and adds `# doc` comments above existing recipes so `just --list` is self-describing.                                            
  - Diverging targets between this file and `medmcp-template/justfile` after this PR should be limited to the app-specific set above; future template improvements to the shared recipes should flow back   
  here.     