### PR TITLE
Feature(UI): collapsible tool-call summary and cleaner permission flow 

### DIFF
--- a/.chainlit/config.toml
+++ b/.chainlit/config.toml
@@ -36,7 +36,7 @@ latex = false
 user_message_markdown = true
 
 # Autoscroll new user messages at the top of the window
-user_message_autoscroll = true
+user_message_autoscroll = false
 
 # Autoscroll new assistant messages
 assistant_message_autoscroll = true
@@ -95,11 +95,11 @@ name = "MedMCP"
 
 # Force a specific language for all users (e.g., "en-US", "he-IL", "fr-FR")
 # If not set, the browser's language will be used
-# language = "en-US"
+language = "en-US"
 
 # layout = "wide"
 
-# default_sidebar_state = "open"  # Options: "open", "closed", "hidden"
+default_sidebar_state = "open"  # Options: "open", "closed", "hidden"
 
 # Chat settings display location: "message_composer" (default) or "sidebar" (header)
 # chat_settings_location = "message_composer"
@@ -114,7 +114,7 @@ confirm_new_chat = false
 # description = ""
 
 # Chain of Thought (CoT) display mode. Can be "hidden", "tool_call" or "full".
-cot = "full"
+cot = "tool_call"
 
 # Specify a CSS file that can be used to customize the user interface.
 # The CSS file can be served from the public directory or via an external link.
@@ -128,7 +128,7 @@ custom_css = "/public/custom.css"
 custom_js = "/public/custom.js"
 
 # The style of alert boxes. Can be "classic" or "modern".
-alert_style = "classic"
+alert_style = "modern"
 
 # Specify additional attributes for custom JS file
 # custom_js_attributes = "async type = \"module\""

--- a/justfile
+++ b/justfile
@@ -26,7 +26,7 @@ clean-chats:
     rm -rf .vibe/vibehistory
 
 # Install uv (only if just is installed via package manager)
-@install_uv:
+@install-uv:
     if ! command -v uv >/dev/null 2>&1; then \
         echo "uv is not installed. Installing..."; \
         curl -LsSf https://astral.sh/uv/install.sh | sh; \
@@ -35,11 +35,11 @@ clean-chats:
     fi
 
 # Install Ollama via bundled script
-install_ollama:
+install-ollama:
     @./scripts/install_ollama.sh
 
 # Install uv + Ollama, sync dev environment, register pre-commit hooks
-setup: install_uv install_ollama
+setup: install-uv install-ollama
     uv sync
     uv run pre-commit install
 

--- a/src/medmcp/app.py
+++ b/src/medmcp/app.py
@@ -59,6 +59,7 @@ import httpx
 from chainlit.context import context as cl_context
 from chainlit.data import get_data_layer as cl_get_data_layer
 from chainlit.data.sql_alchemy import SQLAlchemyDataLayer
+from chainlit.data.storage_clients.base import BaseStorageClient
 from chainlit.types import ThreadDict
 from chainlit.user import User
 from chainlit.utils import utc_now as _utc_now
@@ -99,7 +100,27 @@ LOCAL_USER_ID: str = "local"
 
 OLLAMA_BASE_URL: str = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434")
 OLLAMA_MODEL: str = os.environ.get("OLLAMA_MODEL", "devstral-medmcp")
-EXPLAIN_TIMEOUT: float = 15.0
+# Timeout for the explanation call.  Local Ollama inference is fast but the
+# model may be cold-starting; 20 s is generous without blocking the UI too long.
+EXPLAIN_TIMEOUT: float = 20.0
+
+# ── Risk taxonomy ──────────────────────────────────────────
+# Predefined categories for tool-call risk assessment.  The LLM is instructed
+# to pick from these keys only — it never invents new ones.
+# Each value is (display_label, severity).  severity drives the icon shown in
+# the permission dialog and the tool-call summary.
+RISK_CATEGORIES: dict[str, tuple[str, str]] = {
+    "file_read": ("Reads existing files", "low"),
+    "file_write": ("Creates or modifies files", "medium"),
+    "file_delete": ("Deletes files — may be irreversible", "high"),
+    "network": ("Contacts an external server or website", "medium"),
+    "code_exec": ("Runs a program or shell command", "high"),
+    "data_exfil": ("Could send your data to an external service", "high"),
+    "system_config": ("Changes system or application settings", "medium"),
+    "privacy": ("Accesses personal or sensitive information", "high"),
+}
+
+_SEVERITY_ICON: dict[str, str] = {"low": "🟢", "medium": "🟡", "high": "🔴"}
 
 # ── JSON-RPC wire helpers ──────────────────────────────────
 
@@ -442,41 +463,98 @@ async def header_auth_callback(_headers: object) -> User | None:
     return User(identifier=LOCAL_USER_ID, metadata={"role": "local"})
 
 
+class _NullStorageClient(BaseStorageClient):
+    """No-op storage client used when file uploads are disabled.
+
+    Chainlit's SQLAlchemyDataLayer logs a warning when no storage provider is
+    supplied, even though file uploads are explicitly disabled in config.toml.
+    Passing this stub silences the warning without changing any behaviour —
+    upload/delete/read_url calls should never occur with uploads disabled.
+    """
+
+    async def upload_file(
+        self,
+        object_key: str,
+        data: bytes | str,
+        mime: str = "application/octet-stream",
+        overwrite: bool = True,
+        content_disposition: str | None = None,
+    ) -> dict[str, Any]:
+        return {}
+
+    async def delete_file(self, object_key: str) -> bool:
+        return True
+
+    async def get_read_url(self, object_key: str) -> str:
+        return ""
+
+    async def close(self) -> None:
+        pass
+
+
 @cl.data_layer  # pyright: ignore[reportUnknownMemberType]
 def get_data_layer() -> SQLAlchemyDataLayer:
     """Wire chainlit to a local sqlite database for thread persistence."""
     _bootstrap_threads_db(THREADS_DB_PATH)
