### PR TITLE
Feature(UI): Add opt-in plain-language tool-call explanations

### DIFF
--- a/.chainlit/config.toml
+++ b/.chainlit/config.toml
@@ -125,7 +125,7 @@ custom_css = "/public/custom.css"
 
 # Specify a JavaScript file that can be used to customize the user interface.
 # The JavaScript file can be served from the public directory.
-# custom_js = "/public/test.js"
+custom_js = "/public/custom.js"
 
 # The style of alert boxes. Can be "classic" or "modern".
 alert_style = "classic"

--- a/public/custom.js
+++ b/public/custom.js
@@ -1,0 +1,156 @@
+// Override the Reset button in the ChatSettings panel so that it restores
+// widget defaults (the `initial` values) rather than the values captured when
+// the panel was opened.
+(function () {
+  "use strict";
+
+  // Default values extracted from widget `initial` fields, keyed by widget id.
+  let _defaults = {};
+
+  // ── Capture widget definitions from the socket ──────────────────────
+
+  function extractDefaults(inputs) {
+    const defaults = {};
+    for (const input of inputs) {
+      if (Array.isArray(input?.inputs)) {
+        // Tab — recurse into its children.
+        Object.assign(defaults, extractDefaults(input.inputs));
+      } else if (input?.id !== undefined) {
+        defaults[input.id] = input.initial;
+      }
+    }
+    return defaults;
+  }
+
+  // Parse a socket.io frame for a `chat_settings` event and store the defaults.
+  function parseSioFrame(text) {
+    if (typeof text !== "string") return;
+    // socket.io v4 frames: 42["event_name", payload]
+    const match = text.match(/42\["chat_settings",(.+?)\](?:\d|$)/s);
+    if (match) {
+      try {
+        _defaults = extractDefaults(JSON.parse(match[1]));
+      } catch {
+        // Ignore parse errors on non-matching frames.
+      }
+    }
+  }
+
+  // Hook transports to intercept socket.io frames carrying `chat_settings`.
+  // socket.io starts with HTTP long-polling and upgrades to WebSocket, so we
+  // need to intercept both.
+  function hookTransports() {
+    // ── WebSocket ──
+    const OrigWS = window.WebSocket;
+    const hookedSockets = new WeakSet();
+
+    window.WebSocket = function (...args) {
+      const ws = new OrigWS(...args);
+      if (!hookedSockets.has(ws)) {
+        hookedSockets.add(ws);
+        ws.addEventListener("message", function (evt) {
+          parseSioFrame(evt.data);
+        });
+      }
+      return ws;
+    };
+    window.WebSocket.prototype = OrigWS.prototype;
+    Object.assign(window.WebSocket, OrigWS);
+
+    // ── XMLHttpRequest (long-polling fallback) ──
+    const origOpen = XMLHttpRequest.prototype.open;
+    XMLHttpRequest.prototype.open = function (...args) {
+      // Only hook requests that look like socket.io polling.
+      const url = args[1];
+      if (typeof url === "string" && url.includes("socket.io")) {
+        this.addEventListener("load", function () {
+          parseSioFrame(this.responseText);
+        });
+      }
+      return origOpen.apply(this, args);
+    };
+  }
+
+  // ── Override the Reset button ───────────────────────────────────────
+
+  function overrideResetButton() {
+    const observer = new MutationObserver(() => {
+      // The settings panel is rendered inside a dialog with id="chat-settings"
+      // (modal mode) or a sidebar section with id="chat-settings-sidebar-content".
+      const panels = document.querySelectorAll(
+        "#chat-settings, #chat-settings-sidebar-content"
+      );
+      for (const panel of panels) {
+        const buttons = panel.querySelectorAll("button");
+        for (const btn of buttons) {
+          if (btn.dataset.resetPatched) continue;
+          // Skip Confirm and Cancel buttons.
+          if (btn.id === "confirm" || btn.id === "confirm-sidebar") continue;
+          // The Reset button uses variant="outline" (has border classes, no ghost).
+          if (!btn.className.includes("border") || btn.className.includes("ghost"))
+            continue;
+          // Skip switch buttons (they also live inside the panel).
+          if (btn.getAttribute("role") === "switch") continue;
+
+          btn.dataset.resetPatched = "true";
+          btn.addEventListener(
+            "click",
+            function (e) {
+              e.stopImmediatePropagation();
+              e.preventDefault();
+              resetToDefaults(panel);
+            },
+            true
+          );
+        }
+      }
+    });
+
+    observer.observe(document.body, { childList: true, subtree: true });
+  }
+
+  function resetToDefaults(panel) {
+    if (Object.keys(_defaults).length === 0) return;
+
+    for (const [id, defaultValue] of Object.entries(_defaults)) {
+      // Switch widgets — Radix UI renders <button role="switch"> with
+      // data-state="checked" / "unchecked".
+      const switchBtn = panel.querySelector(`button[role="switch"][id="${id}"]`);
+      if (switchBtn) {
+        const isChecked =
+          switchBtn.getAttribute("data-state") === "checked" ||
+          switchBtn.getAttribute("aria-checked") === "true";
+        const shouldBeChecked = !!defaultValue;
+        if (isChecked !== shouldBeChecked) {
+          switchBtn.click();
+        }
+        continue;
+      }
+
+      // Text / number inputs — set value via the native setter so React picks
+      // up the change.
+      const input = panel.querySelector(`input[name="${id}"], input[id="${id}"]`);
+      if (input) {
+        const proto =
+          input.tagName === "TEXTAREA"
+            ? HTMLTextAreaElement.prototype
+            : HTMLInputElement.prototype;
+        const setter = Object.getOwnPropertyDescriptor(proto, "value")?.set;
+        if (setter) {
+          setter.call(input, defaultValue ?? "");
+          input.dispatchEvent(new Event("input", { bubbles: true }));
+          input.dispatchEvent(new Event("change", { bubbles: true }));
+        }
+      }
+    }
+  }
+
+  // ── Bootstrap ───────────────────────────────────────────────────────
+
+  hookTransports();
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", overrideResetButton);
+  } else {
+    overrideResetButton();
+  }
+})();

