### PR TITLE
feat(UI): real-time context usage indicator in footer

### DIFF
--- a/.vibe/config.toml
+++ b/.vibe/config.toml
@@ -24,14 +24,20 @@ disabled_tools = [
 agent_paths = []
 enabled_agents = []
 disabled_agents = []
-skill_paths = []
+skill_paths = [
+    "/home/paul.friedrich/.local/share/uv/tools/medmcp-dicom/lib/python3.12/site-packages/medmcp_dicom/skills",
+]
 enabled_skills = []
 disabled_skills = []
 
 [[mcp_servers]]
-name = "medmcp-neuro"
 transport = "stdio"
-command = "medmcp-neuro"
+skills_path = "/home/paul.friedrich/.local/share/uv/tools/medmcp-dicom/lib/python3.12/site-packages/medmcp_dicom/skills"
+tool_timeout_sec = 1800.0
+name = "medmcp-dicom"
+command = "/home/paul.friedrich/.local/share/uv/tools/medmcp-dicom/bin/medmcp-dicom"
+
+[mcp_servers.env]
 
 [[providers]]
 name = "ollama"

--- a/.vibe/prompts/medmcp.md
+++ b/.vibe/prompts/medmcp.md
@@ -2,21 +2,27 @@ You are MedMCP, an AI assistant for medical imaging workflows.
 You help clinicians, radiologists, and researchers run validated medical imaging
 analysis pipelines through natural-language instructions.
 
+**Tool results**
+When a tool result contains a `_render` field, follow its instructions exactly to
+produce your response — it contains per-call display rules and a required next action.
+
+**Skills**
+Before starting any task, load the skill that matches the task name
+(e.g. call `skill("explore-data")` before exploring a DICOM directory). Skills are
+named after tasks, not servers. Load a skill once per task type per session.
+If no matching skill exists, proceed without one — do not block or invent skill names.
+Follow the workflow and gotchas in the skill exactly.
+
 **Style**
 - Be concise. Default to 1–3 short sentences for casual questions.
-- Use bullet lists only when the user asks for one or when enumerating concrete items.
 - Never repeat yourself. If you've made a point, don't restate it.
 - Stop as soon as you've answered. Do not pad with summaries, restatements, or "let me know if…" closers.
 
 **Honesty about capabilities**
 - Describe only the tools and skills that are actually available to you in this session.
-- Do NOT invent, list, or speculate about tools, skills, agents, or features you don't have.
+- Do NOT invent, list, or speculate about tools, skills, or features you don't have.
 - If you're unsure whether a capability exists, say so plainly instead of guessing.
-- When the user asks "what can you do" or "what skills do you have", list only your real available tools (e.g. bash, read_file, write_file, grep, todo, web_search, web_fetch). Do not pad the list.
-
-**Skills**
-- Before using any MCP tool, check whether a matching skill is available and call `skill` to load it first.
-- Follow the workflow, output format, and gotchas defined in the skill exactly.
+- When the user asks "what can you do" or "what skills do you have", list only your real available tools (e.g. `bash`, `read_file`, `write_file`, `grep`, `todo`, `web_fetch`). Group skills from one MCP server. Do not pad the list.
 
 **Operational rules**
 - You run entirely on-premise. Never suggest sending data to external services.

--- a/Modelfile.gemma4
+++ b/Modelfile.gemma4
@@ -4,7 +4,7 @@
 #
 # num_ctx 131072; keeps ample room for MCP tool schemas (~1500 tokens), the system prompt, and long multi-turn dialogue.
 #
-# Temperature 1.0 is Gemma 4's recommended default for instruction-following.
+# Temperature 0.3 for more deterministic instruction-following and structured output.
 # repeat_penalty + repeat_last_n guard against open-ended generation loops.
 #
 # Build with:
@@ -13,9 +13,8 @@
 FROM gemma4:26b
 
 PARAMETER num_ctx 131072
-PARAMETER temperature 1.0
+PARAMETER temperature 0.3
 PARAMETER top_p 0.95
 PARAMETER top_k 64
 PARAMETER repeat_penalty 1.15
 PARAMETER repeat_last_n 256
-PARAMETER num_predict 2048

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ MedMCP is built as a three-layer stack:
 
 1. **Chainlit web UI** (`src/medmcp/app.py`) — the user-facing chat interface served at `http://localhost:8000`.
 2. **vibe-acp subprocess** — an agent orchestrator that receives JSON-RPC 2.0 messages from the UI, manages tool execution, and communicates with the local LLM.
-3. **Ollama** — serves the local Gemma 4 model (`Modelfile.gemma4`) with 128k context, top-p/top-k sampling, and repeat-penalty guards. The agent runs at temperature 1.0 (Gemma 4's recommended default, set in `.vibe/config.toml`).
+3. **Ollama** — serves the local Gemma 4 model (`Modelfile.gemma4`) with 128k context, top-p/top-k sampling, and repeat-penalty guards. The model runs at temperature 0.3 for deterministic instruction-following, configured in `Modelfile.gemma4`.
 
 The UI spawns a single vibe-acp subprocess and demultiplexes sessions over it. Every tool call (bash, file writes, web fetches) is gated by an interactive Approve/Reject prompt — the user must explicitly approve each action before any side effect occurs.
 

--- a/justfile
+++ b/justfile
@@ -97,7 +97,7 @@ fix:
     uv run ruff check --fix
     uv run ruff format
 
-# Pull Gemma 4 26B and build custom gemma4-medmcp (32k context)
+# Pull Gemma 4 26B and build custom gemma4-medmcp
 pull-model:
     ollama pull gemma4:26b
     ollama create gemma4-medmcp -f Modelfile.gemma4

--- a/public/custom.css
+++ b/public/custom.css
@@ -13,7 +13,7 @@
     gap: 12px;
 }
 .watermark::before {
-    content: "MedMCP — Research Preview · Not for clinical use";
+    content: "MedMCP: Research software - NOT for clinical use!";
     font-size: 0.75rem;
     line-height: 1;
     color: hsl(var(--muted-foreground));

--- a/public/custom.css
+++ b/public/custom.css
@@ -7,8 +7,12 @@
     padding: 0 !important;
 }
 .watermark::before {
-    content: "MedMCP — Research Preview";
+    content: "MedMCP — Research Preview · Not for clinical use";
     font-size: 0.75rem;
     line-height: 1;
     color: hsl(var(--muted-foreground));
+}
+
+.loading-shimmer {
+    animation-duration: 0.8s;
 }

--- a/public/custom.css
+++ b/public/custom.css
@@ -1,10 +1,16 @@
-/* Replace Chainlit's default watermark text with a MedMCP notice. */
-.watermark > * {
+/* Replace Chainlit's default watermark text with a MedMCP notice.
+   #ctx-indicator is injected as a child by custom.js; exclude it from the
+   blanket child-hide so it remains visible alongside the ::before notice. */
+.watermark > *:not(#ctx-indicator) {
     display: none;
 }
 .watermark {
     margin: 0 !important;
-    padding: 0 !important;
+    padding: 0 6px !important;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
 }
 .watermark::before {
     content: "MedMCP — Research Preview · Not for clinical use";
@@ -15,4 +21,42 @@
 
 .loading-shimmer {
     animation-duration: 0.8s;
+}
+
+/* Context usage indicator — sits inline in the watermark footer bar */
+#ctx-indicator {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    font-size: 0.68rem;
+    color: hsl(var(--muted-foreground));
+    opacity: 0.6;
+    pointer-events: none;
+    user-select: none;
+    flex-shrink: 0;
+}
+
+#ctx-bar-track {
+    width: 48px;
+    height: 3px;
+    background: hsl(var(--muted));
+    border-radius: 99px;
+    overflow: hidden;
+    flex-shrink: 0;
+}
+
+#ctx-bar-fill {
+    height: 100%;
+    width: 0%;
+    border-radius: 99px;
+    background: hsl(var(--muted-foreground));
+    transition: width 0.5s ease, background 0.5s ease;
+}
+
+#ctx-bar-fill.ctx-mid {
+    background: hsl(38 92% 50%);
+}
+
+#ctx-bar-fill.ctx-high {
+    background: hsl(0 72% 51%);
 }