-    return SQLAlchemyDataLayer(conninfo=f"sqlite+aiosqlite:///{THREADS_DB_PATH}")
+    return SQLAlchemyDataLayer(
+        conninfo=f"sqlite+aiosqlite:///{THREADS_DB_PATH}",
+        storage_provider=_NullStorageClient(),
+    )
 
 
 # ── Tool-call explanation (opt-in) ────────────────────────
 
 
-async def _generate_human_readable(tc: JsonDict) -> str | None:
-    """Ask the local Ollama model to explain a tool call in plain language.
+def _raw_input_to_str(raw_input_val: object) -> str:
+    """Stringify a rawInput value for inclusion in the explanation prompt."""
+    if isinstance(raw_input_val, dict):
+        try:
+            # pyright: ignore — json.dumps accepts Any-typed dict values at runtime
+            return json.dumps(raw_input_val, indent=2)  # pyright: ignore[reportUnknownArgumentType]
+        except (TypeError, ValueError):
+            return str(raw_input_val)  # pyright: ignore[reportUnknownArgumentType]
+    return str(raw_input_val)
 
-    Returns a short explanation string, or ``None`` if the request fails or
-    times out. Errors are logged but never propagated — the permission dialog
-    simply renders without an explanation.
+
+async def _generate_explanation(tc: JsonDict) -> tuple[str, list[str]] | None:
+    """Ask the local Ollama model to explain a tool call for a non-technical user.
+
+    Returns ``(explanation, risks)`` on success or ``None`` on failure/timeout.
+    ``explanation`` is a single plain-language sentence aimed at a physician with
+    no IT background.  ``risks`` is a (possibly empty) list of keys from
+    :data:`RISK_CATEGORIES` that the model identified as applicable.
+
+    Errors are logged but never propagated — the permission dialog renders
+    without an explanation rather than blocking the user.
     """
     title = tc.get("title") or ""
-    raw_input_val: object = tc.get("rawInput") or ""
-    if isinstance(raw_input_val, dict):
-        ri_dict = cast("JsonDict", raw_input_val)
-        try:
-            raw_input_str = json.dumps(ri_dict, indent=2)
-        except (TypeError, ValueError):
-            raw_input_str = str(ri_dict)
-    else:
-        raw_input_str = str(raw_input_val)
+    raw_input_str = _raw_input_to_str(tc.get("rawInput") or "")
 
+    # Keep the input snippet short so the prompt stays well within the model's
+    # context window.  The full raw input is already shown in the JSON fence
+    # inside the permission dialog, so truncating here is fine.
+    if len(raw_input_str) > 400:
+        raw_input_str = raw_input_str[:400] + "\n… (truncated)"
+
+    valid_keys = ", ".join(RISK_CATEGORIES)
     prompt = (
-        "You are a SECURITY-AWARE assistant. A tool call is about to be "
-        "executed on the user's machine. Explain what it does in ONE short "
-        "sentence that a NON-TECHNICAL user can understand. Focus on the "
-        "effect and any risks. Reply with ONLY the explanation.\n\n"
-        f"Tool: {title}\nInput: {raw_input_str}"
+        "You are a security-aware assistant helping a physician review an AI action "
+        "before it runs on their computer. Your job is to explain what the action does "
+        "and flag any risks — in plain language that requires no IT knowledge.\n\n"
+        "Guidelines for the explanation:\n"
+        "- Write ONE clear sentence a doctor with no computer background can understand.\n"
+        "- Avoid all technical jargon. Translate terms like 'bash', 'stdin', 'API', "
+        "'filesystem path', 'subprocess', or 'flag' into everyday language "
+        "(e.g. 'runs a program', 'opens a file', 'contacts a website').\n"
+        "- State what the action will DO and what will CHANGE as a result.\n\n"
+        "Then select every applicable risk from this fixed list (use the exact keys):\n"
+        f"{valid_keys}\n\n"
+        "Respond with ONLY a JSON object — no markdown fences, no extra text:\n"
+        '{"explanation": "<one sentence>", "risks": ["<key>", ...]}\n\n'
+        f"Tool: {title}\n"
+        f"Input: {raw_input_str}"
     )
+
     try:
         async with httpx.AsyncClient(timeout=EXPLAIN_TIMEOUT) as client:
             resp = await client.post(
@@ -484,8 +562,8 @@ async def _generate_human_readable(tc: JsonDict) -> str | None:
                 json={
                     "model": OLLAMA_MODEL,
                     "messages": [{"role": "user", "content": prompt}],
-                    "temperature": 0.0,
-                    "max_tokens": 120,
+                    "temperature": 0.1,
+                    "max_tokens": 300,
                 },
             )
             resp.raise_for_status()
@@ -494,14 +572,72 @@ async def _generate_human_readable(tc: JsonDict) -> str | None:
             if not choices:
                 return None
             message = cast("JsonDict", choices[0].get("message") or {})
-            text = str(message.get("content") or "").strip()
-            return text or None
+            raw_text = str(message.get("content") or "").strip()
     except Exception:
         _audit.warning("failed to generate tool-call explanation", exc_info=True)
         return None
 
+    return _parse_explanation_response(raw_text)
+
+
+def _parse_explanation_response(raw_text: str) -> tuple[str, list[str]] | None:
+    """Parse the LLM's JSON response into ``(explanation, risks)``.
+
+    Handles models that wrap JSON in markdown code fences.  Returns ``None`` if
+    no valid JSON object can be extracted.
+    """
+    import re
+
+    text = raw_text.strip()
+
+    # Strip markdown code fences if present (```json ... ``` or ``` ... ```)
+    fence_match = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL)
+    if fence_match:
+        text = fence_match.group(1)
+    else:
+        # Find the first { ... } block in case the model added preamble text
+        brace_match = re.search(r"\{.*\}", text, re.DOTALL)
+        if brace_match:
+            text = brace_match.group(0)
+
+    try:
+        payload_raw: object = json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        _audit.warning("could not parse explanation JSON: %r", raw_text[:200])
+        return None
+
+    if not isinstance(payload_raw, dict):
+        return None
+    payload = cast("JsonDict", payload_raw)
+
+    explanation = str(payload.get("explanation") or "").strip()  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
+    if not explanation:
+        return None
+
+    raw_risks = payload.get("risks")  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+    risks: list[str] = (
+        [k for k in cast("list[object]", raw_risks) if isinstance(k, str) and k in RISK_CATEGORIES]
+        if isinstance(raw_risks, list)
+        else []
+    )
+
+    return explanation, risks
+
 
 # ── Permission UI ──────────────────────────────────────────
+
+
+def _format_risk_badges(risks: list[str]) -> str:
+    """Render a list of risk keys as a compact inline string with severity icons."""
+    parts: list[str] = []
+    for key in risks:
+        entry = RISK_CATEGORIES.get(key)
+        if entry is None:
+            continue
+        label, severity = entry
+        icon = _SEVERITY_ICON.get(severity, "⚠️")
+        parts.append(f"{icon} {label}" if icon else label)
+    return "  ·  ".join(parts)
 
 
 def _format_permission_prompt(tc: JsonDict) -> str:
@@ -509,24 +645,22 @@ def _format_permission_prompt(tc: JsonDict) -> str:
 
     ``tc`` is a ToolCallUpdate from ACP — it has ``title`` (human label, e.g.
     ``"bash: ls -la ~/msseg"``), ``rawInput`` (the JSON-serialized tool args),
-    and optionally ``humanReadable`` (a plain-language explanation of what the
-    tool call does and why).
+    ``humanReadable`` (a plain-language explanation aimed at a non-technical
+    user), and optionally ``risks`` (a list of :data:`RISK_CATEGORIES` keys).
     """
     title = tc.get("title") or "tool call"
     raw_input = tc.get("rawInput")
     human_readable = tc.get("humanReadable")