--- a/src/medmcp/app.py
+++ b/src/medmcp/app.py
@@ -55,6 +55,7 @@ from pathlib import Path
 from typing import Any, cast
 
 import chainlit as cl
+import httpx
 from chainlit.context import context as cl_context
 from chainlit.data import get_data_layer as cl_get_data_layer
 from chainlit.data.sql_alchemy import SQLAlchemyDataLayer
@@ -87,6 +88,17 @@ THREADS_DB_PATH: Path = VIBE_HOME / "medmcp_threads.db"
 # Single fixed user identity used by the data layer. There is no auth: this
 # exists only so chainlit's per-user thread scoping has a stable key.
 LOCAL_USER_ID: str = "local"
+
+# ── Explain tool calls (opt-in) ──────────────────────────
+#
+# When enabled by the user, each permission prompt is preceded by a short
+# LLM-generated plain-language explanation of what the tool call does.
+# The explanation is produced by the same local Ollama model that powers the
+# agent, via a lightweight direct API call.
+
+OLLAMA_BASE_URL: str = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434")
+OLLAMA_MODEL: str = os.environ.get("OLLAMA_MODEL", "devstral-medmcp")
+EXPLAIN_TIMEOUT: float = 15.0
 
 # ── JSON-RPC wire helpers ──────────────────────────────────
 
@@ -436,6 +448,58 @@ def get_data_layer() -> SQLAlchemyDataLayer:
     return SQLAlchemyDataLayer(conninfo=f"sqlite+aiosqlite:///{THREADS_DB_PATH}")
 
 
+# ── Tool-call explanation (opt-in) ────────────────────────
+
+
+async def _generate_human_readable(tc: JsonDict) -> str | None:
+    """Ask the local Ollama model to explain a tool call in plain language.
+
+    Returns a short explanation string, or ``None`` if the request fails or
+    times out. Errors are logged but never propagated — the permission dialog
+    simply renders without an explanation.
+    """
+    title = tc.get("title") or ""
+    raw_input_val: object = tc.get("rawInput") or ""
+    if isinstance(raw_input_val, dict):
+        ri_dict = cast("JsonDict", raw_input_val)
+        try:
+            raw_input_str = json.dumps(ri_dict, indent=2)
+        except (TypeError, ValueError):
+            raw_input_str = str(ri_dict)
+    else:
+        raw_input_str = str(raw_input_val)
+
+    prompt = (
+        "You are a SECURITY-AWARE assistant. A tool call is about to be "
+        "executed on the user's machine. Explain what it does in ONE short "
+        "sentence that a NON-TECHNICAL user can understand. Focus on the "
+        "effect and any risks. Reply with ONLY the explanation.\n\n"
+        f"Tool: {title}\nInput: {raw_input_str}"
+    )
+    try:
+        async with httpx.AsyncClient(timeout=EXPLAIN_TIMEOUT) as client:
+            resp = await client.post(
+                f"{OLLAMA_BASE_URL}/v1/chat/completions",
+                json={
+                    "model": OLLAMA_MODEL,
+                    "messages": [{"role": "user", "content": prompt}],
+                    "temperature": 0.0,
+                    "max_tokens": 120,
+                },
+            )
+            resp.raise_for_status()
+            data = cast("JsonDict", resp.json())
+            choices = cast("list[JsonDict]", data.get("choices") or [])
+            if not choices:
+                return None
+            message = cast("JsonDict", choices[0].get("message") or {})
+            text = str(message.get("content") or "").strip()
+            return text or None
+    except Exception:
+        _audit.warning("failed to generate tool-call explanation", exc_info=True)
+        return None
+
+
 # ── Permission UI ──────────────────────────────────────────
 
 