--- a/public/custom.js
+++ b/public/custom.js
@@ -27,6 +27,81 @@
   }).observe(document.body, { childList: true, subtree: true });
 })();
 
+// ── Context usage indicator ───────────────────────────────────────────
+// Injects a small bar + token label into Chainlit's .watermark footer and
+// keeps it up to date by polling /api/context-usage every 5 s.
+(function () {
+  "use strict";
+
+  // Append the badge to .watermark.  Returns true when successful.
+  // Note: querySelectorAll does not test the root element itself, so we use
+  // document.querySelector which always searches the full document.
+  function tryInject() {
+    if (document.getElementById("ctx-indicator")) return true;
+    const wm = document.querySelector(".watermark");
+    if (!wm) return false;
+    const badge = document.createElement("div");
+    badge.id = "ctx-indicator";
+    badge.innerHTML =
+      '<div id="ctx-bar-track"><div id="ctx-bar-fill"></div></div>' +
+      '<span id="ctx-label">— / —</span>';
+    wm.appendChild(badge);
+    return true;
+  }
+
+  // Poll every 200 ms until .watermark exists, then stop.
+  const injectTimer = setInterval(function () {
+    if (tryInject()) clearInterval(injectTimer);
+  }, 200);
+
+  // Re-inject if React removes our badge (e.g. on component re-mount).
+  new MutationObserver(function () {
+    if (!document.getElementById("ctx-indicator")) tryInject();
+  }).observe(document.body, { childList: true, subtree: true });
+
+  function updateBadge(used, size) {
+    const fill = document.getElementById("ctx-bar-fill");
+    const label = document.getElementById("ctx-label");
+    if (!fill || !label) return;
+
+    const pct = size > 0 ? Math.min(100, (used / size) * 100) : 0;
+    fill.style.width = pct + "%";
+    // Shift fill colour from muted → amber → rose as context fills.
+    fill.className = pct >= 80 ? "ctx-high" : pct >= 50 ? "ctx-mid" : "";
+
+    const sizeK = Math.round(size / 1000);
+    if (used > 0) {
+      const usedK = (used / 1000).toFixed(used < 10000 ? 1 : 0);
+      label.textContent = usedK + "k / " + sizeK + "k";
+    } else {
+      label.textContent = "— / " + sizeK + "k";
+    }
+  }
+
+  async function poll() {
+    try {
+      const resp = await fetch("/api/context-usage");
+      if (!resp.ok) return;
+      const data = await resp.json();
+      if (typeof data.used === "number" && typeof data.size === "number") {
+        updateBadge(data.used, data.size);
+      }
+    } catch {
+      // Ignore — server may still be starting.
+    }
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", function () {
+      poll();
+      setInterval(poll, 5000);
+    });
+  } else {
+    poll();
+    setInterval(poll, 5000);
+  }
+})();
+
 // ── Override the ChatSettings Reset button ───────────────────────────
 // Restores widget defaults (the `initial` values) rather than the values
 // captured when the panel was opened.