+    raw_risks = tc.get("risks")  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+    risks: list[str] = cast("list[str]", raw_risks) if isinstance(raw_risks, list) else []
 
     body = f"**Approve tool call?**\n\n`{title}`"
     if isinstance(human_readable, str) and human_readable:
         body += f"\n\n> {human_readable}"
+    if risks:
+        body += f"\n\n{_format_risk_badges(risks)}"
     if raw_input:
-        if isinstance(raw_input, str):
-            input_str = raw_input
-        else:
-            try:
-                input_str = json.dumps(raw_input, indent=2)
-            except (TypeError, ValueError):
-                input_str = str(raw_input)
+        input_str = _raw_input_to_str(raw_input)
         body += f"\n\n```json\n{input_str}\n```"
     return body
 
@@ -1006,6 +1140,11 @@ def _build_tool_summary(tool_call_info: dict[str, JsonDict]) -> str:
         human_readable = info.get("humanReadable")
         if isinstance(human_readable, str) and human_readable:
             line += f"\n  > {human_readable}"
+        raw_risks: object = info.get("risks")
+        if isinstance(raw_risks, list) and raw_risks:
+            badges = _format_risk_badges(cast("list[str]", raw_risks))
+            if badges:
+                line += f"\n  {badges}"
 
         ro = info.get("rawOutput")
         ot = info.get("outputText")
@@ -1125,25 +1264,33 @@ async def _process_session_frame(
         params = cast("JsonDict", msg.get("params") or {})
         tc: JsonDict = dict(cast("JsonDict", params.get("toolCall") or {}))
         options = cast("list[JsonDict]", params.get("options") or [])
-        # Backfill title/rawInput from the cached tool_call event, because
-        # request_permission only ships the toolCallId.
+        # Backfill title/rawInput/humanReadable/risks from the cached tool_call
+        # event, because request_permission only ships the toolCallId.
         cached = tool_call_info.get(cast("str", tc.get("toolCallId") or ""), {})
-        for key in ("title", "rawInput", "humanReadable"):
+        for key in ("title", "rawInput", "humanReadable", "risks"):
             if tc.get(key) is None and cached.get(key) is not None:
                 tc[key] = cached[key]
 
-        # Generate a plain-language explanation if the user opted in and
-        # one wasn't already provided by vibe-acp.
+        # Generate a plain-language explanation + risk assessment if the user
+        # opted in and one wasn't already provided by vibe-acp.
         if _is_explain_enabled() and tc.get("humanReadable") is None:
             with contextlib.suppress(Exception):
-                tc["humanReadable"] = await _generate_human_readable(tc)
+                result = await _generate_explanation(tc)
+                if result is not None:
+                    tc["humanReadable"], tc["risks"] = result
 
-        # Persist the explanation back into tool_call_info so the summary
-        # step can display it when the user unfolds it.
+        # Persist explanation and risks back into tool_call_info so the
+        # summary step can display them when the user unfolds it.
         tc_id_perm = cast("str", tc.get("toolCallId") or "")
-        if tc_id_perm in tool_call_info and isinstance(tc.get("humanReadable"), str):
-            tool_call_info[tc_id_perm]["humanReadable"] = tc["humanReadable"]
-            if "step" in tool_summary_holder:
+        if tc_id_perm in tool_call_info:
+            updated = False
+            if isinstance(tc.get("humanReadable"), str):
+                tool_call_info[tc_id_perm]["humanReadable"] = tc["humanReadable"]
+                updated = True
+            if isinstance(tc.get("risks"), list):
+                tool_call_info[tc_id_perm]["risks"] = tc["risks"]
+                updated = True
+            if updated and "step" in tool_summary_holder:
                 await _update_tool_summary(tool_summary_holder, tool_call_info)
 
         outcome = await _ask_user_for_permission(tc, options)

--- a/src/medmcp/app.py
+++ b/src/medmcp/app.py
@@ -61,6 +61,7 @@ from chainlit.data import get_data_layer as cl_get_data_layer
 from chainlit.data.sql_alchemy import SQLAlchemyDataLayer
 from chainlit.types import ThreadDict
 from chainlit.user import User
+from chainlit.utils import utc_now as _utc_now
 
 # A loose alias for parsed JSON-RPC payloads. The ACP protocol is too dynamic
 # to model exhaustively as TypedDicts, so we keep the wire format as
@@ -558,15 +559,21 @@ async def _ask_user_for_permission(tc: JsonDict, options: list[JsonDict]) -> Jso
     ]
 
     _audit.info("permission requested: %s", title)