@@ -443,12 +507,17 @@ def _format_permission_prompt(tc: JsonDict) -> str:
     """Build the markdown body shown in the permission dialog.
 
     ``tc`` is a ToolCallUpdate from ACP — it has ``title`` (human label, e.g.
-    ``"bash: ls -la ~/msseg"``) and ``rawInput`` (the JSON-serialized tool args).
+    ``"bash: ls -la ~/msseg"``), ``rawInput`` (the JSON-serialized tool args),
+    and optionally ``humanReadable`` (a plain-language explanation of what the
+    tool call does and why).
     """
     title = tc.get("title") or "tool call"
     raw_input = tc.get("rawInput")
+    human_readable = tc.get("humanReadable")
 
     body = f"**Approve tool call?**\n\n`{title}`"
+    if isinstance(human_readable, str) and human_readable:
+        body += f"\n\n> {human_readable}"
     if raw_input:
         if isinstance(raw_input, str):
             input_str = raw_input
@@ -577,6 +646,8 @@ async def _handle_tool_call(
         info["title"] = t
     if (ri := update.get("rawInput")) is not None:
         info["rawInput"] = ri
+    if (hr := update.get("humanReadable")) is not None:
+        info["humanReadable"] = hr
 
     raw_input = update.get("rawInput")
     if tc_id in tool_steps:
@@ -615,6 +686,23 @@ async def _handle_tool_call_update(update: JsonDict, tool_steps: dict[str, cl.St
         await step.update()
 
 
+# ── Explain toggle (ChatSettings) ─────────────────────────
+
+
+def _is_explain_enabled() -> bool:
+    """Check whether the user has opted in to tool-call explanations."""
+    val = cl.user_session.get("explain_tools")  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+    return bool(val)  # pyright: ignore[reportUnknownArgumentType]
+
+
+@cl.on_settings_update  # pyright: ignore[reportUnknownMemberType]
+async def on_settings_update(settings: dict[str, Any]) -> None:
+    """Persist chat-settings changes (explain toggle) into the user session."""
+    new_value = bool(settings.get("explain_tools", False))
+    cl.user_session.set("explain_tools", new_value)  # pyright: ignore[reportUnknownMemberType]
+    _audit.info("explain_tools set to %s via settings", new_value)
+
+
 # ── Chainlit hooks ─────────────────────────────────────────
 
 
@@ -627,6 +715,20 @@ async def on_chat_start() -> None:
     session is persisted in thread metadata so :func:`on_chat_resume` can pick
     it back up later.
     """
+    cl.user_session.set("explain_tools", False)  # pyright: ignore[reportUnknownMemberType]
+    await cl.ChatSettings(
+        inputs=[
+            cl.input_widget.Switch(
+                id="explain_tools",
+                label="Explain tool calls",
+                initial=False,
+                description=(
+                    "Enable this option to add a plain-language explanation to each tool call."
+                ),
+            ),
+        ],
+    ).send()
+
     await _client.ensure_started()
 
     resp = await _client.request("session/new", {"cwd": PROJECT_ROOT, "mcp_servers": []})
@@ -655,6 +757,20 @@ async def on_chat_resume(thread: ThreadDict) -> None:
     history at us via ``session/update`` events; we drain and discard them
     because chainlit's persistence is the source of truth for the UI.
     """
+    cl.user_session.set("explain_tools", False)  # pyright: ignore[reportUnknownMemberType]
+    await cl.ChatSettings(
+        inputs=[
+            cl.input_widget.Switch(
+                id="explain_tools",
+                label="Explain tool calls",
+                initial=False,
+                description=(
+                    "Enable this option to add a plain-language explanation to each tool call."
+                ),
+            ),
+        ],
+    ).send()
+
     await _client.ensure_started()
 
     # ThreadDict's typing carries Dict[Unknown, Unknown] for the metadata field,
@@ -906,9 +1022,15 @@ async def _process_session_frame(
         # Backfill title/rawInput from the cached tool_call event, because
         # request_permission only ships the toolCallId.
         cached = tool_call_info.get(cast("str", tc.get("toolCallId") or ""), {})
-        for key in ("title", "rawInput"):
+        for key in ("title", "rawInput", "humanReadable"):
             if tc.get(key) is None and cached.get(key) is not None:
                 tc[key] = cached[key]
+
+        # Generate a plain-language explanation if the user opted in and
+        # one wasn't already provided by vibe-acp.
+        if _is_explain_enabled() and tc.get("humanReadable") is None:
+            with contextlib.suppress(Exception):
+                tc["humanReadable"] = await _generate_human_readable(tc)
 
         outcome = await _ask_user_for_permission(tc, options)
         await _client.respond(req_id, {"outcome": outcome})

--- a/tests/test_permission_prompt.py
+++ b/tests/test_permission_prompt.py
@@ -1,0 +1,191 @@
+"""Tests for the permission-prompt formatting and explanation generation in app.py."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from medmcp.app import (
+    OLLAMA_BASE_URL,  # pyright: ignore[reportPrivateUsage]
+    OLLAMA_MODEL,  # pyright: ignore[reportPrivateUsage]
+    _format_permission_prompt,  # pyright: ignore[reportPrivateUsage]
+    _generate_human_readable,  # pyright: ignore[reportPrivateUsage]
+)
+
+# ── _format_permission_prompt ─────────────────────────────
+
+
+class TestFormatPermissionPrompt:
+    """Verify that _format_permission_prompt renders the expected markdown."""
+
+    def test_title_only(self) -> None:
+        """Minimal tool call with just a title."""
+        result = _format_permission_prompt({"title": "bash: echo hi"})
+        assert "`bash: echo hi`" in result
+        assert "Approve tool call?" in result
+
+    def test_with_raw_input(self) -> None:
+        """Raw input should appear inside a json code fence."""
+        result = _format_permission_prompt(
+            {
+                "title": "bash: ls",
+                "rawInput": {"command": "ls -la"},
+            }
+        )
+        assert "```json" in result
+        assert '"command"' in result
+
+    def test_with_human_readable(self) -> None:
+        """Human-readable description should render as a blockquote."""
+        result = _format_permission_prompt(
+            {
+                "title": "bash: find . -name '*.log' -delete",
+                "humanReadable": "Delete all .log files in the current directory tree.",
+            }
+        )
+        assert "> Delete all .log files" in result
+
+    def test_human_readable_before_raw_input(self) -> None:
+        """The human-readable line must appear before the raw input block."""
+        result = _format_permission_prompt(
+            {
+                "title": "bash: rm -rf /tmp/old",
+                "rawInput": {"command": "rm -rf /tmp/old"},
+                "humanReadable": "Remove the /tmp/old directory.",
+            }
+        )
+        hr_pos = result.index("> Remove the /tmp/old directory.")
+        raw_pos = result.index("```json")
+        assert hr_pos < raw_pos
+
+    def test_missing_human_readable(self) -> None:
+        """When humanReadable is absent the output should not contain a blockquote."""
+        result = _format_permission_prompt(
+            {
+                "title": "bash: ls",
+                "rawInput": "ls",
+            }
+        )
+        assert "> " not in result
+
+    def test_empty_human_readable_ignored(self) -> None:
+        """An empty humanReadable string should be treated as absent."""
+        result = _format_permission_prompt(
+            {
+                "title": "bash: ls",
+                "humanReadable": "",
+            }
+        )
+        assert result.count(">") == 0
+
+    def test_fallback_title(self) -> None:
+        """When title is missing, fall back to 'tool call'."""
+        result = _format_permission_prompt({})
+        assert "`tool call`" in result
+
+
+# ── _generate_human_readable ──────────────────────────────
+
+
+def _mock_ollama_response(text: str) -> httpx.Response:
+    """Build a fake httpx.Response mimicking Ollama's chat/completions endpoint."""
+    return httpx.Response(
+        200,
+        json={
+            "choices": [{"message": {"content": text}}],
+        },
+        request=httpx.Request("POST", f"{OLLAMA_BASE_URL}/v1/chat/completions"),
+    )
+
+
+class TestGenerateHumanReadable:
+    """Verify _generate_human_readable calls Ollama and parses the response."""
+
+    @pytest.mark.asyncio
+    async def test_returns_explanation(self) -> None:
+        """A successful Ollama response should yield the explanation text."""
+        mock_response = _mock_ollama_response("Lists all files in the current directory.")
+        with patch("medmcp.app.httpx.AsyncClient") as mock_client_cls:
+            instance = AsyncMock()
+            instance.post.return_value = mock_response
+            instance.__aenter__ = AsyncMock(return_value=instance)
+            instance.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = instance
+
+            result = await _generate_human_readable({"title": "bash: ls -la"})
+
+        assert result == "Lists all files in the current directory."
+        instance.post.assert_called_once()
+        call_kwargs: dict[str, Any] = instance.post.call_args[1]
+        assert call_kwargs["json"]["model"] == OLLAMA_MODEL
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_empty_choices(self) -> None:
+        """An empty choices array should return None."""
+        response = httpx.Response(
+            200,
+            json={"choices": []},
+            request=httpx.Request("POST", f"{OLLAMA_BASE_URL}/v1/chat/completions"),
+        )
+        with patch("medmcp.app.httpx.AsyncClient") as mock_client_cls:
+            instance = AsyncMock()
+            instance.post.return_value = response
+            instance.__aenter__ = AsyncMock(return_value=instance)
+            instance.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = instance
+
+            result = await _generate_human_readable({"title": "bash: ls"})
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_network_error(self) -> None:
+        """Network failures should return None, not raise."""
+        with patch("medmcp.app.httpx.AsyncClient") as mock_client_cls:
+            instance = AsyncMock()
+            instance.post.side_effect = httpx.ConnectError("connection refused")
+            instance.__aenter__ = AsyncMock(return_value=instance)
+            instance.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = instance
+
+            result = await _generate_human_readable({"title": "bash: ls"})
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_blank_content(self) -> None:
+        """A blank content string should be treated as no explanation."""
+        response = _mock_ollama_response("   ")
+        with patch("medmcp.app.httpx.AsyncClient") as mock_client_cls:
+            instance = AsyncMock()
+            instance.post.return_value = response
+            instance.__aenter__ = AsyncMock(return_value=instance)
+            instance.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = instance
+
+            result = await _generate_human_readable({"title": "bash: ls"})
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_dict_raw_input_serialized(self) -> None:
+        """Dict rawInput should be JSON-serialized in the prompt sent to Ollama."""
+        mock_response = _mock_ollama_response("Writes hello to a file.")
+        with patch("medmcp.app.httpx.AsyncClient") as mock_client_cls:
+            instance = AsyncMock()
+            instance.post.return_value = mock_response
+            instance.__aenter__ = AsyncMock(return_value=instance)
+            instance.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = instance
+
+            await _generate_human_readable(
+                {"title": "write_file", "rawInput": {"path": "/tmp/x", "content": "hello"}}
+            )
+
+        call_kwargs: dict[str, Any] = instance.post.call_args[1]
+        prompt: str = call_kwargs["json"]["messages"][0]["content"]
+        # The dict should have been serialized, not repr'd
+        assert '"path"' in prompt


### PR DESCRIPTION
 ## Summary
- Add a "Explain tool calls" toggle in ChatSettings that, when enabled, generates a plain-language explanation for each tool call via the local Ollama model before showing the permission prompt
- Support a native `humanReadable` field from vibe-acp - if present, the extra LLM call is skipped
- Send ChatSettings before the vibe-acp handshake to minimize UI delay
- Add tests for `_format_permission_prompt` and `_generate_human_readable`

## Related issue
Closes #17 

## Test plan
- [x] `just check` passes (lint, format, typecheck, 13 tests)
- [x] Launch UI with `just ui`, verify the settings toggle appears
- [x] Enable "Explain tool calls", trigger a tool call, confirm the explanation blockquote appears in the permission dialog
- [x] With the toggle off, confirm no explanation is shown

## Screenshots
<img width="808" height="252" alt="Screenshot from 2026-04-10 09-50-51" src="https://github.com/user-attachments/assets/11169ae0-20a8-42ef-86e9-6b5a35367976" />
<img width="606" height="341" alt="Screenshot from 2026-04-10 09-51-29" src="https://github.com/user-attachments/assets/9b801411-7f43-49ff-b3a7-8a2f14fb2363" />

## Security & data handling
- New outbound HTTP call to the local Ollama instance (`localhost:11434`) - no data leaves the institution's network                                                                                                 
- Tool-call titles and raw inputs are sent to the local model for summarization; this is opt-in (off by default) and gated behind an explicit user toggle                                                                                                                       
- No change to the permission model - all tool calls still require explicit user approval

## Notes
- If vibe-acp adds a native `humanReadable` field to `ToolCallUpdate` events in the future, it will be used directly - no extra LLM call 
- The explanation adds ~2–5s latency per tool call when enabled, depending on model load