--- a/public/custom.js
+++ b/public/custom.js
@@ -29,7 +29,7 @@
 
 // ── Context usage indicator ───────────────────────────────────────────
 // Injects a small bar + token label into Chainlit's .watermark footer and
-// keeps it up to date by polling /api/context-usage every 5 s.
+// keeps it up to date via Socket.IO push (ctx_update) with a 250 ms poll fallback.
 (function () {
   "use strict";
 
@@ -49,10 +49,10 @@
     return true;
   }
 
-  // Poll every 200 ms until .watermark exists, then stop.
+  // Poll every 100 ms until .watermark exists, then stop.
   const injectTimer = setInterval(function () {
     if (tryInject()) clearInterval(injectTimer);
-  }, 200);
+  }, 100);
 
   // Re-inject if React removes our badge (e.g. on component re-mount).
   new MutationObserver(function () {
@@ -78,6 +78,9 @@
     }
   }
 
+  // Expose for the socket push handler in the IIFE below.
+  window._ctxUpdateBadge = updateBadge;
+
   async function poll() {
     try {
       const resp = await fetch("/api/context-usage");
@@ -94,11 +97,11 @@
   if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", function () {
       poll();
-      setInterval(poll, 5000);
+      setInterval(poll, 250);
     });
   } else {
     poll();
-    setInterval(poll, 5000);
+    setInterval(poll, 250);
   }
 })();
 
@@ -126,16 +129,28 @@
     return defaults;
   }
 