-    response = await cl.AskActionMessage(
+    ask_msg = cl.AskActionMessage(
         content=_format_permission_prompt(tc),
         actions=actions,
         timeout=300,
-    ).send()
+    )
+    response = await ask_msg.send()
 
     if response is None:
         _audit.warning("permission timed out: %s", title)
         return {"outcome": "cancelled"}
+
+    # Remove the permission prompt from the chat so approved/denied tool calls
+    # don't pile up as stale "Selected: ..." bubbles. The tool step that wraps
+    # the call already provides a persistent record of what ran.
+    await ask_msg.remove()
 
     # AskActionResponse is a TypedDict whose ``payload`` field is typed as a
     # bare ``Dict``; pyright can't see the contents we put in it on the way out.
@@ -661,7 +668,7 @@ async def _handle_tool_call(
     else:
         title_val = update.get("title")
         tool_title = title_val if isinstance(title_val, str) and title_val else "tool"
-        step = cl.Step(name=tool_title, type="tool", parent_id=parent_id)
+        step = cl.Step(name=tool_title, type="run", parent_id=parent_id)
         if raw_input is not None:
             step.input = _stringify_raw(raw_input)
         await step.send()
@@ -715,13 +722,13 @@ async def on_chat_start() -> None:
     session is persisted in thread metadata so :func:`on_chat_resume` can pick
     it back up later.
     """
-    cl.user_session.set("explain_tools", False)  # pyright: ignore[reportUnknownMemberType]
+    cl.user_session.set("explain_tools", True)  # pyright: ignore[reportUnknownMemberType]
     await cl.ChatSettings(
         inputs=[
             cl.input_widget.Switch(
                 id="explain_tools",
                 label="Explain tool calls",
-                initial=False,
+                initial=True,
                 description=(
                     "Enable this option to add a plain-language explanation to each tool call."
                 ),
@@ -757,13 +764,13 @@ async def on_chat_resume(thread: ThreadDict) -> None:
     history at us via ``session/update`` events; we drain and discard them
     because chainlit's persistence is the source of truth for the UI.
     """
-    cl.user_session.set("explain_tools", False)  # pyright: ignore[reportUnknownMemberType]
+    cl.user_session.set("explain_tools", True)  # pyright: ignore[reportUnknownMemberType]
     await cl.ChatSettings(
         inputs=[
             cl.input_widget.Switch(
                 id="explain_tools",
                 label="Explain tool calls",
-                initial=False,
+                initial=True,
                 description=(
                     "Enable this option to add a plain-language explanation to each tool call."
                 ),
@@ -890,6 +897,9 @@ async def on_message(message: cl.Message) -> None:
     # it later in the permission dialog. vibe-acp's `session/request_permission`
     # payload only carries `toolCallId`, not the title or raw_input.
     tool_call_info: dict[str, JsonDict] = {}
+    # Mutable holder for the single visible tool-summary Step (type="tool").
+    # Created lazily on the first tool call; keyed by "step" when present.
+    tool_summary_holder: dict[str, cl.Step] = {}
 
     # Send the prompt and get a future for its response. We then race the
     # future against queue reads so session_update notifications and
@@ -942,6 +952,7 @@ async def on_message(message: cl.Message) -> None:
                             assistant_msg_getter=_ensure_assistant_msg,
                             tool_steps=tool_steps,
                             tool_call_info=tool_call_info,
+                            tool_summary_holder=tool_summary_holder,
                             parent_id=parent_id,
                         )
                 # Surface any error from the prompt response itself.
@@ -958,6 +969,7 @@ async def on_message(message: cl.Message) -> None:
                 assistant_msg_getter=_ensure_assistant_msg,
                 tool_steps=tool_steps,
                 tool_call_info=tool_call_info,
+                tool_summary_holder=tool_summary_holder,
                 parent_id=parent_id,
             )
 
@@ -976,6 +988,65 @@ async def on_message(message: cl.Message) -> None:
     if assistant_msg is not None:
         await assistant_msg.update()
 
+    # Final refresh of the tool summary step — set end to stop the spinner.
+    await _update_tool_summary(tool_summary_holder, tool_call_info, final=True)
+
+
+def _build_tool_summary(tool_call_info: dict[str, JsonDict]) -> str:
+    """Build a markdown summary of all tool calls for the summary step output."""
+    lines: list[str] = []
+    for info in tool_call_info.values():
+        title = str(info.get("title") or "tool")
+        status = info.get("status")
+        status_icon = (
+            "done" if status == "completed" else ("error" if status == "failed" else "...")
+        )
+        line = f"- **{title}** — *{status_icon}*"
+
+        human_readable = info.get("humanReadable")
+        if isinstance(human_readable, str) and human_readable:
+            line += f"\n  > {human_readable}"
+
+        ro = info.get("rawOutput")
+        ot = info.get("outputText")
+        output_str: str | None = None
+        if ro is not None:
+            output_str = _stringify_raw(ro)
+        elif isinstance(ot, str):
+            output_str = ot
+        if output_str is not None:
+            preview = output_str[:200].replace("\n", " ")
+            if len(output_str) > 200:
+                preview += "…"
+            line += f"\n  ```\n  {preview}\n  ```"
+        lines.append(line)
+    return "\n".join(lines)
+
+
+async def _update_tool_summary(
+    tool_summary_holder: dict[str, cl.Step],
+    tool_call_info: dict[str, JsonDict],
+    *,
+    final: bool = False,
+) -> None:
+    """Refresh the single visible tool-summary Step.
+
+    While tools are running the step keeps ``start`` set and ``end`` unset so
+    that Chainlit's frontend treats it as a running ``type="tool"`` step.  This
+    is important because the frontend suppresses its own loader when it detects
+    a running tool step; without this the user sees two spinners.
+
+    Pass ``final=True`` once the agent turn is complete to set ``end`` and stop
+    the spinner.
+    """
+    step = tool_summary_holder.get("step")
+    if step is None:
+        return
+    step.output = _build_tool_summary(tool_call_info)
+    if final:
+        step.end = _utc_now()
+    await step.update()
+
 
 async def _process_session_frame(
     msg: JsonDict,
@@ -983,6 +1054,7 @@ async def _process_session_frame(
     assistant_msg_getter: Callable[[], Awaitable[cl.Message]],
     tool_steps: dict[str, cl.Step],
     tool_call_info: dict[str, JsonDict],
+    tool_summary_holder: dict[str, cl.Step],
     parent_id: str | None,
 ) -> None:
     """Dispatch one inbound JSON-RPC frame from a session queue.
@@ -1006,10 +1078,44 @@ async def _process_session_frame(
                 await target.stream_token(text)
 
         elif update_type == "tool_call":
+            tc_id = cast("str", update.get("toolCallId") or "")
+            is_new_tool = tc_id not in tool_steps
             await _handle_tool_call(update, tool_steps, tool_call_info, parent_id)
+            # Maintain a single visible summary Step (type="tool") that the
+            # user can expand. Individual tool steps use type="run" and are
+            # hidden by cot="tool_call".
+            if is_new_tool:
+                if "step" not in tool_summary_holder:
+                    summary = cl.Step(name="Tool Calls (1)", type="tool", parent_id=parent_id)
+                    summary.start = _utc_now()
+                    summary.output = _build_tool_summary(tool_call_info)
+                    await summary.send()
+                    tool_summary_holder["step"] = summary
+                else:
+                    tool_summary_holder["step"].name = f"Tool Calls ({len(tool_call_info)})"
+                    await _update_tool_summary(tool_summary_holder, tool_call_info)
 
         elif update_type == "tool_call_update":
+            # Track tool output for the summary step.
+            tc_id = cast("str", update.get("toolCallId") or "")
+            if tc_id in tool_call_info:
+                raw_output = update.get("rawOutput")
+                if raw_output is not None:
+                    tool_call_info[tc_id]["rawOutput"] = raw_output
+                else:
+                    text_parts = _extract_text_blocks(update.get("content"))
+                    if text_parts:
+                        tool_call_info[tc_id]["outputText"] = "\n".join(text_parts)
+                status = update.get("status")
+                if isinstance(status, str):
+                    tool_call_info[tc_id]["status"] = status
             await _handle_tool_call_update(update, tool_steps)
+            # Refresh the summary step after each tool completion.
+            if "step" in tool_summary_holder and update.get("status") in (
+                "completed",
+                "failed",
+            ):
+                await _update_tool_summary(tool_summary_holder, tool_call_info)
 
     elif method == "session/request_permission":
         req_id_raw = msg.get("id")
@@ -1031,6 +1137,14 @@ async def _process_session_frame(
         if _is_explain_enabled() and tc.get("humanReadable") is None:
             with contextlib.suppress(Exception):
                 tc["humanReadable"] = await _generate_human_readable(tc)
+
+        # Persist the explanation back into tool_call_info so the summary
+        # step can display it when the user unfolds it.
+        tc_id_perm = cast("str", tc.get("toolCallId") or "")
+        if tc_id_perm in tool_call_info and isinstance(tc.get("humanReadable"), str):
+            tool_call_info[tc_id_perm]["humanReadable"] = tc["humanReadable"]
+            if "step" in tool_summary_holder:
+                await _update_tool_summary(tool_summary_holder, tool_call_info)
 
         outcome = await _ask_user_for_permission(tc, options)
         await _client.respond(req_id, {"outcome": outcome})

--- a/tests/test_permission_prompt.py
+++ b/tests/test_permission_prompt.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -11,8 +12,10 @@ import pytest
 from medmcp.app import (
     OLLAMA_BASE_URL,  # pyright: ignore[reportPrivateUsage]
     OLLAMA_MODEL,  # pyright: ignore[reportPrivateUsage]
+    RISK_CATEGORIES,  # pyright: ignore[reportPrivateUsage]
     _format_permission_prompt,  # pyright: ignore[reportPrivateUsage]
-    _generate_human_readable,  # pyright: ignore[reportPrivateUsage]
+    _generate_explanation,  # pyright: ignore[reportPrivateUsage]
+    _parse_explanation_response,  # pyright: ignore[reportPrivateUsage]
 )
 
 # ── _format_permission_prompt ─────────────────────────────
@@ -86,41 +89,251 @@ class TestFormatPermissionPrompt:
         result = _format_permission_prompt({})
         assert "`tool call`" in result
 
+    def test_risks_rendered_as_badges(self) -> None:
+        """Known risk keys should render as labelled badge lines."""
+        result = _format_permission_prompt(
+            {
+                "title": "bash: rm -rf /data",
+                "humanReadable": "Permanently deletes the /data folder.",
+                "risks": ["file_delete", "code_exec"],
+            }
+        )
+        label_delete, _ = RISK_CATEGORIES["file_delete"]
+        label_exec, _ = RISK_CATEGORIES["code_exec"]
+        assert label_delete in result
+        assert label_exec in result
 
-# ── _generate_human_readable ──────────────────────────────
+    def test_risks_appear_after_human_readable(self) -> None:
+        """Risk badges must follow the blockquote explanation, before the JSON fence."""
+        result = _format_permission_prompt(
+            {
+                "title": "bash: curl http://example.com",
+                "rawInput": {"url": "http://example.com"},
+                "humanReadable": "Downloads a file from the internet.",
+                "risks": ["network"],
+            }
+        )
+        hr_pos = result.index("> Downloads")
+        label_network, _ = RISK_CATEGORIES["network"]
+        risk_pos = result.index(label_network)
+        raw_pos = result.index("```json")
+        assert hr_pos < risk_pos < raw_pos
+
+    def test_unknown_risk_keys_ignored(self) -> None:
+        """Risk keys not in RISK_CATEGORIES should be silently dropped."""
+        result = _format_permission_prompt(
+            {
+                "title": "bash: ls",
+                "risks": ["not_a_real_risk", "file_read"],
+            }
+        )
+        assert "not_a_real_risk" not in result
+        label_read, _ = RISK_CATEGORIES["file_read"]
+        assert label_read in result
+
+    def test_no_risks_no_badge_line(self) -> None:
+        """An empty risks list should not add any badge output."""
+        result_with = _format_permission_prompt({"title": "bash: ls", "risks": ["file_read"]})
+        result_without = _format_permission_prompt({"title": "bash: ls", "risks": []})
+        assert len(result_with) > len(result_without)
 
 
-def _mock_ollama_response(text: str) -> httpx.Response:
+# ── _parse_explanation_response ───────────────────────────
+
+
+class TestParseExplanationResponse:
+    """Unit tests for the JSON parser — no Ollama calls needed."""
+
+    def test_valid_json(self) -> None:
+        """Clean JSON should parse to (explanation, risks)."""
+        payload = json.dumps({"explanation": "Lists folder contents.", "risks": ["file_read"]})
+        result = _parse_explanation_response(payload)
+        assert result == ("Lists folder contents.", ["file_read"])
+
+    def test_json_in_code_fence(self) -> None:
+        """JSON wrapped in a markdown code fence should still parse correctly."""
+        payload = '```json\n{"explanation": "Reads a file.", "risks": ["file_read"]}\n```'
+        result = _parse_explanation_response(payload)
+        assert result is not None
+        explanation, risks = result
+        assert explanation == "Reads a file."
+        assert risks == ["file_read"]
+
+    def test_preamble_text_stripped(self) -> None:
+        """If the model adds leading text before the JSON object, it should be stripped."""
+        payload = 'Here is the result:\n{"explanation": "Does something.", "risks": []}'
+        result = _parse_explanation_response(payload)
+        assert result is not None
+        assert result[0] == "Does something."
+
+    def test_invalid_risk_keys_filtered(self) -> None:
+        """Risk keys not in RISK_CATEGORIES should be removed."""
+        payload = json.dumps(
+            {"explanation": "Does something.", "risks": ["file_read", "invented_risk"]}
+        )
+        result = _parse_explanation_response(payload)
+        assert result is not None
+        _, risks = result
+        assert risks == ["file_read"]
+        assert "invented_risk" not in risks
+
+    def test_all_valid_risk_keys_accepted(self) -> None:
+        """All keys in RISK_CATEGORIES should be accepted."""
+        all_keys = list(RISK_CATEGORIES)
+        payload = json.dumps({"explanation": "Does everything.", "risks": all_keys})
+        result = _parse_explanation_response(payload)
+        assert result is not None
+        _, risks = result
+        assert set(risks) == set(all_keys)
+
+    def test_missing_explanation_returns_none(self) -> None:
+        """A payload without an explanation key should return None."""
+        payload = json.dumps({"risks": ["file_read"]})
+        assert _parse_explanation_response(payload) is None
+
+    def test_empty_explanation_returns_none(self) -> None:
+        """An empty explanation string should be treated as absent."""
+        payload = json.dumps({"explanation": "   ", "risks": []})
+        assert _parse_explanation_response(payload) is None
+
+    def test_empty_risks_list_allowed(self) -> None:
+        """An empty risks list is valid — some tool calls have no notable risks."""
+        payload = json.dumps({"explanation": "Checks the date.", "risks": []})
+        result = _parse_explanation_response(payload)
+        assert result == ("Checks the date.", [])
+
+    def test_invalid_json_returns_none(self) -> None:
+        """Garbage text that cannot be parsed as JSON should return None."""
+        assert _parse_explanation_response("not json at all") is None
+
+    def test_non_dict_json_returns_none(self) -> None:
+        """A JSON array at the top level should return None."""
+        assert _parse_explanation_response('["a", "b"]') is None
+
+
+# ── _generate_explanation ─────────────────────────────────
+
+
+def _mock_ollama_response(body: str) -> httpx.Response:
     """Build a fake httpx.Response mimicking Ollama's chat/completions endpoint."""
     return httpx.Response(
         200,
-        json={
-            "choices": [{"message": {"content": text}}],
-        },
+        json={"choices": [{"message": {"content": body}}]},
         request=httpx.Request("POST", f"{OLLAMA_BASE_URL}/v1/chat/completions"),
     )
 
 
-class TestGenerateHumanReadable:
-    """Verify _generate_human_readable calls Ollama and parses the response."""
+class TestGenerateExplanation:
+    """Verify _generate_explanation calls Ollama and parses the structured response."""
 
     @pytest.mark.asyncio
-    async def test_returns_explanation(self) -> None:
-        """A successful Ollama response should yield the explanation text."""
-        mock_response = _mock_ollama_response("Lists all files in the current directory.")
-        with patch("medmcp.app.httpx.AsyncClient") as mock_client_cls:
+    async def test_returns_explanation_and_risks(self) -> None:
+        """A successful Ollama JSON response yields (explanation, risks)."""
+        body = json.dumps({"explanation": "Lists all files in the folder.", "risks": ["file_read"]})
+        with patch("medmcp.app.httpx.AsyncClient") as mock_cls:
             instance = AsyncMock()
-            instance.post.return_value = mock_response
+            instance.post.return_value = _mock_ollama_response(body)
             instance.__aenter__ = AsyncMock(return_value=instance)
             instance.__aexit__ = AsyncMock(return_value=False)
-            mock_client_cls.return_value = instance
+            mock_cls.return_value = instance
 
-            result = await _generate_human_readable({"title": "bash: ls -la"})
+            result = await _generate_explanation({"title": "bash: ls -la"})
 
-        assert result == "Lists all files in the current directory."
-        instance.post.assert_called_once()
+        assert result is not None
+        explanation, risks = result
+        assert explanation == "Lists all files in the folder."
+        assert risks == ["file_read"]
+
+    @pytest.mark.asyncio
+    async def test_correct_model_and_low_temperature(self) -> None:
+        """The request must use the configured model and temperature=0."""
+        body = json.dumps({"explanation": "Does something.", "risks": []})
+        with patch("medmcp.app.httpx.AsyncClient") as mock_cls:
+            instance = AsyncMock()
+            instance.post.return_value = _mock_ollama_response(body)
+            instance.__aenter__ = AsyncMock(return_value=instance)
+            instance.__aexit__ = AsyncMock(return_value=False)
+            mock_cls.return_value = instance
+
+            await _generate_explanation({"title": "bash: ls"})
+
         call_kwargs: dict[str, Any] = instance.post.call_args[1]
         assert call_kwargs["json"]["model"] == OLLAMA_MODEL
+        assert call_kwargs["json"]["temperature"] == 0.0
+
+    @pytest.mark.asyncio
+    async def test_prompt_contains_physician_language(self) -> None:
+        """The prompt must explicitly mention the physician audience."""
+        body = json.dumps({"explanation": "x", "risks": []})
+        with patch("medmcp.app.httpx.AsyncClient") as mock_cls:
+            instance = AsyncMock()
+            instance.post.return_value = _mock_ollama_response(body)
+            instance.__aenter__ = AsyncMock(return_value=instance)
+            instance.__aexit__ = AsyncMock(return_value=False)
+            mock_cls.return_value = instance
+
+            await _generate_explanation({"title": "bash: ls"})
+
+        call_kwargs: dict[str, Any] = instance.post.call_args[1]
+        prompt: str = call_kwargs["json"]["messages"][0]["content"]
+        assert "physician" in prompt.lower()
+
+    @pytest.mark.asyncio
+    async def test_prompt_lists_all_risk_keys(self) -> None:
+        """Every key in RISK_CATEGORIES must appear in the prompt."""
+        body = json.dumps({"explanation": "x", "risks": []})
+        with patch("medmcp.app.httpx.AsyncClient") as mock_cls:
+            instance = AsyncMock()
+            instance.post.return_value = _mock_ollama_response(body)
+            instance.__aenter__ = AsyncMock(return_value=instance)
+            instance.__aexit__ = AsyncMock(return_value=False)
+            mock_cls.return_value = instance
+
+            await _generate_explanation({"title": "bash: ls"})
+
+        call_kwargs: dict[str, Any] = instance.post.call_args[1]
+        prompt: str = call_kwargs["json"]["messages"][0]["content"]
+        for key in RISK_CATEGORIES:
+            assert key in prompt, f"Risk key '{key}' missing from prompt"
+
+    @pytest.mark.asyncio
+    async def test_dict_raw_input_serialized_in_prompt(self) -> None:
+        """Dict rawInput should be JSON-serialized in the prompt, not repr'd."""
+        body = json.dumps({"explanation": "Writes a file.", "risks": ["file_write"]})
+        with patch("medmcp.app.httpx.AsyncClient") as mock_cls:
+            instance = AsyncMock()
+            instance.post.return_value = _mock_ollama_response(body)
+            instance.__aenter__ = AsyncMock(return_value=instance)
+            instance.__aexit__ = AsyncMock(return_value=False)
+            mock_cls.return_value = instance
+
+            await _generate_explanation(
+                {"title": "write_file", "rawInput": {"path": "/tmp/x", "content": "hello"}}
+            )
+
+        call_kwargs: dict[str, Any] = instance.post.call_args[1]
+        prompt: str = call_kwargs["json"]["messages"][0]["content"]
+        assert '"path"' in prompt
+
+    @pytest.mark.asyncio
+    async def test_long_raw_input_truncated(self) -> None:
+        """RawInput longer than 400 chars should be truncated in the prompt."""
+        body = json.dumps({"explanation": "Does something.", "risks": []})
+        long_input = "x" * 600
+        with patch("medmcp.app.httpx.AsyncClient") as mock_cls:
+            instance = AsyncMock()
+            instance.post.return_value = _mock_ollama_response(body)
+            instance.__aenter__ = AsyncMock(return_value=instance)
+            instance.__aexit__ = AsyncMock(return_value=False)
+            mock_cls.return_value = instance
+
+            await _generate_explanation({"title": "bash: cat", "rawInput": long_input})
+
+        call_kwargs: dict[str, Any] = instance.post.call_args[1]
+        prompt: str = call_kwargs["json"]["messages"][0]["content"]
+        assert "truncated" in prompt
+        # The full 600-char string must not appear verbatim
+        assert long_input not in prompt
 
     @pytest.mark.asyncio
     async def test_returns_none_on_empty_choices(self) -> None:
@@ -130,62 +343,41 @@ class TestGenerateHumanReadable:
             json={"choices": []},
             request=httpx.Request("POST", f"{OLLAMA_BASE_URL}/v1/chat/completions"),
         )
-        with patch("medmcp.app.httpx.AsyncClient") as mock_client_cls:
+        with patch("medmcp.app.httpx.AsyncClient") as mock_cls:
             instance = AsyncMock()
             instance.post.return_value = response
             instance.__aenter__ = AsyncMock(return_value=instance)
             instance.__aexit__ = AsyncMock(return_value=False)
-            mock_client_cls.return_value = instance
+            mock_cls.return_value = instance
 
-            result = await _generate_human_readable({"title": "bash: ls"})
+            result = await _generate_explanation({"title": "bash: ls"})
 
         assert result is None
 
     @pytest.mark.asyncio
     async def test_returns_none_on_network_error(self) -> None:
         """Network failures should return None, not raise."""
-        with patch("medmcp.app.httpx.AsyncClient") as mock_client_cls:
+        with patch("medmcp.app.httpx.AsyncClient") as mock_cls:
             instance = AsyncMock()
             instance.post.side_effect = httpx.ConnectError("connection refused")
             instance.__aenter__ = AsyncMock(return_value=instance)
             instance.__aexit__ = AsyncMock(return_value=False)
-            mock_client_cls.return_value = instance
+            mock_cls.return_value = instance
 
-            result = await _generate_human_readable({"title": "bash: ls"})
-
-        assert result is None
-
-    @pytest.mark.asyncio
-    async def test_returns_none_on_blank_content(self) -> None:
-        """A blank content string should be treated as no explanation."""
-        response = _mock_ollama_response("   ")
-        with patch("medmcp.app.httpx.AsyncClient") as mock_client_cls:
-            instance = AsyncMock()
-            instance.post.return_value = response
-            instance.__aenter__ = AsyncMock(return_value=instance)
-            instance.__aexit__ = AsyncMock(return_value=False)
-            mock_client_cls.return_value = instance
-
-            result = await _generate_human_readable({"title": "bash: ls"})
+            result = await _generate_explanation({"title": "bash: ls"})
 
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_dict_raw_input_serialized(self) -> None:
-        """Dict rawInput should be JSON-serialized in the prompt sent to Ollama."""
-        mock_response = _mock_ollama_response("Writes hello to a file.")
-        with patch("medmcp.app.httpx.AsyncClient") as mock_client_cls:
+    async def test_returns_none_on_invalid_json_response(self) -> None:
+        """A non-JSON response body should return None, not raise."""
+        with patch("medmcp.app.httpx.AsyncClient") as mock_cls:
             instance = AsyncMock()
-            instance.post.return_value = mock_response
+            instance.post.return_value = _mock_ollama_response("I cannot help with that.")
             instance.__aenter__ = AsyncMock(return_value=instance)
             instance.__aexit__ = AsyncMock(return_value=False)
-            mock_client_cls.return_value = instance
+            mock_cls.return_value = instance
 
-            await _generate_human_readable(
-                {"title": "write_file", "rawInput": {"path": "/tmp/x", "content": "hello"}}
-            )
+            result = await _generate_explanation({"title": "bash: ls"})
 
-        call_kwargs: dict[str, Any] = instance.post.call_args[1]
-        prompt: str = call_kwargs["json"]["messages"][0]["content"]
-        # The dict should have been serialized, not repr'd
-        assert '"path"' in prompt
+        assert result is None

--- a/tests/test_permission_prompt.py
+++ b/tests/test_permission_prompt.py
@@ -246,7 +246,7 @@ class TestGenerateExplanation:
 
     @pytest.mark.asyncio
     async def test_correct_model_and_low_temperature(self) -> None:
-        """The request must use the configured model and temperature=0."""
+        """The request must use the configured model and a low temperature."""
         body = json.dumps({"explanation": "Does something.", "risks": []})
         with patch("medmcp.app.httpx.AsyncClient") as mock_cls:
             instance = AsyncMock()
@@ -259,7 +259,7 @@ class TestGenerateExplanation:
 
         call_kwargs: dict[str, Any] = instance.post.call_args[1]
         assert call_kwargs["json"]["model"] == OLLAMA_MODEL
-        assert call_kwargs["json"]["temperature"] == 0.0
+        assert call_kwargs["json"]["temperature"] == 0.1
 
     @pytest.mark.asyncio
     async def test_prompt_contains_physician_language(self) -> None:


### PR DESCRIPTION
## Summary
- Aggregate all tool calls into a single expandable "Tool Calls (N)" summary step with status icons, explanations, and output previews
- Remove permission prompts from chat after user responds to reduce clutter 
- Enable "Explain tool calls" by default 
- Tune "Explain tool calls" prompt to A) describe and B) assign a risk to each action
- Tune Chainlit config: disable user-message autoscroll, force en-US locale, open sidebar by default, switch to cot="tool_call" and modern alert style 
- Unify `justfile`

## Test plan
- [x] Launch UI with `just ui`, send a multi-tool prompt, verify a single "Tool Calls (N)" step appears and is expandable
- [x] Confirm individual tool steps are hidden but visible inside the summary 
- [x] Approve/deny a permission prompt and verify it disappears from the chat after responding 
- [x] Verify the "Explain tool calls" toggle defaults to on and explanations appear in the summary

## Security & data handling
No new tool surface, network calls, or file-write paths. The `ask_msg.remove()` call is purely cosmetic (removes the UI element, not the audit log entry). Permission gating is unchanged.

## Notes
- The `cot="tool_call"` Chainlit setting hides `type="run"` steps; the new summary step uses `type="tool"` to remain visible. If `cot` is changed back to `"full"`, individual steps will reappear alongside the summary.