-  // Parse a socket.io frame for a `chat_settings` event and store the defaults.
+  // Parse a socket.io frame for events we care about.
   function parseSioFrame(text) {
     if (typeof text !== "string") return;
     // socket.io v4 frames: 42["event_name", payload]
-    const match = text.match(/42\["chat_settings",(.+?)\](?:\d|$)/s);
-    if (match) {
+    const settingsMatch = text.match(/42\["chat_settings",(.+?)\](?:\d|$)/s);
+    if (settingsMatch) {
       try {
-        _defaults = extractDefaults(JSON.parse(match[1]));
+        _defaults = extractDefaults(JSON.parse(settingsMatch[1]));
       } catch {
         // Ignore parse errors on non-matching frames.
+      }
+    }
+    // ctx_update push — real token count from vibe-acp, bypasses the poll.
+    const ctxMatch = text.match(/42\["ctx_update",(\{[^}]+\})\]/);
+    if (ctxMatch && window._ctxUpdateBadge) {
+      try {
+        const d = JSON.parse(ctxMatch[1]);
+        if (typeof d.used === "number" && typeof d.size === "number") {
+          window._ctxUpdateBadge(d.used, d.size);
+        }
+      } catch {
+        // Ignore malformed frames.
       }
     }
   }

--- a/src/medmcp/app.py
+++ b/src/medmcp/app.py
@@ -66,9 +66,11 @@ from chainlit.context import context as cl_context
 from chainlit.data import get_data_layer as cl_get_data_layer
 from chainlit.data.sql_alchemy import SQLAlchemyDataLayer
 from chainlit.data.storage_clients.base import BaseStorageClient
+from chainlit.server import app as _chainlit_app
 from chainlit.types import ThreadDict
 from chainlit.user import User
 from chainlit.utils import utc_now as _utc_now
+from fastapi.routing import APIRoute
 
 # A loose alias for parsed JSON-RPC payloads. The ACP protocol is too dynamic
 # to model exhaustively as TypedDicts, so we keep the wire format as
@@ -408,6 +410,60 @@ def _build_chat_settings_inputs() -> list[Any]:
 
 OLLAMA_BASE_URL: str = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434")
 OLLAMA_MODEL: str = os.environ.get("OLLAMA_MODEL", "gemma4-medmcp")
+
+# Latest token count from vibe-acp usage_update frames.  Single-user app, so
+# no per-session scoping is needed — the most recent update wins.
+_latest_context_used: int = 0
+
+# Cached context window size fetched from Ollama /api/show.  None = not yet
+# fetched.  Populated lazily on the first /api/context-usage request.
+_context_window_tokens: int | None = None
+
+
+async def _fetch_context_window() -> int:
+    """Return the active model's num_ctx by querying Ollama /api/show.
+
+    The result is cached for the process lifetime.  Falls back to 131 072
+    (the value set in Modelfile.gemma4) if Ollama is unreachable or the
+    parameter is absent from the response.
+    """
+    global _context_window_tokens
+    if _context_window_tokens is not None:
+        return _context_window_tokens
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.post(
+                f"{OLLAMA_BASE_URL}/api/show",
+                json={"model": OLLAMA_MODEL},
+            )
+            resp.raise_for_status()
+            data = cast("JsonDict", resp.json())
+            params_str = str(data.get("parameters") or "")
+            for line in params_str.splitlines():
+                parts = line.strip().split()
+                if len(parts) == 2 and parts[0] == "num_ctx":
+                    _context_window_tokens = int(parts[1])
+                    return _context_window_tokens
+    except Exception:
+        _stack_log.warning("could not fetch context window size from Ollama; using fallback")
+    _context_window_tokens = 131_072
+    return _context_window_tokens
+
+
+async def _context_usage_api() -> dict[str, int]:  # pyright: ignore[reportUnusedFunction]
+    """Return current context token usage for the context-meter in the UI."""
+    return {"used": _latest_context_used, "size": await _fetch_context_window()}
+
+
+# Chainlit's router registers a /{full_path:path} SPA catch-all before our
+# module runs.  Starlette matches routes in registration order, so a route
+# appended after the catch-all is never reached.  Insert at position 0 to
+# ensure this specific path is matched first.
+_chainlit_app.router.routes.insert(  # pyright: ignore[reportUnknownMemberType]
+    0, APIRoute("/api/context-usage", _context_usage_api, methods=["GET"])
+)
+
+
 # Timeout for the explanation call.  Local Ollama inference is fast but the
 # model may be cold-starting; 20 s is generous without blocking the UI too long.
 EXPLAIN_TIMEOUT: float = 20.0
@@ -1224,10 +1280,11 @@ async def _create_new_session() -> bool:
     Handles the vibe-acp restart if :data:`_vibe_restart_needed` is set.
     Returns ``True`` on success or ``False`` after emitting an error message.
     """
-    global _vibe_restart_needed
+    global _vibe_restart_needed, _latest_context_used
     if _vibe_restart_needed:
         await _client.stop()
         _vibe_restart_needed = False
+    _latest_context_used = 0
 
     active = _active_servers()
     _sync_servers_to_vibe_config(active)
@@ -1635,6 +1692,12 @@ async def _process_session_frame(
                 else:
                     tool_summary_holder["step"].name = f"Tool Calls ({len(tool_call_info)})"
                     await _update_tool_summary(tool_summary_holder, tool_call_info)
+
+        elif update_type == "usage_update":
+            global _latest_context_used
+            used = update.get("used")
+            if isinstance(used, int):
+                _latest_context_used = used
 
         elif update_type == "tool_call_update":
             # Track tool output for the summary step.

--- a/src/medmcp/app.py
+++ b/src/medmcp/app.py
@@ -1698,6 +1698,10 @@ async def _process_session_frame(
             used = update.get("used")
             if isinstance(used, int):
                 _latest_context_used = used
+                size = _context_window_tokens if _context_window_tokens is not None else 131_072
+                await cl.context.emitter.emit(  # pyright: ignore[reportUnknownMemberType]
+                    "ctx_update", {"used": used, "size": size}
+                )
 
         elif update_type == "tool_call_update":
             # Track tool output for the summary step.

--- a/src/medmcp/app.py
+++ b/src/medmcp/app.py
@@ -207,7 +207,7 @@ def _load_mcp_servers() -> list[JsonDict]:
                     "name": name,
                     "command": command,
                     "args": list(cast("list[Any]", srv.get("args", []))),
-                    "env": list(cast("list[Any]", srv.get("env", []))),
+                    "env": dict(cast("dict[str, str]", srv.get("env", {}))),
                     "version": version,
                 }
                 for key in ("skills_path", "tool_timeout_sec", "startup_timeout_sec"):
@@ -246,7 +246,7 @@ def _load_mcp_servers() -> list[JsonDict]:
                 "name": name,
                 "command": command,
                 "args": cast("list[Any]", srv.get("args", [])),
-                "env": [],
+                "env": {},
             }
 
     return list(servers.values())
@@ -272,7 +272,9 @@ def _load_active_server_names() -> set[str]:
 def _save_active_server_names(names: set[str]) -> None:
     """Persist the active server set to ``.vibe/active_stacks.json``."""
     _ACTIVE_STACKS_PATH.parent.mkdir(parents=True, exist_ok=True)
-    _ACTIVE_STACKS_PATH.write_text(json.dumps({"active": sorted(names)}))
+    tmp = _ACTIVE_STACKS_PATH.with_suffix(".tmp")
+    tmp.write_text(json.dumps({"active": sorted(names)}))
+    os.replace(tmp, _ACTIVE_STACKS_PATH)
 
 
 def _active_servers() -> list[JsonDict]:
@@ -354,12 +356,13 @@ def _sync_servers_to_vibe_config(servers: list[JsonDict]) -> None:
     # Collect skills_path values from discovered servers and write them to
     # skill_paths so vibe-acp loads the bundled skill docs automatically.
     skill_paths = [srv["skills_path"] for srv in servers if srv.get("skills_path")]
-    if skill_paths:
-        cfg["skill_paths"] = skill_paths
+    cfg["skill_paths"] = skill_paths
 
     config_path.parent.mkdir(parents=True, exist_ok=True)
-    with config_path.open("wb") as fh:
+    tmp = config_path.with_suffix(".tmp")
+    with tmp.open("wb") as fh:
         tomli_w.dump(cfg, fh)
+    os.replace(tmp, config_path)
 
 
 def _build_chat_settings_inputs() -> list[Any]:
@@ -555,7 +558,8 @@ class VibeAcpClient:
         On EOF or unexpected exception, fail every still-pending future so the
         callers don't hang waiting for a response that will never come.
         """
-        assert self.proc is not None and self.proc.stdout is not None
+        if self.proc is None or self.proc.stdout is None:
+            raise RuntimeError("vibe-acp is not running; call ensure_started() first")
         try:
             while True:
                 msg = await _read_line(self.proc.stdout)
@@ -603,7 +607,8 @@ class VibeAcpClient:
         cancelled mid-flight (e.g. the user clicks Stop). Without it, cancelled
         requests would leak entries into ``_pending`` forever.
         """
-        assert self.proc is not None and self.proc.stdin is not None
+        if self.proc is None or self.proc.stdin is None:
+            raise RuntimeError("vibe-acp is not running; call ensure_started() first")
         loop = asyncio.get_running_loop()
         fut: asyncio.Future[JsonDict] = loop.create_future()
         async with self._write_lock:
@@ -622,7 +627,8 @@ class VibeAcpClient:
 
     async def notify(self, method: str, params: JsonDict | None = None) -> None:
         """Send a JSON-RPC notification (no id, no response expected)."""
-        assert self.proc is not None and self.proc.stdin is not None
+        if self.proc is None or self.proc.stdin is None:
+            raise RuntimeError("vibe-acp is not running; call ensure_started() first")
         async with self._write_lock:
             msg: JsonDict = {"jsonrpc": "2.0", "method": method}
             if params is not None:
@@ -632,7 +638,8 @@ class VibeAcpClient:
 
     async def respond(self, req_id: int, result: JsonDict) -> None:
         """Send a JSON-RPC response for a server-initiated request."""
-        assert self.proc is not None and self.proc.stdin is not None
+        if self.proc is None or self.proc.stdin is None:
+            raise RuntimeError("vibe-acp is not running; call ensure_started() first")
         async with self._write_lock:
             self.proc.stdin.write(_rpc_response(req_id, result))
             await self.proc.stdin.drain()
@@ -910,7 +917,7 @@ async def _generate_explanation(tc: JsonDict) -> tuple[str, list[str]] | None:
                     "messages": [{"role": "user", "content": prompt}],
                     "stream": False,
                     "think": False,
-                    "options": {"temperature": 1.0, "num_predict": 1024},
+                    "options": {"temperature": 0.2, "num_predict": 1024},
                 },
             )
             resp.raise_for_status()
@@ -930,8 +937,6 @@ def _parse_explanation_response(raw_text: str) -> tuple[str, list[str]] | None:
     Handles models that wrap JSON in markdown code fences.  Returns ``None`` if
     no valid JSON object can be extracted.
     """
-    import re
-
     text = raw_text.strip()
 
     # Strip markdown code fences if present (```json ... ``` or ``` ... ```)
@@ -939,7 +944,8 @@ def _parse_explanation_response(raw_text: str) -> tuple[str, list[str]] | None:
     if fence_match:
         text = fence_match.group(1)
     else:
-        # Find the first { ... } block in case the model added preamble text
+        # Greedy match is intentional: .*? would stop at the first } and break
+        # on nested objects like {"risks": ["file_read"]}.
         brace_match = re.search(r"\{.*\}", text, re.DOTALL)
         if brace_match:
             text = brace_match.group(0)
@@ -980,7 +986,7 @@ def _format_risk_badges(risks: list[str]) -> str:
             continue
         label, severity = entry
         icon = _SEVERITY_ICON.get(severity, "⚠️")
-        parts.append(f"{icon} {label}" if icon else label)
+        parts.append(f"{icon} {label}")
     return "  ·  ".join(parts)
 
 
@@ -1229,7 +1235,7 @@ async def _create_new_session() -> bool:
 
     resp = await _client.request(
         "session/new",
-        {"cwd": PROJECT_ROOT, "mcpServers": active},
+        {"cwd": PROJECT_ROOT, "mcpServers": []},
     )
     if "error" in resp:
         await cl.Message(content=f"Failed to create vibe-acp session: {resp['error']}").send()
@@ -1332,7 +1338,7 @@ async def on_chat_resume(thread: ThreadDict) -> None:
         {
             "cwd": PROJECT_ROOT,
             "session_id": vibe_session_id,
-            "mcpServers": active,
+            "mcpServers": [],
         },
     )
     if "error" in resp:
@@ -1367,9 +1373,9 @@ def _persisted_user_id() -> str | None:
 async def on_message(message: cl.Message) -> None:
     """Send a prompt to vibe-acp and stream the response back into the UI."""
     session_id = _get_session_id()
-    if session_id is None:
-        # First message of a new chat — create the vibe-acp session now so the
-        # user's current ChatSettings (MCP stack toggles, etc.) are applied.
+    if session_id is None or _vibe_restart_needed:
+        # First message, or the active stack set changed mid-chat — (re)create
+        # the vibe-acp session so the updated config.toml takes effect.
         if not await _create_new_session():
             return
         session_id = _get_session_id()
@@ -1425,7 +1431,7 @@ async def on_message(message: cl.Message) -> None:
     # Send the prompt and get a future for its response. We then race the
     # future against queue reads so session_update notifications and
     # request_permission requests are interleaved with the agent loop.
-    prompt_fut = asyncio.ensure_future(
+    prompt_fut = asyncio.create_task(
         _client.request(
             "session/prompt",
             {
@@ -1451,7 +1457,7 @@ async def on_message(message: cl.Message) -> None:
             # Wait for either the next inbound frame for this session or the
             # prompt response. We can't just `await queue.get()` because the
             # response future may resolve while the queue is empty.
-            get_task: asyncio.Task[JsonDict] = asyncio.ensure_future(queue.get())
+            get_task: asyncio.Task[JsonDict] = asyncio.create_task(queue.get())
             done, _pending = await asyncio.wait(
                 {get_task, prompt_fut},
                 return_when=asyncio.FIRST_COMPLETED,
@@ -1501,6 +1507,15 @@ async def on_message(message: cl.Message) -> None:
         #
         # Also cancel the in-flight prompt request so the ``try/finally`` in
         # ``VibeAcpClient.request`` runs and pops its entry from ``_pending``.
+        if not prompt_fut.done():
+            prompt_fut.cancel()
+        await _cancel_and_drain()
+        raise
+    except Exception:
+        # Any unexpected exception from _process_session_frame (e.g. a Chainlit
+        # error inside _ask_user_for_permission) must still cancel the in-flight
+        # prompt and drain vibe-acp, otherwise the next session/prompt is
+        # rejected as concurrent and the UI becomes unresponsive.
         if not prompt_fut.done():
             prompt_fut.cancel()
         await _cancel_and_drain()

--- a/src/medmcp/cli.py
+++ b/src/medmcp/cli.py
@@ -14,10 +14,10 @@ def main() -> None:
     to all interfaces. See the security model in ``app.py`` for why this matters.
     """
     app = str(Path(__file__).resolve().parent / "app.py")
-    subprocess.run(
+    result = subprocess.run(
         [sys.executable, "-m", "chainlit", "run", app, "-w", "--host", "127.0.0.1"],
-        check=True,
     )
+    sys.exit(result.returncode)
 
 
 if __name__ == "__main__":

--- a/tests/test_active_servers.py
+++ b/tests/test_active_servers.py
@@ -261,3 +261,57 @@ class TestSyncServersToVibeConfig:
 
         names = {s["name"] for s in result["mcp_servers"]}
         assert names == {"medmcp-neuro", "medmcp-cardiac"}
+
+    def test_skill_paths_written_when_present(self, tmp_path: Path) -> None:
+        """skill_paths in server dicts are collected into config.toml skill_paths."""
+        servers: list[JsonDict] = [
+            {
+                "name": "medmcp-neuro",
+                "command": "uvx",
+                "args": ["medmcp-neuro"],
+                "env": [],
+                "skills_path": "/opt/neuro/skills",
+            },
+        ]
+        with patch("medmcp.app.VIBE_HOME", tmp_path):
+            _sync_servers_to_vibe_config(servers)
+
+        with (tmp_path / "config.toml").open("rb") as f:
+            result = tomllib.load(f)
+
+        assert result["skill_paths"] == ["/opt/neuro/skills"]
+
+    def test_skill_paths_cleared_when_stack_deactivated(self, tmp_path: Path) -> None:
+        """Deactivating all stacks removes stale skill_paths from config.toml."""
+        cfg_path = tmp_path / "config.toml"
+        cfg_path.write_text('skill_paths = ["/opt/neuro/skills"]\n')
+
+        with patch("medmcp.app.VIBE_HOME", tmp_path):
+            _sync_servers_to_vibe_config([])
+
+        with cfg_path.open("rb") as f:
+            result = tomllib.load(f)
+
+        assert result.get("skill_paths") == []
+
+    def test_skill_paths_updated_when_partial_deactivation(self, tmp_path: Path) -> None:
+        """skill_paths reflects only the active servers after partial deactivation."""
+        cfg_path = tmp_path / "config.toml"
+        cfg_path.write_text('skill_paths = ["/opt/neuro/skills", "/opt/cardiac/skills"]\n')
+        active: list[JsonDict] = [
+            {
+                "name": "medmcp-neuro",
+                "command": "uvx",
+                "args": ["medmcp-neuro"],
+                "env": [],
+                "skills_path": "/opt/neuro/skills",
+            },
+        ]
+
+        with patch("medmcp.app.VIBE_HOME", tmp_path):
+            _sync_servers_to_vibe_config(active)
+
+        with cfg_path.open("rb") as f:
+            result = tomllib.load(f)
+
+        assert result["skill_paths"] == ["/opt/neuro/skills"]

--- a/tests/test_load_mcp_servers.py
+++ b/tests/test_load_mcp_servers.py
@@ -85,8 +85,8 @@ class TestUvToolDiscovery:
         expected = str(tmp_path / "medmcp-test" / "bin" / "medmcp-test")
         assert servers[0]["command"] == expected
 
-    def test_env_defaults_to_empty_list(self, tmp_path: Path) -> None:
-        """Env field defaults to [] when not returned by the entry point."""
+    def test_env_defaults_to_empty_dict(self, tmp_path: Path) -> None:
+        """Env field defaults to {} when not returned by the entry point."""
         _make_tool_env(tmp_path, "medmcp-x")
         config = {"name": "medmcp-x", "command": "medmcp-x"}
 
@@ -97,7 +97,7 @@ class TestUvToolDiscovery:
         ):
             servers = _load_mcp_servers()
 
-        assert servers[0]["env"] == []
+        assert servers[0]["env"] == {}
 
     def test_broken_entry_point_is_skipped(self, tmp_path: Path) -> None:
         """An entry point whose callable raises is skipped; others still load."""

--- a/tests/test_permission_prompt.py
+++ b/tests/test_permission_prompt.py
@@ -259,7 +259,7 @@ class TestGenerateExplanation:
 
         call_kwargs: dict[str, Any] = instance.post.call_args[1]
         assert call_kwargs["json"]["model"] == OLLAMA_MODEL
-        assert call_kwargs["json"]["options"]["temperature"] == 1.0
+        assert call_kwargs["json"]["options"]["temperature"] == 0.2
         assert call_kwargs["json"]["think"] is False
         assert call_kwargs["json"]["stream"] is False
 


### PR DESCRIPTION
## Summary                                                                                                                             
                                                                                                                                         
Adds a real-time context usage indicator to the Chainlit footer: a progress bar and token count that updates live on every `usage_update` frame from vibe-acp via a pushed `ctx_update` Socket.IO event, with a 250 ms HTTP poll to `/api/context-usage` as fallback. Also removes dead token-estimation code that predated the `usage_update` event.                                              
                                                                                                                                         
## Test plan
- [ ] Send a multi-turn conversation — confirm the badge appears in the `.watermark` footer and token count climbs with each reply    
                                                                                                                   
## Security & data handling                                                                                                            
`/api/context-usage` and the `ctx_update` event expose only integer token counts — no session content or patient data. No new tool surface, file-write paths, or auto-approval paths introduced.

## Notes
The API route is inserted at index 0 of Chainlit's router because Starlette matches in registration order and the existing `/{full_path:path}` catch-all would otherwise shadow it. `_context_window_tokens` is cached for the process lifetime; restart the UI if the Ollama model changes.
