### PR TITLE
feat: provenance capture, distillable workflows, and deterministic replay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,4 +217,8 @@ __marimo__/
 .vibe/medmcp_threads.db
 .vibe/medmcp_threads.db-journal
 .vibe/active_stacks.json
+.vibe/active_workflows.json
+.vibe/provenance_enabled.json
+.vibe/provenance/
+.vibe/workflows/
 data/

--- a/.gitignore
+++ b/.gitignore
@@ -218,6 +218,7 @@ __marimo__/
 .vibe/medmcp_threads.db-journal
 .vibe/active_stacks.json
 .vibe/active_workflows.json
+.vibe/workflows_enabled.json
 .vibe/provenance_enabled.json
 .vibe/provenance/
 .vibe/workflows/

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ MedMCP runs entirely on-premise and is designed to meet the data governance and 
 - [Vision](#vision)
 - [Architecture](#architecture)
 - [Imaging Stacks](#imaging-stacks)
+- [Provenance & Reusable Workflows](#provenance--reusable-workflows)
 - [Security](#security)
 - [Contributing](#contributing)
 - [License](#license)
@@ -102,6 +103,20 @@ just install-stack "git+ssh://git@github.com/medmcp/medmcp-neuro.git"
 ```
 
 Once installed, the stack is auto-discovered via its `[medmcp.stacks]` entry point and appears as a toggle in the UI's **ChatSettings panel** — no manual edits to `.vibe/config.toml` needed. Toggle changes take effect on the next conversation. Restart the UI after installing or removing a stack.
+
+---
+
+## Provenance & Reusable Workflows
+
+Beyond running one-off analyses, MedMCP records what it does and lets you turn a successful session into a repeatable pipeline.
+
+- **Provenance** — every session is recorded to `.vibe/provenance/<session>/`: the environment (git commit, active stacks + versions, model), one normalized entry per tool call (resolved arguments, structured outputs, permission decision, duration), a mirror of the approval log, and a documentation-grade `report.md`. Recording is on by default and can be turned off per session with the **Record provenance** switch in settings. Deleting a chat in the UI removes its logs; you never need the CLI for cleanup.
+
+- **Save a workflow** — the **Save workflow** button in the message box distills the current chat into a reusable workflow. MedMCP keeps only the steps that mattered (dropping exploratory, failed, and rejected tool calls) and lifts concrete file paths into named inputs, producing a human-readable `SKILL.md` and a machine-readable `recipe.yaml`. Review, rename, refine, and **Promote** it to keep it as a permanent skill.
+
+- **Replay on new data (no LLM)** — the **Run** button replays a saved workflow deterministically: it asks for the new inputs (each labelled with what it is, e.g. *the input_path for `medmcp-neuro:skull_strip`*), shows you the exact steps it will run, and on confirmation calls the same tools in the same order — no model reasoning involved. Step outputs are fed forward automatically, and a failed step aborts the run.
+
+Personal workflows can be toggled on/off individually, or disabled entirely with the **Personal workflows** master switch in settings. The same operations are available from the `medmcp` CLI (`medmcp list`, `report`, `distill`, `promote`, …) and the matching `just` recipes for scripted use.
 
 ---
 

--- a/chainlit.md
+++ b/chainlit.md
@@ -1,2 +1,33 @@
-# MedMCP
-We wil add information on how to use this tool with a later PR.
+# Welcome to MedMCP
+
+MedMCP lets you run validated medical-imaging tools through plain language — no command line, no Python environments, no library APIs. Everything runs **locally**: your data never leaves this machine.
+
+> ⚠️ MedMCP is under active development and **not licensed for clinical use**.
+
+## Getting started
+
+1. **Just ask.** Describe what you want in natural language, e.g. *"Skull-strip the T1 in `data/patient01/t1.nii.gz` and register it to MNI."*
+2. **Approve each step.** Before any tool runs (file writes, conversions, processing), MedMCP shows you what it will do and waits for your **Approve / Reject**. Nothing happens without your click.
+3. **Follow along.** Each tool call is summarized with a plain-language explanation and the result.
+
+## Choosing your tools
+
+Open the **settings** (gear icon) to:
+
+- **Toggle imaging stacks** — enable only the domains you need (e.g. `medmcp-neuro`). Changes apply to your next message.
+- **Explain tool calls** — add a short plain-language explanation to each step.
+- **Record provenance** — keep a reproducible log of the session.
+
+## Saving & reusing workflows
+
+Found a sequence that works? Turn it into a repeatable pipeline:
+
+- **Save workflow** (button in the message box) — distills the current chat into a reusable workflow, keeping just the steps that mattered.
+- **Manage workflows** — review, rename, refine, or promote your saved workflows.
+- **Run** — replay a saved workflow on **new data**, deterministically and **without the LLM**. MedMCP asks for the new inputs (each labelled with what it is), shows you the exact steps, and runs them on your confirmation.
+
+## Your data stays yours
+
+Every session is recorded locally under `.vibe/provenance/` (toggle it off in settings if you prefer). Deleting a chat removes its logs. Web search is disabled and the app is reachable only from this machine.
+
+Happy analyzing! 🧠

--- a/justfile
+++ b/justfile
@@ -20,12 +20,21 @@ clean:
     rm -f .coverage
     rm -f coverage.*
 
-# Remove local chat/session state under .vibe/
+# Promoted workflows under .vibe/workflows/active/ are preserved; use
+# clean-workflows to remove those too.
+
+# Remove local chat/session state under .vibe/ (logs, DB, history, provenance, drafts)
 clean-chats:
     rm -rf .vibe/logs
     rm -f .vibe/medmcp_threads.db
     rm -f .vibe/trusted_folders.toml
     rm -rf .vibe/vibehistory
+    rm -rf .vibe/provenance
+    rm -rf .vibe/workflows/draft
+
+# Remove ALL distilled workflows, including promoted ones under active/
+clean-workflows:
+    rm -rf .vibe/workflows
 
 # Install uv (only if just is installed via package manager)
 @install-uv:
@@ -108,6 +117,34 @@ pull-model:
 # Launch mistral-vibe CLI (reads .vibe/config.toml)
 vibe *ARGS:
     uv run vibe {{ARGS}}
+
+# List sessions that have a provenance record
+provenance-list:
+    uv run medmcp list
+
+# Render the human-readable provenance report for a session
+# Usage: just report <session-id>
+report SESSION:
+    uv run medmcp report {{SESSION}}
+
+# Distill a reusable workflow (recipe.yaml + SKILL.md) from a session's raw log
+# Usage: just distill <session-id>   (add --no-llm to skip the narrative pass)
+distill SESSION *ARGS:
+    uv run medmcp distill {{SESSION}} {{ARGS}}
+
+# Promote a reviewed draft workflow into active/ so it loads as a skill
+# Usage: just promote <workflow-name>
+promote NAME:
+    uv run medmcp promote {{NAME}}
+
+# List personal workflows (draft + promoted)
+workflows:
+    uv run medmcp workflows
+
+# Delete a personal workflow (draft or active) by name
+# Usage: just delete-workflow <workflow-name>
+delete-workflow NAME:
+    uv run medmcp delete {{NAME}}
 
 # Launch the Chainlit web UI
 ui:

--- a/public/custom.js
+++ b/public/custom.js
@@ -274,6 +274,58 @@
   }
 })();
 
+// ── One-click "Save workflow" command ─────────────────────────────────
+// Native Chainlit commands fire only when a message is *sent* — clicking the
+// composer command button merely selects the command (onCommandSelect). So the
+// "Save workflow" button normally needs a follow-up Enter. When the user clicks
+// it we submit the composer ourselves so it acts as a single click.
+//
+// Each button is identified by its stable DOM id. Chainlit renders every command
+// button with id `command-<command id>`, so ours are `command-save-workflow` and
+// `command-manage-workflows` (must match the command ids in app.py). After the
+// click registers the selection, we send the same way a manual Enter does: the
+// composer's send handler fires on a plain `Enter` keydown (it checks only key +
+// shiftKey), and React 18 delegates events at the document root, so a bubbling
+// synthetic keydown reaches it even with an empty input.
+(function () {
+  "use strict";
+
+  const ONE_CLICK_COMMAND_IDS = ["command-save-workflow", "command-manage-workflows"];
+  const SELECTOR = ONE_CLICK_COMMAND_IDS.map((id) => '[id="' + id + '"]').join(",");
+  let busy = false;
+
+  function submitComposer() {
+    const input = document.getElementById("chat-input");
+    if (!input) return;
+    input.focus();
+    const submit = document.getElementById("chat-submit");
+    if (submit && !submit.disabled) {
+      submit.click();
+      return;
+    }
+    const opts = { key: "Enter", code: "Enter", bubbles: true, cancelable: true };
+    input.dispatchEvent(new KeyboardEvent("keydown", opts));
+    input.dispatchEvent(new KeyboardEvent("keyup", opts));
+  }
+
+  document.addEventListener(
+    "click",
+    function (e) {
+      if (busy) return;
+      const el = e.target;
+      if (!(el instanceof Element)) return;
+      if (!el.closest(SELECTOR)) return;
+      busy = true;
+      // Let React register the command selection before we submit.
+      setTimeout(function () {
+        busy = false;
+        submitComposer();
+      }, 200);
+    },
+    true
+  );
+})();
+
 // ── Make the extensions info textarea read-only ───────────────────────
 // The TextInput widget has no readonly prop, so we set the attribute via JS.
 (function () {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,10 +32,12 @@ dependencies = [
     "sqlalchemy[asyncio]>=2.0.49,<3",
     "aiosqlite>=0.20",
     "tomli-w>=1.0",
+    "pyyaml>=6.0",
 ]
 
 [project.scripts]
 medmcp-ui = "medmcp.cli:main"
+medmcp = "medmcp.provcli:main"
 
 [dependency-groups]
 test = [
@@ -45,7 +47,8 @@ test = [
 quality = [
     "ruff>=0.15.11",
     "pyright>=1.1.400",
-    "pre-commit>=4.6.0"
+    "pre-commit>=4.6.0",
+    "types-pyyaml>=6.0"
 ]
 dev = [
     { include-group = "test" },

--- a/src/medmcp/app.py
+++ b/src/medmcp/app.py
@@ -74,7 +74,8 @@ from chainlit.user import User
 from chainlit.utils import utc_now as _utc_now
 from fastapi.routing import APIRoute
 
-from medmcp import distill, provenance
+from medmcp import distill, provenance, replay
+from medmcp.workflow import Recipe
 
 # A loose alias for parsed JSON-RPC payloads. The ACP protocol is too dynamic
 # to model exhaustively as TypedDicts, so we keep the wire format as
@@ -122,6 +123,8 @@ DISCARD_WORKFLOW_ACTION: str = "discard_workflow"
 TEST_WORKFLOW_ACTION: str = "test_workflow"
 DELETE_WORKFLOW_ACTION: str = "delete_workflow"
 EDIT_WORKFLOW_ACTION: str = "edit_workflow"
+RUN_WORKFLOW_ACTION: str = "run_workflow"
+CONFIRM_REPLAY_ACTION: str = "confirm_replay"
 
 
 _stack_log: logging.Logger = logging.getLogger(__name__)
@@ -2411,11 +2414,18 @@ async def _handle_save_workflow_command() -> None:
 def _manage_actions(name: str) -> list[cl.Action]:
     """Build the per-workflow buttons for the Manage list.
 
-    Every workflow offers Edit and Delete. Edit opens the full editable preview
-    (Test / Promote / Rename / Refine / Discard); for a promoted workflow it first
+    Every workflow offers Run, Edit and Delete. Run replays the workflow
+    deterministically on new inputs (no LLM); Edit opens the full editable preview
+    (Test / Promote / Rename / Refine / Discard); for a promoted workflow Edit first
     unpromotes it back to a draft. Activate/deactivate stays in the settings gear.
     """
     return [
+        cl.Action(
+            name=RUN_WORKFLOW_ACTION,
+            payload={"name": name},
+            label="Run",
+            tooltip="Replay this workflow on new inputs — runs the exact tools, no LLM",
+        ),
         cl.Action(
             name=EDIT_WORKFLOW_ACTION,
             payload={"name": name},
@@ -2456,6 +2466,161 @@ async def _handle_manage_workflows_command() -> None:
             content=f"**`{name}`** · {status}\n\n{description}",
             actions=_manage_actions(name),
         ).send()
+
+
+# ── Deterministic replay (Run) ────────────────────────────────────────────────
+
+
+def _workflow_dir(name: str) -> Path | None:
+    """Return the on-disk dir for workflow *name* (active wins over draft), or None."""
+    for kind in ("active", "draft"):
+        d = VIBE_HOME / "workflows" / kind / name
+        if (d / "recipe.yaml").exists():
+            return d
+    return None
+
+
+def _input_prompt(name: str, example: str, description: str) -> str:
+    """Build the message asking the user for one replay input value."""
+    desc = f" — {description}" if description else ""
+    return f"**`{name}`**{desc}\n(e.g. `{example}`)"
+
+
+def _format_replay_preview(recipe: Recipe, inputs: dict[str, str]) -> str:
+    """Render the resolved steps a replay will run, for the confirm prompt."""
+    lines: list[str] = [f"**Replay `{recipe.name}`** will run these steps, no LLM:\n"]
+    if recipe.inputs:
+        lines.append("**Inputs**")
+        for wf_input in recipe.inputs:
+            desc = f" — {wf_input.description}" if wf_input.description else ""
+            lines.append(f"- `{wf_input.name}`{desc} = `{inputs.get(wf_input.name, '?')}`")
+        lines.append("")
+    lines.append(f"**Steps ({len(recipe.steps)})**")
+    bindings: dict[str, Any] = dict(inputs)
+    for i, step in enumerate(recipe.steps, start=1):
+        # Inputs are known now; cross-step refs ({{stepM.*}}) resolve at runtime,
+        # so they intentionally still show as placeholders here.
+        args = replay.resolve_arguments(step.arguments, bindings)
+        rendered = json.dumps(args, default=str)
+        lines.append(f"{i}. `{step.server}:{step.tool}` — `{rendered}`")
+    return "\n".join(lines)
+
+
+async def _send_replay_preview(recipe: Recipe, inputs: dict[str, str]) -> None:
+    """Show the resolved steps and a Run-now button carrying the bound inputs."""
+    await cl.Message(
+        content=_format_replay_preview(recipe, inputs),
+        actions=[
+            cl.Action(
+                name=CONFIRM_REPLAY_ACTION,
+                payload={"name": recipe.name, "inputs": inputs},
+                label="Run now",
+                tooltip="Execute the steps above on the inputs shown",
+            )
+        ],
+    ).send()
+
+
+async def _run_replay_and_report(name: str, inputs: dict[str, str]) -> None:
+    """Execute a workflow replay, streaming per-step status, then report the outcome."""
+    draft_dir = _workflow_dir(name)
+    if draft_dir is None:
+        await cl.Message(content=f"Could not find a recipe for `{name}`.").send()
+        return
+    recipe = await asyncio.to_thread(distill.load_recipe, draft_dir)
+    servers = _active_servers()
+
+    progress = cl.Message(content=f"▶️ Replaying **`{name}`**…")
+    await progress.send()
+    log_lines: list[str] = []
+
+    async def _on_step(step_result: replay.StepResult) -> None:
+        icon = "✅" if step_result.ok else "❌"
+        line = f"{icon} {step_result.index}. `{step_result.server}:{step_result.tool}`"
+        if step_result.produced:
+            produced = ", ".join(f"`{v}`" for v in step_result.produced.values())
+            line += f" → {produced}"
+        if not step_result.ok and step_result.error:
+            line += f"\n   ↳ {step_result.error}"
+        log_lines.append(line)
+        progress.content = f"▶️ Replaying **`{name}`**…\n\n" + "\n".join(log_lines)
+        await progress.update()
+
+    result = await replay.run(recipe, inputs, servers=servers, cwd=PROJECT_ROOT, on_step=_on_step)
+
+    if result.ok:
+        outputs: list[str] = []
+        for step_result in result.steps:
+            outputs.extend(step_result.produced.values())
+        summary = f"✅ **Replay of `{name}` complete** — {len(result.steps)} step(s) ran."
+        if outputs:
+            summary += "\n\n**Outputs**\n" + "\n".join(f"- `{o}`" for o in outputs)
+    else:
+        summary = f"❌ **Replay of `{name}` failed.** {result.error or ''}".rstrip()
+    progress.content = f"Replayed **`{name}`**\n\n" + "\n".join(log_lines)
+    await progress.update()
+    await cl.Message(content=summary).send()
+
+
+@cl.action_callback(RUN_WORKFLOW_ACTION)  # pyright: ignore[reportUntypedFunctionDecorator, reportUnknownMemberType]
+async def _on_run_workflow(action: cl.Action) -> None:  # pyright: ignore[reportUnusedFunction]
+    """Start a deterministic replay: collect new inputs, then preview and confirm."""
+    name = _action_name(action)
+    if name is None:
+        await cl.Message(content="Could not determine which workflow to run.").send()
+        return
+    draft_dir = _workflow_dir(name)
+    if draft_dir is None:
+        await cl.Message(content=f"Could not find a recipe for `{name}`.").send()
+        return
+    recipe = await asyncio.to_thread(distill.load_recipe, draft_dir)
+
+    # Surface non-input problems (built-in steps, uninstalled stacks) up front by
+    # validating with the recorded examples standing in for the inputs.
+    examples = {i.name: i.example for i in recipe.inputs}
+    structural = replay.validate(recipe, examples, _active_servers())
+    if structural is not None:
+        await cl.Message(content=f"Can't replay `{name}`: {structural}").send()
+        return
+
+    if not recipe.inputs:
+        await _send_replay_preview(recipe, {})
+        return
+
+    # Collect each input as a normal message (same pattern as Rename/Refine).
+    descriptions = {i.name: i.description for i in recipe.inputs}
+    cl.user_session.set(  # pyright: ignore[reportUnknownMemberType]
+        "pending_workflow",
+        {
+            "action": "run",
+            "name": name,
+            "input_names": [i.name for i in recipe.inputs],
+            "examples": examples,
+            "descriptions": descriptions,
+            "collected": {},
+        },
+    )
+    first = recipe.inputs[0]
+    await cl.Message(
+        content=(
+            f"Replaying **`{name}`** on new data. Provide a value for each input "
+            f"(send `-` at any point to cancel).\n\n"
+            + _input_prompt(first.name, first.example, first.description)
+        )
+    ).send()
+
+
+@cl.action_callback(CONFIRM_REPLAY_ACTION)  # pyright: ignore[reportUntypedFunctionDecorator, reportUnknownMemberType]
+async def _on_confirm_replay(action: cl.Action) -> None:  # pyright: ignore[reportUnusedFunction]
+    """Execute a previewed replay when the user clicks Run now."""
+    payload = cast("dict[str, Any]", action.payload or {})  # pyright: ignore[reportUnknownMemberType]
+    name = payload.get("name")
+    raw_inputs: object = payload.get("inputs") or {}
+    if not isinstance(name, str) or not isinstance(raw_inputs, dict):
+        await cl.Message(content="Could not start the replay (missing parameters).").send()
+        return
+    inputs = {str(k): str(v) for k, v in cast("JsonDict", raw_inputs).items()}
+    await _run_replay_and_report(name, inputs)
 
 
 @cl.action_callback(TEST_WORKFLOW_ACTION)  # pyright: ignore[reportUntypedFunctionDecorator, reportUnknownMemberType]
@@ -2641,6 +2806,38 @@ async def _consume_pending_workflow_input(text: str) -> bool:
     value = text.strip()
     if value in ("", "-"):
         await cl.Message(content=f"{action.capitalize()} cancelled — `{name}` is unchanged.").send()
+        return True
+
+    if action == "run":
+        input_names = [str(n) for n in cast("list[Any]", pending.get("input_names") or [])]
+        examples = cast("JsonDict", pending.get("examples") or {})
+        descriptions = cast("JsonDict", pending.get("descriptions") or {})
+        collected = {
+            str(k): str(v) for k, v in cast("JsonDict", pending.get("collected") or {}).items()
+        }
+        # Record this answer for the next unfilled input.
+        remaining = [n for n in input_names if n not in collected]
+        if remaining:
+            collected[remaining[0]] = value
+        still = [n for n in input_names if n not in collected]
+        if still:
+            # More inputs to gather — re-arm and prompt for the next one.
+            cl.user_session.set(  # pyright: ignore[reportUnknownMemberType]
+                "pending_workflow", {**pending, "collected": collected}
+            )
+            nxt = still[0]
+            await cl.Message(
+                content=_input_prompt(
+                    nxt, str(examples.get(nxt, "")), str(descriptions.get(nxt, ""))
+                )
+            ).send()
+            return True
+        draft_dir = _workflow_dir(name)
+        if draft_dir is None:
+            await cl.Message(content=f"Could not find a recipe for `{name}`.").send()
+            return True
+        recipe = await asyncio.to_thread(distill.load_recipe, draft_dir)
+        await _send_replay_preview(recipe, collected)
         return True
 
     if action == "refine":

--- a/src/medmcp/app.py
+++ b/src/medmcp/app.py
@@ -104,6 +104,8 @@ _ACTIVE_STACKS_PATH: Path = VIBE_HOME / "active_stacks.json"
 _ACTIVE_WORKFLOWS_PATH: Path = VIBE_HOME / "active_workflows.json"
 # Persists the provenance-capture on/off preference; defaults to on when absent.
 _PROVENANCE_ENABLED_PATH: Path = VIBE_HOME / "provenance_enabled.json"
+# Master on/off for the personal-workflows feature; defaults to on when absent.
+_WORKFLOWS_ENABLED_PATH: Path = VIBE_HOME / "workflows_enabled.json"
 
 # Single fixed user identity used by the data layer. There is no auth: this
 # exists only so chainlit's per-user thread scoping has a stable key.
@@ -378,6 +380,30 @@ def _save_provenance_enabled(enabled: bool) -> None:
     os.replace(tmp, _PROVENANCE_ENABLED_PATH)
 
 
+def _load_workflows_enabled() -> bool:
+    """Return whether the personal-workflows feature is enabled (default ``True``).
+
+    The master switch: when off, the Save/Manage composer buttons are hidden and
+    no personal workflow is loaded as a skill (see ``_workflow_commands`` and
+    ``_sync_servers_to_vibe_config``).
+    """
+    if not _WORKFLOWS_ENABLED_PATH.exists():
+        return True
+    try:
+        data = cast("dict[str, Any]", json.loads(_WORKFLOWS_ENABLED_PATH.read_text()))
+        return bool(data.get("enabled", True))
+    except (json.JSONDecodeError, OSError):
+        return True
+
+
+def _save_workflows_enabled(enabled: bool) -> None:
+    """Persist the personal-workflows master on/off preference to disk."""
+    _WORKFLOWS_ENABLED_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tmp = _WORKFLOWS_ENABLED_PATH.with_suffix(".tmp")
+    tmp.write_text(json.dumps({"enabled": enabled}))
+    os.replace(tmp, _WORKFLOWS_ENABLED_PATH)
+
+
 def _active_servers() -> list[JsonDict]:
     """Return only the active subset of all discovered servers."""
     active_names = _load_active_server_names()
@@ -457,24 +483,32 @@ def _sync_servers_to_vibe_config(servers: list[JsonDict]) -> None:
     # Collect skills_path values from discovered servers and write them to
     # skill_paths so vibe-acp loads the bundled skill docs automatically.
     skill_paths = [srv["skills_path"] for srv in servers if srv.get("skills_path")]
-    # Promoted, reusable workflows live here as <name>/SKILL.md; include the
-    # directory so distilled workflows are discoverable as skills (Tier 3).
-    workflows_active = VIBE_HOME / "workflows" / "active"
-    if workflows_active.is_dir():
-        skill_paths.append(str(workflows_active))
-    # Draft workflows are loaded too, so a draft can be tested (invoked as
-    # `/<name>`) before it is promoted. Promotion just moves the draft into
-    # active/ to keep it permanently; both dirs hold <name>/SKILL.md entries.
-    workflows_draft = VIBE_HOME / "workflows" / "draft"
-    if workflows_draft.is_dir():
-        skill_paths.append(str(workflows_draft))
+    # The personal-workflows feature can be turned off entirely by the master
+    # toggle; when off, no workflow dir is added to skill_paths and every workflow
+    # is listed in disabled_skills, so nothing personal is loaded.
+    workflows_enabled = _load_workflows_enabled()
+    if workflows_enabled:
+        # Promoted, reusable workflows live here as <name>/SKILL.md; include the
+        # directory so distilled workflows are discoverable as skills (Tier 3).
+        workflows_active = VIBE_HOME / "workflows" / "active"
+        if workflows_active.is_dir():
+            skill_paths.append(str(workflows_active))
+        # Draft workflows are loaded too, so a draft can be tested (invoked as
+        # `/<name>`) before it is promoted. Promotion just moves the draft into
+        # active/ to keep it permanently; both dirs hold <name>/SKILL.md entries.
+        workflows_draft = VIBE_HOME / "workflows" / "draft"
+        if workflows_draft.is_dir():
+            skill_paths.append(str(workflows_draft))
     cfg["skill_paths"] = skill_paths
 
     # Personal workflows toggled off in the gear are disabled by name so vibe-acp
-    # skips loading them, without removing them from disk. Non-workflow entries in
-    # disabled_skills (if any were set manually) are preserved.
+    # skips loading them, without removing them from disk. With the master toggle
+    # off, all of them are disabled. Non-workflow entries in disabled_skills (if
+    # any were set manually) are preserved.
     all_workflows = {w["name"] for w in _discover_workflows()}
-    deactivated = all_workflows - _load_active_workflow_names()
+    deactivated = (
+        all_workflows if not workflows_enabled else (all_workflows - _load_active_workflow_names())
+    )
     existing_disabled = cast("list[str]", cfg.get("disabled_skills", []))
     preserved = [s for s in existing_disabled if s not in all_workflows]
     cfg["disabled_skills"] = sorted(set(preserved) | deactivated)
@@ -509,6 +543,15 @@ def _build_chat_settings_inputs() -> list[Any]:
                     "permission decisions, and a summary report."
                 ),
             ),
+            cl.input_widget.Switch(
+                id="workflows_enabled",
+                label="Personal workflows",
+                initial=_load_workflows_enabled(),
+                description=(
+                    "Turn the personal-workflows feature on or off. When off, the Save/Manage "
+                    "workflow buttons are hidden and no saved workflow is loaded as a skill."
+                ),
+            ),
         ],
     )
 
@@ -533,7 +576,9 @@ def _build_chat_settings_inputs() -> list[Any]:
 
     tabs: list[Any] = [general_tab, stacks_tab]
 
-    workflows = _discover_workflows()
+    # The per-workflow switches only matter while the feature is on; when the
+    # master toggle is off they would be inert, so hide the whole tab.
+    workflows = _discover_workflows() if _load_workflows_enabled() else []
     if workflows:
         active_workflows = _load_active_workflow_names()
         workflow_inputs: list[cl.input_widget.InputWidget] = [
@@ -559,7 +604,13 @@ def _workflow_commands() -> list[CommandDict]:
     Rendered as buttons in the message box; clicking one and sending sets
     ``message.command`` so ``on_message`` can act on it (distill the chat, or
     list workflows) instead of forwarding the text to the agent.
+
+    Returns an empty list when the personal-workflows feature is toggled off, so
+    the buttons disappear from the composer.
     """
+    if not _load_workflows_enabled():
+        return []
+
     save: CommandDict = {
         "id": SAVE_WORKFLOW_COMMAND,
         "icon": "save",
@@ -930,6 +981,9 @@ _client: VibeAcpClient = VibeAcpClient()
 # the process is replaced at the next on_chat_start.
 _vibe_restart_needed: bool = False
 
+# Guards the one-shot orphaned-provenance GC (see _gc_orphaned_provenance).
+_provenance_gc_done: bool = False
+
 # Pre-warm MCP server discovery so on_chat_start doesn't block on the first
 # browser connection. lru_cache is effectively thread-safe in CPython; if the
 # thread hasn't finished by the time on_chat_start fires it simply re-runs.
@@ -1138,10 +1192,74 @@ class _MedMcpDataLayer(SQLAlchemyDataLayer):
             _audit.info("deleted thread %s and purged session logs %s", thread_id, session_id)
 
 
+def _referenced_vibe_session_ids() -> set[str] | None:
+    """Collect every vibe_session_id referenced by a persisted thread.
+
+    Returns ``None`` — meaning "could not determine the full reference set" — if
+    the threads DB is missing, the query fails, or any row's metadata can't be
+    parsed. Callers MUST treat ``None`` as "do not delete anything": an empty or
+    partial set would otherwise make the GC wipe logs for chats that still exist.
+    A successfully read DB with zero matching rows correctly returns an empty set.
+    """
+    if not THREADS_DB_PATH.exists():
+        return None
+    try:
+        con = sqlite3.connect(THREADS_DB_PATH)
+        try:
+            rows = con.execute("SELECT metadata FROM threads").fetchall()
+        finally:
+            con.close()
+    except Exception:
+        return None
+    ids: set[str] = set()
+    for (raw,) in rows:
+        if not raw:
+            # No metadata → this thread has no provenance to reference; safe.
+            continue
+        try:
+            meta: object = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            # Can't tell what this thread references → bail rather than risk
+            # deleting its logs.
+            return None
+        if not isinstance(meta, dict):
+            return None
+        sid = cast("dict[str, Any]", meta).get("vibe_session_id")
+        if isinstance(sid, str):
+            ids.add(sid)
+    return ids
+
+
+def _gc_orphaned_provenance() -> None:
+    """Once per process, purge provenance records no thread references anymore.
+
+    Belt-and-suspenders to the on-delete purge: cleans up records left behind by
+    older builds, crashes, or any path that created provenance without persisting
+    a thread mapping, so users never have to fall back to the CLI / just recipes.
+
+    Fail-safe: if the referenced set can't be determined with certainty
+    (:func:`_referenced_vibe_session_ids` returns ``None``) the GC is skipped, so
+    a transient read error can never delete logs for chats that still exist.
+    """
+    global _provenance_gc_done
+    if _provenance_gc_done:
+        return
+    _provenance_gc_done = True
+    referenced = _referenced_vibe_session_ids()
+    if referenced is None:
+        _audit.info("gc: skipped — could not determine referenced sessions")
+        return
+    with contextlib.suppress(Exception):
+        purged = provenance.purge_orphans(referenced)
+        if purged:
+            _audit.info("gc: purged %d orphaned provenance record(s): %s", len(purged), purged)
+
+
 @cl.data_layer  # pyright: ignore[reportUnknownMemberType]
 def get_data_layer() -> SQLAlchemyDataLayer:
     """Wire chainlit to a local sqlite database for thread persistence."""
     _bootstrap_threads_db(THREADS_DB_PATH)
+    _gc_orphaned_provenance()
     return _MedMcpDataLayer(
         conninfo=f"sqlite+aiosqlite:///{THREADS_DB_PATH}",
         storage_provider=_NullStorageClient(),
@@ -1506,6 +1624,9 @@ async def on_settings_update(settings: dict[str, Any]) -> None:
     - ``stack_<name>`` — updates the persistent active-stack set in
       ``.vibe/active_stacks.json``; the new set takes effect on the next
       conversation (vibe-acp reads config.toml at session-creation time).
+    - ``workflows_enabled`` — master on/off for personal workflows, persisted to
+      ``.vibe/workflows_enabled.json``. Hides/shows the composer buttons
+      immediately and toggles workflow skill loading on the next session.
     - ``workflow_<name>`` — updates the active-workflow set in
       ``.vibe/active_workflows.json``; deactivated workflows are written to
       ``disabled_skills`` on the next session so vibe-acp skips loading them.
@@ -1535,7 +1656,19 @@ async def on_settings_update(settings: dict[str, Any]) -> None:
                 sorted(active_names),
             )
 
-    workflows = _discover_workflows()
+    wf_enabled = bool(settings.get("workflows_enabled", True))
+    if wf_enabled != _load_workflows_enabled():
+        _save_workflows_enabled(wf_enabled)
+        _vibe_restart_needed = True
+        # Show/hide the Save/Manage composer buttons immediately for this chat.
+        with contextlib.suppress(Exception):
+            await cl.context.emitter.set_commands(_workflow_commands())  # pyright: ignore[reportUnknownMemberType]
+        _audit.info("personal workflows %s via settings", "enabled" if wf_enabled else "disabled")
+
+    # Per-workflow switches only exist while the feature is on; when off the
+    # Workflows tab is hidden, so skip this to preserve the saved active set
+    # instead of resetting it from absent settings keys.
+    workflows = _discover_workflows() if wf_enabled else []
     if workflows:
         active_workflows: set[str] = {
             wf["name"] for wf in workflows if bool(settings.get(f"workflow_{wf['name']}", True))
@@ -1612,10 +1745,11 @@ async def _create_new_session(reload_session_id: str | None = None) -> bool:
         return False
     _set_session_id(session_id)
     _client.register_session(session_id)
-    # Capture the environment manifest (Tier-1 provenance) for this session.
-    if _is_provenance_enabled():
-        with contextlib.suppress(Exception):
-            provenance.write_manifest(session_id, servers=active, model_name=OLLAMA_MODEL)
+    # The Tier-1 provenance manifest is intentionally NOT written here. session/new
+    # runs eagerly on every page load (to warm MCP servers), but the thread→session
+    # mapping that lets the UI purge provenance on delete is only saved on the first
+    # message. Writing the manifest here would leak un-purgeable records for chats
+    # that are opened but never used; it is written in on_message instead.
     return True
 
 
@@ -1772,20 +1906,39 @@ async def on_message(message: cl.Message) -> None:
             await cl.Message(content="Internal error: session was not initialized.").send()
             return
 
-    # Persist the chainlit-thread → vibe-session mapping on the first message
-    # of this chat. Done lazily so refreshes that never produce a conversation
-    # don't leave empty threads in the sidebar. Idempotent: gated by a flag.
+    # Persist the chainlit-thread → vibe-session mapping on the first message of
+    # this chat. Done lazily so refreshes that never produce a conversation don't
+    # leave empty threads in the sidebar. This mapping is what lets the UI find
+    # and purge the session's logs on delete, so the "persisted" flag is only set
+    # once the mapping is actually written — otherwise a chat whose thread_id was
+    # not ready yet (or whose write failed) would lose its logs forever. We retry
+    # on the next message until it sticks.
     if not cl.user_session.get("vibe_session_persisted"):  # pyright: ignore[reportUnknownMemberType]
         thread_id = cl_context.session.thread_id
         data_layer = cast("Any", cl_get_data_layer())
+        mapping_saved = False
         if thread_id and data_layer is not None:
-            with contextlib.suppress(Exception):
+            try:
                 await data_layer.update_thread(
                     thread_id=thread_id,
                     user_id=_persisted_user_id(),
                     metadata={"vibe_session_id": session_id},
                 )
-        cl.user_session.set("vibe_session_persisted", True)  # pyright: ignore[reportUnknownMemberType]
+                mapping_saved = True
+            except Exception:
+                _audit.warning(
+                    "could not persist thread→session mapping for %s; will retry", session_id
+                )
+        if mapping_saved:
+            # Write the Tier-1 provenance manifest only now that the mapping
+            # exists, so provenance is never created for a session the UI can't
+            # later find and purge on delete.
+            if _is_provenance_enabled():
+                with contextlib.suppress(Exception):
+                    provenance.write_manifest(
+                        session_id, servers=_active_servers(), model_name=OLLAMA_MODEL
+                    )
+            cl.user_session.set("vibe_session_persisted", True)  # pyright: ignore[reportUnknownMemberType]
 
     queue = _client.get_session_queue(session_id)
     if queue is None:
@@ -2525,6 +2678,15 @@ async def on_chat_end() -> None:
     session_id = _get_session_id()
     if session_id is not None:
         _client.unregister_session(session_id)
+        # A session that was eagerly created (to warm MCP servers) but never
+        # received a message has no thread mapping, so it can never be deleted
+        # from the UI. Purge its on-disk logs here so abandoned chats — page
+        # refreshes, opened-and-closed tabs — don't leak transcripts/provenance.
+        if not cl.user_session.get("vibe_session_persisted"):  # pyright: ignore[reportUnknownMemberType]
+            with contextlib.suppress(Exception):
+                provenance.purge_session(session_id)
+            _audit.info("purged logs for abandoned (unsent) session %s", session_id)
+            return
         # Render the human-readable provenance report for this session.
         if _is_provenance_enabled():
             with contextlib.suppress(Exception):

--- a/src/medmcp/app.py
+++ b/src/medmcp/app.py
@@ -54,6 +54,7 @@ import sqlite3
 import subprocess
 import sys
 import threading
+import time
 import tomllib
 from collections.abc import Awaitable, Callable
 from functools import lru_cache
@@ -68,10 +69,12 @@ from chainlit.data import get_data_layer as cl_get_data_layer
 from chainlit.data.sql_alchemy import SQLAlchemyDataLayer
 from chainlit.data.storage_clients.base import BaseStorageClient
 from chainlit.server import app as _chainlit_app
-from chainlit.types import ThreadDict
+from chainlit.types import CommandDict, ThreadDict
 from chainlit.user import User
 from chainlit.utils import utc_now as _utc_now
 from fastapi.routing import APIRoute
+
+from medmcp import distill, provenance
 
 # A loose alias for parsed JSON-RPC payloads. The ACP protocol is too dynamic
 # to model exhaustively as TypedDicts, so we keep the wire format as
@@ -97,10 +100,26 @@ VIBE_HOME: Path = Path(PROJECT_ROOT) / ".vibe"
 THREADS_DB_PATH: Path = VIBE_HOME / "medmcp_threads.db"
 # Tracks which discovered stacks are enabled; defaults to all when absent.
 _ACTIVE_STACKS_PATH: Path = VIBE_HOME / "active_stacks.json"
+# Tracks which personal workflows are enabled (loaded as skills); all when absent.
+_ACTIVE_WORKFLOWS_PATH: Path = VIBE_HOME / "active_workflows.json"
+# Persists the provenance-capture on/off preference; defaults to on when absent.
+_PROVENANCE_ENABLED_PATH: Path = VIBE_HOME / "provenance_enabled.json"
 
 # Single fixed user identity used by the data layer. There is no auth: this
 # exists only so chainlit's per-user thread scoping has a stable key.
 LOCAL_USER_ID: str = "local"
+
+# Composer command id (a button in the message box) and the review action names
+# for the in-chat workflow-distillation flow. See _handle_save_workflow_command.
+SAVE_WORKFLOW_COMMAND: str = "save-workflow"
+MANAGE_WORKFLOWS_COMMAND: str = "manage-workflows"
+PROMOTE_WORKFLOW_ACTION: str = "promote_workflow"
+REFINE_WORKFLOW_ACTION: str = "refine_workflow"
+RENAME_WORKFLOW_ACTION: str = "rename_workflow"
+DISCARD_WORKFLOW_ACTION: str = "discard_workflow"
+TEST_WORKFLOW_ACTION: str = "test_workflow"
+DELETE_WORKFLOW_ACTION: str = "delete_workflow"
+EDIT_WORKFLOW_ACTION: str = "edit_workflow"
 
 
 _stack_log: logging.Logger = logging.getLogger(__name__)
@@ -280,6 +299,85 @@ def _save_active_server_names(names: set[str]) -> None:
     os.replace(tmp, _ACTIVE_STACKS_PATH)
 
 
+def _read_skill_description(skill_md: Path) -> str:
+    """Return the ``description:`` frontmatter value from a SKILL.md, or ``''``."""
+    try:
+        lines = skill_md.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return ""
+    for line in lines[:15]:
+        if line.startswith("description:"):
+            return line.split(":", 1)[1].strip()
+    return ""
+
+
+def _discover_workflows() -> list[JsonDict]:
+    """Discover personal workflows from ``draft/`` and ``active/``.
+
+    Returns ``{name, description, kind}`` dicts, deduplicated by name (an active
+    workflow shadows a draft of the same name). ``kind`` is ``"active"`` for
+    promoted workflows and ``"draft"`` for unpromoted ones.
+    """
+    found: dict[str, JsonDict] = {}
+    for kind in ("active", "draft"):
+        base = VIBE_HOME / "workflows" / kind
+        if not base.is_dir():
+            continue
+        for d in sorted(base.iterdir()):
+            skill = d / "SKILL.md"
+            if not d.is_dir() or not skill.is_file() or d.name in found:
+                continue
+            found[d.name] = {
+                "name": d.name,
+                "description": _read_skill_description(skill),
+                "kind": kind,
+            }
+    return list(found.values())
+
+
+def _load_active_workflow_names() -> set[str]:
+    """Return the set of workflow names currently enabled (loaded as skills).
+
+    When ``.vibe/active_workflows.json`` is absent every discovered workflow is
+    active, so a freshly distilled/promoted workflow is on by default.
+    """
+    all_names = {w["name"] for w in _discover_workflows()}
+    if not _ACTIVE_WORKFLOWS_PATH.exists():
+        return all_names
+    try:
+        data = cast("dict[str, Any]", json.loads(_ACTIVE_WORKFLOWS_PATH.read_text()))
+        return set(cast("list[str]", data.get("active", list(all_names))))
+    except (json.JSONDecodeError, OSError):
+        return all_names
+
+
+def _save_active_workflow_names(names: set[str]) -> None:
+    """Persist the active workflow set to ``.vibe/active_workflows.json``."""
+    _ACTIVE_WORKFLOWS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tmp = _ACTIVE_WORKFLOWS_PATH.with_suffix(".tmp")
+    tmp.write_text(json.dumps({"active": sorted(names)}))
+    os.replace(tmp, _ACTIVE_WORKFLOWS_PATH)
+
+
+def _load_provenance_enabled() -> bool:
+    """Return whether provenance capture is enabled (default ``True`` when unset)."""
+    if not _PROVENANCE_ENABLED_PATH.exists():
+        return True
+    try:
+        data = cast("dict[str, Any]", json.loads(_PROVENANCE_ENABLED_PATH.read_text()))
+        return bool(data.get("enabled", True))
+    except (json.JSONDecodeError, OSError):
+        return True
+
+
+def _save_provenance_enabled(enabled: bool) -> None:
+    """Persist the provenance-capture on/off preference to disk."""
+    _PROVENANCE_ENABLED_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tmp = _PROVENANCE_ENABLED_PATH.with_suffix(".tmp")
+    tmp.write_text(json.dumps({"enabled": enabled}))
+    os.replace(tmp, _PROVENANCE_ENABLED_PATH)
+
+
 def _active_servers() -> list[JsonDict]:
     """Return only the active subset of all discovered servers."""
     active_names = _load_active_server_names()
@@ -359,7 +457,27 @@ def _sync_servers_to_vibe_config(servers: list[JsonDict]) -> None:
     # Collect skills_path values from discovered servers and write them to
     # skill_paths so vibe-acp loads the bundled skill docs automatically.
     skill_paths = [srv["skills_path"] for srv in servers if srv.get("skills_path")]
+    # Promoted, reusable workflows live here as <name>/SKILL.md; include the
+    # directory so distilled workflows are discoverable as skills (Tier 3).
+    workflows_active = VIBE_HOME / "workflows" / "active"
+    if workflows_active.is_dir():
+        skill_paths.append(str(workflows_active))
+    # Draft workflows are loaded too, so a draft can be tested (invoked as
+    # `/<name>`) before it is promoted. Promotion just moves the draft into
+    # active/ to keep it permanently; both dirs hold <name>/SKILL.md entries.
+    workflows_draft = VIBE_HOME / "workflows" / "draft"
+    if workflows_draft.is_dir():
+        skill_paths.append(str(workflows_draft))
     cfg["skill_paths"] = skill_paths
+
+    # Personal workflows toggled off in the gear are disabled by name so vibe-acp
+    # skips loading them, without removing them from disk. Non-workflow entries in
+    # disabled_skills (if any were set manually) are preserved.
+    all_workflows = {w["name"] for w in _discover_workflows()}
+    deactivated = all_workflows - _load_active_workflow_names()
+    existing_disabled = cast("list[str]", cfg.get("disabled_skills", []))
+    preserved = [s for s in existing_disabled if s not in all_workflows]
+    cfg["disabled_skills"] = sorted(set(preserved) | deactivated)
 
     config_path.parent.mkdir(parents=True, exist_ok=True)
     tmp = config_path.with_suffix(".tmp")
@@ -380,6 +498,15 @@ def _build_chat_settings_inputs() -> list[Any]:
                 initial=True,
                 description=(
                     "Enable this option to add a plain-language explanation to each tool call."
+                ),
+            ),
+            cl.input_widget.Switch(
+                id="record_provenance",
+                label="Record provenance",
+                initial=_load_provenance_enabled(),
+                description=(
+                    "Record a reproducible log of each session: environment, tool calls, "
+                    "permission decisions, and a summary report."
                 ),
             ),
         ],
@@ -404,7 +531,52 @@ def _build_chat_settings_inputs() -> list[Any]:
         inputs=stack_inputs,
     )
 
-    return [general_tab, stacks_tab]
+    tabs: list[Any] = [general_tab, stacks_tab]
+
+    workflows = _discover_workflows()
+    if workflows:
+        active_workflows = _load_active_workflow_names()
+        workflow_inputs: list[cl.input_widget.InputWidget] = [
+            cl.input_widget.Switch(
+                id=f"workflow_{wf['name']}",
+                label=wf["name"] + ("  (draft)" if wf["kind"] == "draft" else ""),
+                initial=wf["name"] in active_workflows,
+                description=(
+                    (wf["description"] or "Personal workflow")
+                    + " — loaded as a skill when on. Changes take effect on the next message."
+                ),
+            )
+            for wf in workflows
+        ]
+        tabs.append(cl.input_widget.Tab(id="workflows", label="Workflows", inputs=workflow_inputs))
+
+    return tabs
+
+
+def _workflow_commands() -> list[CommandDict]:
+    """Return the composer command list (Save / Manage workflow buttons).
+
+    Rendered as buttons in the message box; clicking one and sending sets
+    ``message.command`` so ``on_message`` can act on it (distill the chat, or
+    list workflows) instead of forwarding the text to the agent.
+    """
+    save: CommandDict = {
+        "id": SAVE_WORKFLOW_COMMAND,
+        "icon": "save",
+        "description": "Distill this chat into a reusable workflow",
+        "button": True,
+        "persistent": False,
+        "selected": False,
+    }
+    manage: CommandDict = {
+        "id": MANAGE_WORKFLOWS_COMMAND,
+        "icon": "list",
+        "description": "List your workflows to test, promote, or delete them",
+        "button": True,
+        "persistent": False,
+        "selected": False,
+    }
+    return [save, manage]
 
 
 # ── Explain tool calls (opt-in) ──────────────────────────
@@ -933,11 +1105,44 @@ class _NullStorageClient(BaseStorageClient):
         pass
 
 
+class _MedMcpDataLayer(SQLAlchemyDataLayer):
+    """Data layer that also purges on-disk session logs when a thread is deleted.
+
+    Chainlit's delete only removes the thread from the SQLite index; the vibe-acp
+    transcript and our provenance record live on disk and would otherwise be
+    orphaned. We resolve the thread's ``vibe_session_id`` first, then purge both
+    after the row is gone.
+    """
+
+    async def _vibe_session_id_for(self, thread_id: str) -> str | None:
+        """Read the vibe-acp session id from a thread's metadata, if present."""
+        with contextlib.suppress(Exception):
+            thread = await self.get_thread(thread_id)
+            if thread is None:
+                return None
+            raw_meta: object = cast("dict[str, Any]", thread).get("metadata") or {}
+            if isinstance(raw_meta, str):
+                raw_meta = cast("object", json.loads(raw_meta))
+            if isinstance(raw_meta, dict):
+                sid = cast("dict[str, Any]", raw_meta).get("vibe_session_id")
+                return sid if isinstance(sid, str) else None
+        return None
+
+    async def delete_thread(self, thread_id: str) -> None:
+        """Delete the thread, then purge its vibe transcript and provenance logs."""
+        session_id = await self._vibe_session_id_for(thread_id)
+        await super().delete_thread(thread_id)  # pyright: ignore[reportUnknownMemberType]
+        if session_id:
+            with contextlib.suppress(Exception):
+                provenance.purge_session(session_id)
+            _audit.info("deleted thread %s and purged session logs %s", thread_id, session_id)
+
+
 @cl.data_layer  # pyright: ignore[reportUnknownMemberType]
 def get_data_layer() -> SQLAlchemyDataLayer:
     """Wire chainlit to a local sqlite database for thread persistence."""
     _bootstrap_threads_db(THREADS_DB_PATH)
-    return SQLAlchemyDataLayer(
+    return _MedMcpDataLayer(
         conninfo=f"sqlite+aiosqlite:///{THREADS_DB_PATH}",
         storage_provider=_NullStorageClient(),
     )
@@ -1224,6 +1429,7 @@ async def _handle_tool_call(
     """
     tc_id = cast("str", update.get("toolCallId") or "")
     info = tool_call_info.setdefault(tc_id, {})
+    info.setdefault("_started", time.monotonic())
     if (t := update.get("title")) is not None:
         info["title"] = t
     if (ri := update.get("rawInput")) is not None:
@@ -1277,19 +1483,44 @@ def _is_explain_enabled() -> bool:
     return bool(val)  # pyright: ignore[reportUnknownArgumentType]
 
 
+def _is_provenance_enabled() -> bool:
+    """Check whether provenance capture is enabled for the current chat.
+
+    Falls back to the persisted preference when the per-chat value is unset (e.g.
+    a code path that runs before ``on_chat_start`` has populated the session).
+    """
+    val = cl.user_session.get("record_provenance")  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+    if val is None:
+        return _load_provenance_enabled()
+    return bool(val)  # pyright: ignore[reportUnknownArgumentType]
+
+
 @cl.on_settings_update  # pyright: ignore[reportUnknownMemberType]
 async def on_settings_update(settings: dict[str, Any]) -> None:
     """Persist chat-settings changes into the user session.
 
-    Handles two setting types:
+    Handles four setting types:
     - ``explain_tools`` — stored in the Chainlit user session for the current chat.
+    - ``record_provenance`` — persisted to ``.vibe/provenance_enabled.json`` and
+      mirrored into the user session; takes effect immediately.
     - ``stack_<name>`` — updates the persistent active-stack set in
       ``.vibe/active_stacks.json``; the new set takes effect on the next
       conversation (vibe-acp reads config.toml at session-creation time).
+    - ``workflow_<name>`` — updates the active-workflow set in
+      ``.vibe/active_workflows.json``; deactivated workflows are written to
+      ``disabled_skills`` on the next session so vibe-acp skips loading them.
     """
+    global _vibe_restart_needed
+
     new_value = bool(settings.get("explain_tools", False))
     cl.user_session.set("explain_tools", new_value)  # pyright: ignore[reportUnknownMemberType]
     _audit.info("explain_tools set to %s via settings", new_value)
+
+    prov_value = bool(settings.get("record_provenance", True))
+    cl.user_session.set("record_provenance", prov_value)  # pyright: ignore[reportUnknownMemberType]
+    if prov_value != _load_provenance_enabled():
+        _save_provenance_enabled(prov_value)
+        _audit.info("provenance recording set to %s via settings", prov_value)
 
     all_servers = _load_mcp_servers()
     if all_servers:
@@ -1298,11 +1529,23 @@ async def on_settings_update(settings: dict[str, Any]) -> None:
         }
         if active_names != _load_active_server_names():
             _save_active_server_names(active_names)
-            global _vibe_restart_needed
             _vibe_restart_needed = True
             _audit.info(
                 "active stacks updated to: %s; vibe-acp will restart on next session",
                 sorted(active_names),
+            )
+
+    workflows = _discover_workflows()
+    if workflows:
+        active_workflows: set[str] = {
+            wf["name"] for wf in workflows if bool(settings.get(f"workflow_{wf['name']}", True))
+        }
+        if active_workflows != _load_active_workflow_names():
+            _save_active_workflow_names(active_workflows)
+            _vibe_restart_needed = True
+            _audit.info(
+                "active workflows updated to: %s; vibe-acp will reload on next message",
+                sorted(active_workflows),
             )
 
 
@@ -1345,6 +1588,13 @@ async def _create_new_session(reload_session_id: str | None = None) -> bool:
         while not queue.empty():
             with contextlib.suppress(asyncio.QueueEmpty):
                 queue.get_nowait()
+        # Refresh the provenance manifest so the stack/model set is recorded for
+        # the post-toggle continuation of this session.
+        if _is_provenance_enabled():
+            with contextlib.suppress(Exception):
+                provenance.write_manifest(
+                    reload_session_id, servers=active, model_name=OLLAMA_MODEL
+                )
         return True
 
     resp = await _client.request(
@@ -1362,6 +1612,10 @@ async def _create_new_session(reload_session_id: str | None = None) -> bool:
         return False
     _set_session_id(session_id)
     _client.register_session(session_id)
+    # Capture the environment manifest (Tier-1 provenance) for this session.
+    if _is_provenance_enabled():
+        with contextlib.suppress(Exception):
+            provenance.write_manifest(session_id, servers=active, model_name=OLLAMA_MODEL)
     return True
 
 
@@ -1375,6 +1629,8 @@ async def on_chat_start() -> None:
     ``_vibe_restart_needed`` and ``on_message`` recreates the session then.
     """
     cl.user_session.set("explain_tools", True)  # pyright: ignore[reportUnknownMemberType]
+    cl.user_session.set("record_provenance", _load_provenance_enabled())  # pyright: ignore[reportUnknownMemberType]
+    await cl.context.emitter.set_commands(_workflow_commands())  # pyright: ignore[reportUnknownMemberType]
     # Start vibe-acp and build the settings widget concurrently — both involve
     # subprocess calls on first run, so overlapping them saves startup time.
     warmup_task = asyncio.create_task(_client.ensure_started())
@@ -1402,6 +1658,8 @@ async def on_chat_resume(thread: ThreadDict) -> None:
     because chainlit's persistence is the source of truth for the UI.
     """
     cl.user_session.set("explain_tools", True)  # pyright: ignore[reportUnknownMemberType]
+    cl.user_session.set("record_provenance", _load_provenance_enabled())  # pyright: ignore[reportUnknownMemberType]
+    await cl.context.emitter.set_commands(_workflow_commands())  # pyright: ignore[reportUnknownMemberType]
     await cl.ChatSettings(inputs=_build_chat_settings_inputs()).send()
 
     # ThreadDict's typing carries Dict[Unknown, Unknown] for the metadata field,
@@ -1487,6 +1745,20 @@ def _persisted_user_id() -> str | None:
 @cl.on_message  # pyright: ignore[reportUnknownMemberType]
 async def on_message(message: cl.Message) -> None:
     """Send a prompt to vibe-acp and stream the response back into the UI."""
+    # The "Save workflow" composer command distills the current chat instead of
+    # being forwarded to the agent.
+    if message.command == SAVE_WORKFLOW_COMMAND:
+        await _handle_save_workflow_command()
+        return
+    if message.command == MANAGE_WORKFLOWS_COMMAND:
+        await _handle_manage_workflows_command()
+        return
+
+    # A pending Rename/Refine (set by clicking those buttons) consumes this
+    # message as its input value instead of forwarding it to the agent.
+    if await _consume_pending_workflow_input(message.content):
+        return
+
     session_id = _get_session_id()
     stack_reload = _vibe_restart_needed and session_id is not None
     if session_id is None or _vibe_restart_needed:
@@ -1717,6 +1989,44 @@ async def _update_tool_summary(
     await step.update()
 
 
+def _record_tool_event(session_id: str, tc_id: str, info: JsonDict) -> None:
+    """Append a normalized run-log event for a completed tool call (best-effort).
+
+    Idempotent per call via the ``_logged`` marker, since ``tool_call_update``
+    can fire more than once. Never raises — provenance must not break a chat.
+    """
+    if info.get("_logged"):
+        return
+    info["_logged"] = True
+    started = info.get("_started")
+    duration = time.monotonic() - started if isinstance(started, (int, float)) else None
+    title = info.get("title")
+    title_str = title if isinstance(title, str) else None
+    server, tool = provenance.split_tool_name(
+        title_str or tc_id, [str(s["name"]) for s in _active_servers()]
+    )
+    risks = info.get("risks")
+    decision = info.get("decision")
+    human_readable = info.get("humanReadable")
+    output_text = info.get("outputText")
+    event = provenance.normalize_tool_event(
+        tool_call_id=tc_id,
+        title=title_str,
+        server=server,
+        tool=tool,
+        raw_input=info.get("rawInput"),
+        raw_output=info.get("rawOutput"),
+        output_text=output_text if isinstance(output_text, str) else None,
+        status=str(info.get("status") or ""),
+        decision=str(decision) if decision is not None else None,
+        risks=cast("list[str]", risks) if isinstance(risks, list) else None,
+        human_readable=human_readable if isinstance(human_readable, str) else None,
+        duration_sec=duration,
+    )
+    with contextlib.suppress(Exception):
+        provenance.append_run_event(session_id, event)
+
+
 async def _process_session_frame(
     msg: JsonDict,
     *,
@@ -1790,11 +2100,13 @@ async def _process_session_frame(
                     tool_call_info[tc_id]["status"] = status
             await _handle_tool_call_update(update, tool_steps)
             # Refresh the summary step after each tool completion.
-            if "step" in tool_summary_holder and update.get("status") in (
-                "completed",
-                "failed",
-            ):
-                await _update_tool_summary(tool_summary_holder, tool_call_info)
+            if update.get("status") in ("completed", "failed"):
+                if "step" in tool_summary_holder:
+                    await _update_tool_summary(tool_summary_holder, tool_call_info)
+                # Record the normalized run-log event (Tier-1 provenance).
+                sid = _get_session_id()
+                if sid and tc_id in tool_call_info and _is_provenance_enabled():
+                    _record_tool_event(sid, tc_id, tool_call_info[tc_id])
 
     elif method == "session/request_permission":
         req_id_raw = msg.get("id")
@@ -1834,6 +2146,21 @@ async def _process_session_frame(
                 await _update_tool_summary(tool_summary_holder, tool_call_info)
 
         outcome = await _ask_user_for_permission(tc, options)
+        # Persist the decision: stash it on tool_call_info so the run-log event
+        # carries it, and mirror it to the on-disk permissions log.
+        decision = (
+            outcome.get("optionId")
+            if outcome.get("outcome") == "selected"
+            else outcome.get("outcome")
+        )
+        if tc_id_perm in tool_call_info:
+            tool_call_info[tc_id_perm]["decision"] = decision
+        sid = _get_session_id()
+        if sid and _is_provenance_enabled():
+            with contextlib.suppress(Exception):
+                provenance.log_permission(
+                    sid, title=str(tc.get("title") or tc_id_perm), decision=str(decision)
+                )
         await _client.respond(req_id, {"outcome": outcome})
 
 
@@ -1852,6 +2179,340 @@ async def on_stop() -> None:
         await _client.notify("session/cancel", {"session_id": session_id})
 
 
+async def _send_workflow_preview(draft_dir: Path) -> None:
+    """Render a draft workflow's SKILL.md inline with the review action buttons."""
+    skill_md = (draft_dir / "SKILL.md").read_text(encoding="utf-8")
+    await cl.Message(
+        content=(
+            f"**Draft workflow `{draft_dir.name}`** — review below, then **Test** it in this "
+            f"chat, **Refine**/**Rename** it, **Promote** to keep it, or **Discard** it.\n\n"
+            f"```markdown\n{skill_md}\n```"
+        ),
+        actions=[
+            cl.Action(
+                name=TEST_WORKFLOW_ACTION,
+                payload={"name": draft_dir.name},
+                label="Test",
+                tooltip="Load the draft so you can try it in this chat before promoting",
+            ),
+            cl.Action(
+                name=PROMOTE_WORKFLOW_ACTION,
+                payload={"name": draft_dir.name},
+                label="Promote",
+                tooltip="Keep this workflow permanently as a reusable skill",
+            ),
+            cl.Action(
+                name=REFINE_WORKFLOW_ACTION,
+                payload={"name": draft_dir.name},
+                label="Refine",
+                tooltip="Describe a change and regenerate the workflow",
+            ),
+            cl.Action(
+                name=RENAME_WORKFLOW_ACTION,
+                payload={"name": draft_dir.name},
+                label="Rename",
+                tooltip="Give the workflow a different name",
+            ),
+            cl.Action(
+                name=DISCARD_WORKFLOW_ACTION,
+                payload={"name": draft_dir.name},
+                label="Discard",
+                tooltip="Delete this draft",
+            ),
+        ],
+    ).send()
+
+
+def _action_name(action: cl.Action) -> str | None:
+    """Extract the ``name`` from an action payload, or ``None`` if absent."""
+    payload = cast("dict[str, Any]", action.payload or {})  # pyright: ignore[reportUnknownMemberType]
+    name = payload.get("name")
+    return name if isinstance(name, str) else None
+
+
+async def _handle_save_workflow_command() -> None:
+    """Distill the current chat into a draft workflow and preview it in chat.
+
+    Triggered by the "Save workflow" composer command. Runs the (hybrid,
+    LLM-assisted) distillation off the event loop, then shows the draft with
+    review controls. Distillation reads vibe-acp's own transcript, so it works
+    regardless of whether provenance recording is enabled.
+    """
+    session_id = _get_session_id()
+    if session_id is None:
+        await cl.Message(content="There's nothing to save yet — send a message first.").send()
+        return
+
+    progress = cl.Message(content="Distilling this chat into a workflow…")
+    await progress.send()
+    try:
+        draft_dir = await asyncio.to_thread(distill.distill_session, session_id, use_llm=True)
+    except Exception as exc:
+        await progress.remove()
+        await cl.Message(content=f"Could not distill a workflow: {exc}").send()
+        return
+    await progress.remove()
+    await _send_workflow_preview(draft_dir)
+
+
+def _manage_actions(name: str) -> list[cl.Action]:
+    """Build the per-workflow buttons for the Manage list.
+
+    Every workflow offers Edit and Delete. Edit opens the full editable preview
+    (Test / Promote / Rename / Refine / Discard); for a promoted workflow it first
+    unpromotes it back to a draft. Activate/deactivate stays in the settings gear.
+    """
+    return [
+        cl.Action(
+            name=EDIT_WORKFLOW_ACTION,
+            payload={"name": name},
+            label="Edit",
+            tooltip="Open editing controls (test, promote, rename, refine, discard)",
+        ),
+        cl.Action(
+            name=DELETE_WORKFLOW_ACTION,
+            payload={"name": name},
+            label="Delete",
+            tooltip="Delete this workflow from disk",
+        ),
+    ]
+
+
+async def _handle_manage_workflows_command() -> None:
+    """List all personal workflows with per-item Test / Promote / Delete buttons.
+
+    Triggered by the "Manage workflows" composer command. This is the persistent
+    place to act on a workflow after its Save-time preview has scrolled away —
+    e.g. to promote a draft once you've tested it, or to delete any workflow.
+    """
+    workflows = await asyncio.to_thread(_discover_workflows)
+    if not workflows:
+        await cl.Message(
+            content="You have no workflows yet. Use **Save workflow** to distill this chat."
+        ).send()
+        return
+    active_names = await asyncio.to_thread(_load_active_workflow_names)
+    await cl.Message(content=f"**Your workflows ({len(workflows)})**").send()
+    for wf in workflows:
+        name = str(wf["name"])
+        kind = str(wf["kind"])
+        is_active = name in active_names
+        status = "draft" if kind == "draft" else ("active" if is_active else "inactive")
+        description = str(wf["description"]) or "_no description_"
+        await cl.Message(
+            content=f"**`{name}`** · {status}\n\n{description}",
+            actions=_manage_actions(name),
+        ).send()
+
+
+@cl.action_callback(TEST_WORKFLOW_ACTION)  # pyright: ignore[reportUntypedFunctionDecorator, reportUnknownMemberType]
+async def _on_test_workflow(action: cl.Action) -> None:  # pyright: ignore[reportUnusedFunction]
+    """Make a draft loadable so the user can try it in this chat before promoting."""
+    name = _action_name(action)
+    if name is None:
+        await cl.Message(content="Could not determine which workflow to test.").send()
+        return
+    # Draft dirs are already in skill_paths; flag a vibe-acp restart so the next
+    # message respawns the subprocess, which re-scans and loads the draft skill.
+    # The reload preserves the conversation (session/load).
+    global _vibe_restart_needed
+    _vibe_restart_needed = True
+    await cl.Message(
+        content=(
+            f"Draft **`{name}`** is ready to test. On your next message, run it with "
+            f"`/{name}` (optionally add your own inputs after it), e.g. "
+            f"`/{name} on data/your_scan.nii.gz`. When it works, **Promote** to keep it "
+            f"(or **Delete** to remove it)."
+        ),
+        actions=[
+            cl.Action(
+                name=PROMOTE_WORKFLOW_ACTION,
+                payload={"name": name},
+                label="Promote",
+                tooltip="Keep this workflow permanently as a reusable skill",
+            ),
+            cl.Action(
+                name=DELETE_WORKFLOW_ACTION,
+                payload={"name": name},
+                label="Delete",
+                tooltip="Delete this workflow from disk",
+            ),
+        ],
+    ).send()
+
+
+@cl.action_callback(PROMOTE_WORKFLOW_ACTION)  # pyright: ignore[reportUntypedFunctionDecorator, reportUnknownMemberType]
+async def _on_promote_workflow(action: cl.Action) -> None:  # pyright: ignore[reportUnusedFunction]
+    """Promote a reviewed draft workflow into the active (reusable) set."""
+    name = _action_name(action)
+    if name is None:
+        await cl.Message(content="Could not determine which workflow to promote.").send()
+        return
+    try:
+        dst = await asyncio.to_thread(distill.promote_draft, name)
+    except Exception as exc:
+        await cl.Message(content=f"Could not promote the workflow: {exc}").send()
+        return
+    # Make the new skill available without restarting the UI: flag a vibe-acp
+    # restart so the next message respawns the subprocess, which re-reads
+    # skill_paths (the active workflows dir) and re-scans for the new SKILL.md.
+    # The restart is transparent and preserves the conversation (session/load).
+    global _vibe_restart_needed
+    _vibe_restart_needed = True
+    await cl.Message(
+        content=(
+            f"Promoted **`{name}`**. It now lives in your active workflows "
+            f"(`{dst}`) and will be loaded as a skill on your next message — "
+            f"no UI restart needed."
+        )
+    ).send()
+
+
+@cl.action_callback(DISCARD_WORKFLOW_ACTION)  # pyright: ignore[reportUntypedFunctionDecorator, reportUnknownMemberType]
+async def _on_discard_workflow(action: cl.Action) -> None:  # pyright: ignore[reportUnusedFunction]
+    """Delete a draft workflow."""
+    name = _action_name(action)
+    if name is None:
+        await cl.Message(content="Could not determine which workflow to discard.").send()
+        return
+    try:
+        await asyncio.to_thread(distill.discard_draft, name)
+    except Exception as exc:
+        await cl.Message(content=f"Could not discard the workflow: {exc}").send()
+        return
+    await cl.Message(content=f"Discarded draft workflow **`{name}`**.").send()
+
+
+@cl.action_callback(DELETE_WORKFLOW_ACTION)  # pyright: ignore[reportUntypedFunctionDecorator, reportUnknownMemberType]
+async def _on_delete_workflow(action: cl.Action) -> None:  # pyright: ignore[reportUnusedFunction]
+    """Delete a personal workflow (draft or promoted) from disk."""
+    name = _action_name(action)
+    if name is None:
+        await cl.Message(content="Could not determine which workflow to delete.").send()
+        return
+    try:
+        await asyncio.to_thread(distill.delete_workflow, name)
+    except Exception as exc:
+        await cl.Message(content=f"Could not delete the workflow: {exc}").send()
+        return
+    # Drop it from the loaded skill set on the next message.
+    global _vibe_restart_needed
+    _vibe_restart_needed = True
+    await cl.Message(content=f"Deleted workflow **`{name}`** from disk.").send()
+
+
+@cl.action_callback(EDIT_WORKFLOW_ACTION)  # pyright: ignore[reportUntypedFunctionDecorator, reportUnknownMemberType]
+async def _on_edit_workflow(action: cl.Action) -> None:  # pyright: ignore[reportUnusedFunction]
+    """Open a workflow's editing controls.
+
+    For a draft this just re-opens its preview. For a promoted workflow it first
+    unpromotes it back to a draft (and reloads so it leaves the active skill set).
+    """
+    global _vibe_restart_needed
+    name = _action_name(action)
+    if name is None:
+        await cl.Message(content="Could not determine which workflow to edit.").send()
+        return
+
+    draft_dir = VIBE_HOME / "workflows" / "draft" / name
+    active_dir = VIBE_HOME / "workflows" / "active" / name
+
+    if active_dir.is_dir() and not draft_dir.is_dir():
+        # Promoted → unpromote back to a draft before editing.
+        try:
+            draft_dir = await asyncio.to_thread(distill.unpromote_workflow, name)
+        except Exception as exc:
+            await cl.Message(content=f"Could not edit the workflow: {exc}").send()
+            return
+        _vibe_restart_needed = True
+        await cl.Message(
+            content=(
+                f"Moved **`{name}`** back to drafts for editing. Make your changes below, "
+                f"then **Promote** again to keep it."
+            )
+        ).send()
+
+    if not (draft_dir / "SKILL.md").exists():
+        await cl.Message(content=f"Could not find a workflow named `{name}` to edit.").send()
+        return
+    await _send_workflow_preview(draft_dir)
+
+
+@cl.action_callback(RENAME_WORKFLOW_ACTION)  # pyright: ignore[reportUntypedFunctionDecorator, reportUnknownMemberType]
+async def _on_rename_workflow(action: cl.Action) -> None:  # pyright: ignore[reportUnusedFunction]
+    """Arm a rename: the user's next message becomes the new name."""
+    name = _action_name(action)
+    if name is None:
+        await cl.Message(content="Could not determine which workflow to rename.").send()
+        return
+    cl.user_session.set("pending_workflow", {"action": "rename", "name": name})  # pyright: ignore[reportUnknownMemberType]
+    await cl.Message(
+        content=f"Type the new name for **`{name}`** and send it (or send `-` to cancel)."
+    ).send()
+
+
+@cl.action_callback(REFINE_WORKFLOW_ACTION)  # pyright: ignore[reportUntypedFunctionDecorator, reportUnknownMemberType]
+async def _on_refine_workflow(action: cl.Action) -> None:  # pyright: ignore[reportUnusedFunction]
+    """Arm a refine: the user's next message becomes the adjustment instruction."""
+    name = _action_name(action)
+    if name is None:
+        await cl.Message(content="Could not determine which workflow to refine.").send()
+        return
+    cl.user_session.set("pending_workflow", {"action": "refine", "name": name})  # pyright: ignore[reportUnknownMemberType]
+    await cl.Message(
+        content=(
+            f"How should I adjust **`{name}`**? Send an instruction "
+            f"(e.g. 'make it generic for any MRI', 'drop the first step'), or `-` to cancel."
+        )
+    ).send()
+
+
+async def _consume_pending_workflow_input(text: str) -> bool:
+    """Apply a pending Rename/Refine to *text*; return True if one was consumed.
+
+    Clicking Rename/Refine stores a pending action in the user session and asks
+    the user to type the value as a normal message. Consuming it through the
+    standard ``on_message`` path (rather than a blocking ``AskUserMessage`` inside
+    an action callback) keeps the flow on Chainlit's well-tested message channel.
+    """
+    pending = cast(
+        "JsonDict | None",
+        cl.user_session.get("pending_workflow"),  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
+    )
+    if not pending:
+        return False
+    cl.user_session.set("pending_workflow", None)  # pyright: ignore[reportUnknownMemberType]  # consume regardless of outcome
+
+    name = str(pending.get("name") or "")
+    action = str(pending.get("action") or "")
+    value = text.strip()
+    if value in ("", "-"):
+        await cl.Message(content=f"{action.capitalize()} cancelled — `{name}` is unchanged.").send()
+        return True
+
+    if action == "refine":
+        progress = cl.Message(content="Refining the workflow… (this can take up to a minute)")
+        await progress.send()
+        try:
+            draft_dir = await asyncio.to_thread(distill.refine_draft, name, value)
+        except Exception as exc:
+            await progress.remove()
+            await cl.Message(content=f"Could not refine the workflow: {exc}").send()
+            return True
+        await progress.remove()
+        await _send_workflow_preview(draft_dir)
+        return True
+
+    # Default: rename.
+    try:
+        draft_dir = await asyncio.to_thread(distill.rename_draft, name, value)
+    except Exception as exc:
+        await cl.Message(content=f"Could not rename the workflow: {exc}").send()
+        return True
+    await _send_workflow_preview(draft_dir)
+    return True
+
+
 @cl.on_chat_end  # pyright: ignore[reportUnknownMemberType]
 async def on_chat_end() -> None:
     """Detach the chat from its vibe-acp session queue.
@@ -1864,3 +2525,7 @@ async def on_chat_end() -> None:
     session_id = _get_session_id()
     if session_id is not None:
         _client.unregister_session(session_id)
+        # Render the human-readable provenance report for this session.
+        if _is_provenance_enabled():
+            with contextlib.suppress(Exception):
+                provenance.write_report(session_id)

--- a/src/medmcp/distill.py
+++ b/src/medmcp/distill.py
@@ -145,6 +145,23 @@ def _is_failed_result(result_text: str) -> bool:
     return "ok: False" in result_text or "returncode: 1" in result_text
 
 
+# Markers vibe-acp writes into a tool result when the user rejected/cancelled the
+# call, so it never actually ran (see vibe ``get_user_cancellation_message`` and
+# the ACP reject path). Such calls must not become workflow steps.
+_REJECTION_MARKERS: tuple[str, ...] = (
+    "User rejected the tool call",
+    "user_cancellation",  # the <user_cancellation> tag wrapping skip/cancel text
+    "skipped by user",
+    "interrupted by user",
+    "User cancelled the operation",
+)
+
+
+def _is_rejected_result(result_text: str) -> bool:
+    """Detect a tool call the user rejected or cancelled (so it didn't execute)."""
+    return any(marker in result_text for marker in _REJECTION_MARKERS)
+
+
 def _iter_tool_calls(messages: list[JsonDict]) -> list[tuple[str, JsonDict, str]]:
     """Yield ``(tool_name, arguments, result_text)`` for each completed tool call.
 
@@ -198,7 +215,11 @@ def build_recipe(
 
     step_no = 0
     for tool_name, args, result_text in _iter_tool_calls(messages):
-        if _is_exploratory_call(tool_name, args) or _is_failed_result(result_text):
+        if (
+            _is_exploratory_call(tool_name, args)
+            or _is_failed_result(result_text)
+            or _is_rejected_result(result_text)
+        ):
             continue
         step_no += 1
         server, tool = provenance.split_tool_name(tool_name, server_names)
@@ -213,7 +234,13 @@ def build_recipe(
                     new_args[key] = f"{{{{{inputs[value].name}}}}}"
                 else:
                     placeholder = f"in_{len(inputs) + 1}"
-                    inputs[value] = WorkflowInput(name=placeholder, example=value)
+                    # Describe the input by its first use so the user knows what to
+                    # supply on replay (e.g. "the input_path for medmcp-neuro:skull_strip").
+                    inputs[value] = WorkflowInput(
+                        name=placeholder,
+                        example=value,
+                        description=f"the {key} for {server}:{tool}",
+                    )
                     new_args[key] = f"{{{{{placeholder}}}}}"
             else:
                 new_args[key] = value
@@ -389,7 +416,9 @@ def render_skill_md(recipe: Recipe, prose: JsonDict | None) -> str:
         parts += ["", "## Gotchas", "", gotchas_md.strip()]
     if recipe.inputs:
         parts += ["", "## Inputs", ""]
-        parts += [f"- `{{{{{i.name}}}}}` — e.g. `{i.example}`" for i in recipe.inputs]
+        for i in recipe.inputs:
+            desc = f" — {i.description}" if i.description else ""
+            parts.append(f"- `{{{{{i.name}}}}}`{desc} (e.g. `{i.example}`)")
     return "\n".join(parts).rstrip() + "\n"
 
 

--- a/src/medmcp/distill.py
+++ b/src/medmcp/distill.py
@@ -1,0 +1,616 @@
+"""Tier-2 distillation: turn a session's raw log into a reusable workflow.
+
+Reads vibe-acp's ``messages.jsonl`` (the authoritative record of exact tool
+names, arguments, and structured results), filters out exploratory/failed
+calls, and lifts concrete file paths into named placeholders to produce a
+:class:`~medmcp.workflow.Recipe`. The recipe is emitted two ways from one
+distillation (Option C):
+
+- ``recipe.yaml`` — machine-readable + replayable.
+- ``SKILL.md``    — frontmatter + ``## Steps`` / ``## Gotchas``, droppable into a
+  ``skill_paths`` directory so it plugs into the existing skill system.
+
+The prose (workflow name, description, narrative steps, gotchas) is written by a
+hybrid pass: the step sequence is extracted deterministically, then the local
+Ollama model is asked to write the human-facing narrative. If the model is
+unavailable the narrative falls back to a mechanical rendering so distillation
+never hard-fails.
+
+Output lands in ``.vibe/workflows/draft/<name>/`` for human review; promotion to
+an active ``skill_paths`` location is a separate, deliberate step.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+from pathlib import Path
+from typing import Any, cast
+
+import httpx
+import yaml
+
+from medmcp import provenance
+from medmcp.workflow import Recipe, RecipeStep, WorkflowInput
+
+JsonDict = dict[str, Any]
+
+OLLAMA_BASE_URL: str = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434")
+OLLAMA_MODEL: str = os.environ.get("OLLAMA_MODEL", "gemma4-medmcp")
+PROSE_TIMEOUT: float = 60.0
+
+# Read-only / orchestration tools that carry no reusable workflow meaning; they
+# are dropped from the distilled recipe so it captures the actual pipeline.
+EXPLORATORY_TOOLS: frozenset[str] = frozenset(
+    {"read_file", "grep", "todo", "skill", "task", "ls", "web_fetch", "web_search"}
+)
+
+# Shell tools whose command is inspected so read-only invocations can be dropped.
+_SHELL_TOOLS: frozenset[str] = frozenset({"bash", "shell", "sh"})
+
+# Shell utilities that only inspect state. A ``bash`` call running one of these
+# (with no output redirection) is exploration, not a reusable workflow step.
+_READONLY_SHELL_CMDS: frozenset[str] = frozenset(
+    {
+        "ls", "cat", "find", "head", "tail", "pwd", "echo", "stat", "file",
+        "tree", "wc", "du", "df", "which", "type", "realpath", "dirname", "basename",
+    }
+)  # fmt: skip
+
+
+def _is_exploratory_call(tool_name: str, arguments: JsonDict) -> bool:
+    """Return True if a call only inspects state and carries no workflow meaning.
+
+    Covers the named :data:`EXPLORATORY_TOOLS` plus shell calls whose command is
+    a bare read-only inspection (e.g. ``bash`` running ``ls -la data/``). A
+    command with output redirection (``>``/``>>``) is kept since it writes.
+    """
+    if tool_name in EXPLORATORY_TOOLS:
+        return True
+    if tool_name in _SHELL_TOOLS:
+        command = arguments.get("command")
+        if isinstance(command, str):
+            tokens = command.strip().split()
+            if tokens and tokens[0] in _READONLY_SHELL_CMDS and ">" not in command:
+                return True
+    return False
+
+
+_EXT_RE = re.compile(r"\.[A-Za-z0-9]{1,8}(\.gz)?$")
+
+
+# ── Reading the raw log ──────────────────────────────────────────────────────
+
+
+def parse_messages_file(path: Path) -> list[JsonDict]:
+    """Parse a vibe-acp ``messages.jsonl`` file into a list of message dicts."""
+    messages: list[JsonDict] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            messages.append(cast("JsonDict", json.loads(line)))
+        except json.JSONDecodeError:
+            continue
+    return messages
+
+
+def _first_user_message(messages: list[JsonDict]) -> str:
+    """Return the first non-injected user message, for context/naming."""
+    for msg in messages:
+        if msg.get("role") == "user" and not msg.get("injected"):
+            content = msg.get("content")
+            if isinstance(content, str) and content.strip():
+                return content.strip()
+    return ""
+
+
+def _looks_like_path(value: str) -> bool:
+    """Heuristic: does *value* look like a file path or filename?
+
+    Excludes values containing whitespace so that shell command strings (e.g.
+    ``ls -R data/x``) aren't mistaken for paths; imaging paths in this domain do
+    not contain spaces.
+    """
+    if not value or any(c.isspace() for c in value):
+        return False
+    return "/" in value or bool(_EXT_RE.search(value))
+
+
+def _structured_output_paths(result_text: str) -> dict[str, str]:
+    """Extract ``key → path`` pairs from a tool result's structured output."""
+    import ast
+
+    match = re.search(r"structured:\s*(\{.*\})", result_text, re.DOTALL)
+    if not match:
+        return {}
+    try:
+        parsed = ast.literal_eval(match.group(1))
+    except (ValueError, SyntaxError):
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+    out: dict[str, str] = {}
+    for key, value in cast("JsonDict", parsed).items():
+        if isinstance(value, str) and _looks_like_path(value):
+            out[str(key)] = value
+    return out
+
+
+def _is_failed_result(result_text: str) -> bool:
+    """Detect a failed tool result so dead-ends are excluded from the recipe."""
+    return "ok: False" in result_text or "returncode: 1" in result_text
+
+
+def _iter_tool_calls(messages: list[JsonDict]) -> list[tuple[str, JsonDict, str]]:
+    """Yield ``(tool_name, arguments, result_text)`` for each completed tool call.
+
+    Pairs each assistant ``tool_calls`` entry with its matching ``role="tool"``
+    result by ``tool_call_id``. Calls without a result (interrupted) are skipped.
+    """
+    results: dict[str, str] = {}
+    for msg in messages:
+        if msg.get("role") == "tool":
+            call_id = msg.get("tool_call_id")
+            if isinstance(call_id, str):
+                results[call_id] = str(msg.get("content") or "")
+
+    calls: list[tuple[str, JsonDict, str]] = []
+    for msg in messages:
+        if msg.get("role") != "assistant":
+            continue
+        for tc in cast("list[JsonDict]", msg.get("tool_calls") or []):
+            fn = cast("JsonDict", tc.get("function") or {})
+            name = str(fn.get("name") or "")
+            call_id = str(tc.get("id") or "")
+            if not name or call_id not in results:
+                continue
+            try:
+                args = cast("JsonDict", json.loads(str(fn.get("arguments") or "{}")))
+            except json.JSONDecodeError:
+                args = {}
+            calls.append((name, args, results[call_id]))
+    return calls
+
+
+# ── Deterministic recipe extraction ──────────────────────────────────────────
+
+
+def build_recipe(
+    messages: list[JsonDict],
+    *,
+    server_names: list[str],
+    name: str,
+    description: str,
+) -> Recipe:
+    """Extract a parameterized :class:`Recipe` from raw session messages.
+
+    File paths are lifted into placeholders: a path produced by an earlier step
+    becomes ``{{stepM.<key>}}`` when reused, and any other path becomes a
+    workflow input ``{{in_N}}`` (deduplicated by value).
+    """
+    recipe = Recipe(name=name, description=description)
+    produced: dict[str, str] = {}  # concrete path → placeholder reference
+    inputs: dict[str, WorkflowInput] = {}  # concrete path → input definition
+
+    step_no = 0
+    for tool_name, args, result_text in _iter_tool_calls(messages):
+        if _is_exploratory_call(tool_name, args) or _is_failed_result(result_text):
+            continue
+        step_no += 1
+        server, tool = provenance.split_tool_name(tool_name, server_names)
+
+        # Parameterize input paths against earlier outputs / declared inputs.
+        new_args: JsonDict = {}
+        for key, value in args.items():
+            if isinstance(value, str) and _looks_like_path(value):
+                if value in produced:
+                    new_args[key] = produced[value]
+                elif value in inputs:
+                    new_args[key] = f"{{{{{inputs[value].name}}}}}"
+                else:
+                    placeholder = f"in_{len(inputs) + 1}"
+                    inputs[value] = WorkflowInput(name=placeholder, example=value)
+                    new_args[key] = f"{{{{{placeholder}}}}}"
+            else:
+                new_args[key] = value
+
+        # Register this step's outputs so later steps can reference them.
+        produces: dict[str, str] = {}
+        for out_key, out_path in _structured_output_paths(result_text).items():
+            ref = f"step{step_no}.{out_key}"
+            produced[out_path] = f"{{{{{ref}}}}}"
+            produces[out_key] = ref
+
+        recipe.steps.append(
+            RecipeStep(server=server, tool=tool, arguments=new_args, produces=produces)
+        )
+
+    recipe.inputs = list(inputs.values())
+    return recipe
+
+
+def _slugify(text: str) -> str:
+    """Turn arbitrary text into a filesystem/skill-safe slug."""
+    slug = re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
+    return slug[:48] or "workflow"
+
+
+# ── Hybrid prose pass ────────────────────────────────────────────────────────
+
+
+def _prose_prompt(recipe: Recipe, context: str) -> str:
+    """Build the prompt that asks the model to narrate the distilled steps."""
+    steps_desc = "\n".join(
+        f"{i}. {s.server}:{s.tool} arguments={json.dumps(s.arguments)}"
+        for i, s in enumerate(recipe.steps, start=1)
+    )
+    return (
+        "You are documenting a medical-imaging workflow so a colleague can reuse it "
+        "on their own data. Below is the original user request and the exact sequence "
+        "of tool calls that were executed. Write a concise, reusable workflow.\n\n"
+        "GENERALIZE — this is the most important rule. The workflow must be reusable "
+        "beyond the specific scan it was run on:\n"
+        "- Describe inputs at the imaging-modality / anatomy level, NOT the specific "
+        "contrast, sequence, or filename. For example, a workflow run on a T1 scan is a "
+        "brain MRI workflow; refer to 'a brain MRI scan', not 'a T1 scan' or "
+        "'t1n_3d.nii.gz'.\n"
+        "- Only mention a specific contrast/sequence (T1, FLAIR, T2, b0, …) when a step "
+        "genuinely depends on it; otherwise keep it generic.\n"
+        "- The name and description must be modality-level and not tied to one dataset, "
+        "subject, or path.\n\n"
+        "NAME THE TOOLS — every step in steps_markdown MUST explicitly name the exact "
+        "tool it uses, written in backticks as `server:tool` (e.g. `medmcp-neuro:skull_strip`, "
+        "or `builtin:bash` for a built-in tool). This tells the reader precisely which "
+        "tool/skill to call. Never omit, invent, or rephrase a tool name — use only the "
+        "tools listed under 'Executed steps' below, exactly as written. Keep the surrounding "
+        "description generic, but the tool name itself must be verbatim.\n\n"
+        "Respond with ONLY a JSON object — no markdown fences, no extra text:\n"
+        '{"name": "<short-kebab-case-name>", "description": "<one sentence>", '
+        '"steps_markdown": "<numbered markdown list; each step names its `server:tool`>", '
+        '"gotchas_markdown": "<markdown bullet list of caveats, or empty string>"}\n\n'
+        f"Original request:\n{context}\n\n"
+        f"Executed steps (tool names are authoritative — reuse them verbatim):\n{steps_desc}\n"
+    )
+
+
+def _parse_prose_response(raw_text: str) -> JsonDict | None:
+    """Extract the prose JSON object from the model reply (strips code fences)."""
+    text = raw_text.strip()
+    if text.startswith("```"):
+        text = re.sub(r"^```[a-zA-Z]*\n?", "", text)
+        text = re.sub(r"\n?```$", "", text).strip()
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        # Greedy match so nested braces in the markdown body aren't truncated.
+        match = re.search(r"\{.*\}", text, re.DOTALL)
+        if not match:
+            return None
+        try:
+            parsed = json.loads(match.group(0))
+        except json.JSONDecodeError:
+            return None
+    return cast("JsonDict", parsed) if isinstance(parsed, dict) else None
+
+
+def generate_prose(recipe: Recipe, context: str) -> JsonDict | None:
+    """Ask the local model to narrate *recipe*; return prose dict or ``None``.
+
+    Failures are swallowed and reported as ``None`` so distillation can fall
+    back to a mechanical rendering rather than blocking.
+    """
+    prompt = _prose_prompt(recipe, context)
+    try:
+        with httpx.Client(timeout=PROSE_TIMEOUT) as client:
+            resp = client.post(
+                f"{OLLAMA_BASE_URL}/api/chat",
+                json={
+                    "model": OLLAMA_MODEL,
+                    "messages": [{"role": "user", "content": prompt}],
+                    "stream": False,
+                    "think": False,
+                    "options": {"temperature": 0.3, "num_predict": 2048},
+                },
+            )
+            resp.raise_for_status()
+            data = cast("JsonDict", resp.json())
+            message = cast("JsonDict", data.get("message") or {})
+            raw_text = str(message.get("content") or "").strip()
+    except Exception:
+        return None
+    return _parse_prose_response(raw_text)
+
+
+# ── SKILL.md rendering ───────────────────────────────────────────────────────
+
+
+def _mechanical_steps_markdown(recipe: Recipe) -> str:
+    """Render a plain numbered list of steps when no LLM narrative is available."""
+    lines: list[str] = []
+    for i, step in enumerate(recipe.steps, start=1):
+        args = json.dumps(step.arguments)
+        lines.append(f"{i}. **`{step.server}:{step.tool}`** — `{args}`")
+    return "\n".join(lines) or "_No reusable steps were extracted._"
+
+
+def _required_tools(recipe: Recipe) -> list[tuple[str, str]]:
+    """Return the distinct ``(server, tool)`` pairs the recipe uses, first-seen order."""
+    seen: list[tuple[str, str]] = []
+    for step in recipe.steps:
+        pair = (step.server, step.tool)
+        if pair not in seen:
+            seen.append(pair)
+    return seen
+
+
+def _tools_markdown(recipe: Recipe) -> str:
+    """Render the explicit list of tools/skills the workflow requires.
+
+    Derived directly from the recipe (not the LLM) so it is always accurate: each
+    line names a ``server:tool`` and the stack it comes from.
+    """
+    lines: list[str] = []
+    for server, tool in _required_tools(recipe):
+        if server == "builtin":
+            lines.append(f"- `{tool}` — built-in tool")
+        else:
+            lines.append(f"- `{server}:{tool}` — from the `{server}` stack")
+    return "\n".join(lines)
+
+
+def render_skill_md(recipe: Recipe, prose: JsonDict | None) -> str:
+    """Render the ``SKILL.md`` document for *recipe* (using *prose* if present)."""
+    description = recipe.description
+    steps_md = _mechanical_steps_markdown(recipe)
+    gotchas_md = ""
+    if prose is not None:
+        description = str(prose.get("description") or description)
+        steps_md = str(prose.get("steps_markdown") or steps_md)
+        gotchas_md = str(prose.get("gotchas_markdown") or "")
+
+    title = recipe.name.replace("-", " ").strip().capitalize()
+    parts: list[str] = [
+        "---",
+        f"name: {recipe.name}",
+        f"description: {description}",
+        "---",
+        "",
+        f"# {title} workflow",
+    ]
+    tools_md = _tools_markdown(recipe)
+    if tools_md:
+        parts += ["", "## Tools", "", tools_md]
+    parts += ["", "## Steps", "", steps_md]
+    if gotchas_md.strip():
+        parts += ["", "## Gotchas", "", gotchas_md.strip()]
+    if recipe.inputs:
+        parts += ["", "## Inputs", ""]
+        parts += [f"- `{{{{{i.name}}}}}` — e.g. `{i.example}`" for i in recipe.inputs]
+    return "\n".join(parts).rstrip() + "\n"
+
+
+# ── Draft persistence & editing ──────────────────────────────────────────────
+
+
+def _workflows_root(workflows_root: Path | None) -> Path:
+    """Resolve the workflows root, defaulting to ``.vibe/workflows``."""
+    return workflows_root if workflows_root is not None else provenance.VIBE_HOME / "workflows"
+
+
+def _draft_dir(name: str, workflows_root: Path | None) -> Path:
+    """Return the draft directory for workflow *name*."""
+    return _workflows_root(workflows_root) / "draft" / name
+
+
+def _write_draft(draft_dir: Path, recipe: Recipe, prose: JsonDict | None) -> None:
+    """Write ``recipe.yaml``, ``SKILL.md`` and ``prose.json`` for a draft.
+
+    ``prose.json`` caches the LLM narrative so rename/refine can re-render the
+    ``SKILL.md`` without re-running distillation.
+    """
+    draft_dir.mkdir(parents=True, exist_ok=True)
+    recipe_yaml = yaml.safe_dump(recipe.to_dict(), sort_keys=False, allow_unicode=True)
+    (draft_dir / "recipe.yaml").write_text(recipe_yaml, encoding="utf-8")
+    (draft_dir / "SKILL.md").write_text(render_skill_md(recipe, prose), encoding="utf-8")
+    (draft_dir / "prose.json").write_text(
+        json.dumps(prose) if prose is not None else "null", encoding="utf-8"
+    )
+
+
+def _read_prose(draft_dir: Path) -> JsonDict | None:
+    """Read the cached prose for a draft, or ``None`` if absent/mechanical."""
+    path = draft_dir / "prose.json"
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+    return cast("JsonDict", data) if isinstance(data, dict) else None
+
+
+def load_recipe(draft_dir: Path) -> Recipe:
+    """Reconstruct a :class:`Recipe` from a draft's ``recipe.yaml``."""
+    data = cast("JsonDict", yaml.safe_load((draft_dir / "recipe.yaml").read_text(encoding="utf-8")))
+    inputs = [
+        WorkflowInput(
+            name=str(i.get("name", "")),
+            example=str(i.get("example", "")),
+            description=str(i.get("description", "")),
+        )
+        for i in cast("list[JsonDict]", data.get("inputs", []))
+    ]
+    steps = [
+        RecipeStep(
+            server=str(s.get("server", "")),
+            tool=str(s.get("tool", "")),
+            arguments=cast("JsonDict", s.get("arguments", {})),
+            produces=cast("dict[str, str]", s.get("produces", {})),
+        )
+        for s in cast("list[JsonDict]", data.get("steps", []))
+    ]
+    return Recipe(
+        name=str(data.get("name", "")),
+        description=str(data.get("description", "")),
+        inputs=inputs,
+        steps=steps,
+    )
+
+
+# ── Top-level distillation ───────────────────────────────────────────────────
+
+
+def distill_session(
+    session_id: str,
+    *,
+    use_llm: bool = True,
+    workflows_root: Path | None = None,
+) -> Path:
+    """Distill *session_id* into a draft workflow directory and return its path.
+
+    Reads the session's ``messages.jsonl``, builds a parameterized recipe, adds
+    a (hybrid) prose narrative, and writes ``recipe.yaml`` + ``SKILL.md`` into
+    ``<workflows_root>/draft/<name>/`` for human review.
+
+    Raises ``FileNotFoundError`` if the session's raw log cannot be located.
+    """
+    session_dir = provenance.find_vibe_session_dir(session_id)
+    if session_dir is None:
+        raise FileNotFoundError(f"no vibe session log found for session {session_id!r}")
+    messages_path = session_dir / "messages.jsonl"
+    if not messages_path.exists():
+        raise FileNotFoundError(f"no messages.jsonl in {session_dir}")
+
+    messages = parse_messages_file(messages_path)
+    manifest = provenance.read_manifest(session_id)
+    server_names = (
+        [str(s.get("name")) for s in cast("list[JsonDict]", manifest.get("stacks") or [])]
+        if manifest is not None
+        else []
+    )
+
+    context = _first_user_message(messages)
+    fallback_name = _slugify(context) if context else f"workflow-{session_id[:8]}"
+    recipe = build_recipe(
+        messages,
+        server_names=server_names,
+        name=fallback_name,
+        description=context[:120] if context else "Distilled MedMCP workflow",
+    )
+
+    prose = generate_prose(recipe, context) if use_llm else None
+    if prose is not None and isinstance(prose.get("name"), str):
+        recipe.name = _slugify(str(prose["name"]))
+        recipe.description = str(prose.get("description") or recipe.description)
+
+    draft_dir = _draft_dir(recipe.name, workflows_root)
+    _write_draft(draft_dir, recipe, prose)
+    return draft_dir
+
+
+def promote_draft(name: str, *, workflows_root: Path | None = None) -> Path:
+    """Move draft workflow *name* into ``active/`` and return the new path.
+
+    Promotion makes the workflow discoverable as a skill (the active directory is
+    added to ``skill_paths``). Raises ``FileNotFoundError`` if no such draft exists.
+    """
+    src = _draft_dir(name, workflows_root)
+    if not (src / "SKILL.md").exists():
+        raise FileNotFoundError(f"no draft workflow named {name!r} (looked in {src})")
+    dst = _workflows_root(workflows_root) / "active" / name
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    if dst.exists():
+        shutil.rmtree(dst)
+    shutil.move(str(src), str(dst))
+    return dst
+
+
+def unpromote_workflow(name: str, *, workflows_root: Path | None = None) -> Path:
+    """Move a promoted workflow from ``active/`` back to ``draft/`` for editing.
+
+    The inverse of :func:`promote_draft`: it returns the workflow to the draft
+    state so it can be renamed/refined/re-tested, then promoted again. Returns the
+    draft path. Raises ``FileNotFoundError`` if no promoted workflow has that name.
+    """
+    src = _workflows_root(workflows_root) / "active" / name
+    if not (src / "SKILL.md").exists():
+        raise FileNotFoundError(f"no promoted workflow named {name!r} (looked in {src})")
+    dst = _draft_dir(name, workflows_root)
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    if dst.exists():
+        shutil.rmtree(dst)
+    shutil.move(str(src), str(dst))
+    return dst
+
+
+def discard_draft(name: str, *, workflows_root: Path | None = None) -> None:
+    """Delete a draft workflow. Raises ``FileNotFoundError`` if it doesn't exist."""
+    src = _draft_dir(name, workflows_root)
+    if not (src / "SKILL.md").exists():
+        raise FileNotFoundError(f"no draft workflow named {name!r} (looked in {src})")
+    shutil.rmtree(src)
+
+
+def delete_workflow(name: str, *, workflows_root: Path | None = None) -> Path:
+    """Delete a personal workflow by *name* from ``active/`` or ``draft/``.
+
+    Returns the directory that was removed. Raises ``FileNotFoundError`` if no
+    workflow with that name exists in either location.
+    """
+    root = _workflows_root(workflows_root)
+    for kind in ("active", "draft"):
+        target = root / kind / name
+        if (target / "SKILL.md").exists():
+            shutil.rmtree(target)
+            return target
+    raise FileNotFoundError(f"no workflow named {name!r} in {root}")
+
+
+def rename_draft(name: str, new_name: str, *, workflows_root: Path | None = None) -> Path:
+    """Rename a draft workflow (its name, files, and directory). Returns the new dir."""
+    src = _draft_dir(name, workflows_root)
+    if not (src / "SKILL.md").exists():
+        raise FileNotFoundError(f"no draft workflow named {name!r} (looked in {src})")
+    new_slug = _slugify(new_name)
+    recipe = load_recipe(src)
+    recipe.name = new_slug
+    prose = _read_prose(src)
+    if prose is not None:
+        prose["name"] = new_slug
+    # Rewrite in place (so name fields update), then relocate if the slug changed.
+    _write_draft(src, recipe, prose)
+    dst = src.parent / new_slug
+    if dst != src:
+        if dst.exists():
+            shutil.rmtree(dst)
+        shutil.move(str(src), str(dst))
+    return dst
+
+
+def refine_draft(name: str, instruction: str, *, workflows_root: Path | None = None) -> Path:
+    """Regenerate a draft's narrative from a plain-language *instruction*.
+
+    Re-runs the prose model with the user's instruction, keeping the workflow's
+    identity (name) and step recipe unchanged. Raises ``FileNotFoundError`` if the
+    draft is missing, or ``RuntimeError`` if the model returns nothing.
+    """
+    src = _draft_dir(name, workflows_root)
+    if not (src / "SKILL.md").exists():
+        raise FileNotFoundError(f"no draft workflow named {name!r} (looked in {src})")
+    recipe = load_recipe(src)
+    context = (
+        f"Current workflow description: {recipe.description}\n"
+        f"Revise the workflow per this instruction: {instruction}"
+    )
+    prose = generate_prose(recipe, context)
+    if prose is None:
+        raise RuntimeError("the model did not return a refined workflow")
+    # Refine content only; keep the existing name/identity.
+    prose["name"] = recipe.name
+    recipe.description = str(prose.get("description") or recipe.description)
+    _write_draft(src, recipe, prose)
+    return src

--- a/src/medmcp/provcli.py
+++ b/src/medmcp/provcli.py
@@ -1,0 +1,146 @@
+"""CLI for inspecting provenance and distilling reusable workflows.
+
+Exposed as the ``medmcp`` console script::
+
+    medmcp list                 # list sessions with a provenance record
+    medmcp report  <session>    # (re)render report.md and print its path
+    medmcp distill <session>    # distill a draft workflow from the raw log
+    medmcp distill <session> --no-llm   # skip the LLM narrative pass
+    medmcp promote <name>       # move a reviewed draft into active/ (reusable)
+    medmcp workflows            # list personal workflows (draft + promoted)
+    medmcp delete   <name>      # delete a personal workflow (draft or active)
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from medmcp import distill, provenance
+
+
+def _list_sessions() -> int:
+    """Print the session ids that have a provenance directory."""
+    root = provenance.VIBE_HOME / "provenance"
+    if not root.is_dir():
+        print("No provenance records found.", file=sys.stderr)
+        return 0
+    sessions = sorted(p.name for p in root.iterdir() if p.is_dir())
+    for session_id in sessions:
+        manifest = provenance.read_manifest(session_id)
+        created = manifest.get("created_at", "?") if manifest else "?"
+        n_events = len(provenance.read_run_events(session_id))
+        print(f"{session_id}\t{created}\t{n_events} tool calls")
+    return 0
+
+
+def _report(session_id: str, *, to_stdout: bool) -> int:
+    """Render and write report.md for *session_id*."""
+    if to_stdout:
+        print(provenance.render_report(session_id))
+        return 0
+    path = provenance.write_report(session_id)
+    if path is None:
+        print(f"No provenance to report for session {session_id!r}.", file=sys.stderr)
+        return 1
+    print(str(path))
+    return 0
+
+
+def _distill(session_id: str, *, use_llm: bool) -> int:
+    """Distill a draft workflow for *session_id*."""
+    try:
+        draft_dir = distill.distill_session(session_id, use_llm=use_llm)
+    except FileNotFoundError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    print(f"Draft workflow written to: {draft_dir}")
+    print("Review and edit, then promote it into a skill_paths directory to reuse it.")
+    return 0
+
+
+def _promote(name: str) -> int:
+    """Move a reviewed draft workflow into ``active/`` so it loads as a skill."""
+    try:
+        dst = distill.promote_draft(name)
+    except FileNotFoundError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    print(f"Promoted workflow to: {dst}")
+    print("Restart the UI to pick it up; it will be available via the skill system.")
+    return 0
+
+
+def _list_workflows() -> int:
+    """Print personal workflows discovered under ``.vibe/workflows/``."""
+    root = provenance.VIBE_HOME / "workflows"
+    found = False
+    for kind in ("active", "draft"):
+        base = root / kind
+        if not base.is_dir():
+            continue
+        for d in sorted(base.iterdir()):
+            if (d / "SKILL.md").exists():
+                found = True
+                print(f"{d.name}\t{kind}")
+    if not found:
+        print("No personal workflows found.", file=sys.stderr)
+    return 0
+
+
+def _delete(name: str) -> int:
+    """Delete a personal workflow (from active/ or draft/) by name."""
+    try:
+        removed = distill.delete_workflow(name)
+    except FileNotFoundError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    print(f"Deleted workflow: {removed}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for the ``medmcp`` console script."""
+    parser = argparse.ArgumentParser(prog="medmcp", description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("list", help="list sessions with a provenance record")
+
+    report_p = sub.add_parser("report", help="render report.md for a session")
+    report_p.add_argument("session_id")
+    report_p.add_argument(
+        "--print", dest="to_stdout", action="store_true", help="print to stdout instead of writing"
+    )
+
+    distill_p = sub.add_parser("distill", help="distill a reusable workflow from a session")
+    distill_p.add_argument("session_id")
+    distill_p.add_argument(
+        "--no-llm", dest="use_llm", action="store_false", help="skip the LLM narrative pass"
+    )
+
+    promote_p = sub.add_parser("promote", help="move a reviewed draft workflow into active/")
+    promote_p.add_argument("name")
+
+    sub.add_parser("workflows", help="list personal workflows (draft + promoted)")
+
+    delete_p = sub.add_parser("delete", help="delete a personal workflow by name")
+    delete_p.add_argument("name")
+
+    args = parser.parse_args(argv)
+    if args.command == "list":
+        return _list_sessions()
+    if args.command == "report":
+        return _report(args.session_id, to_stdout=args.to_stdout)
+    if args.command == "distill":
+        return _distill(args.session_id, use_llm=args.use_llm)
+    if args.command == "promote":
+        return _promote(args.name)
+    if args.command == "workflows":
+        return _list_workflows()
+    if args.command == "delete":
+        return _delete(args.name)
+    parser.error(f"unknown command {args.command!r}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/medmcp/provenance.py
+++ b/src/medmcp/provenance.py
@@ -271,6 +271,31 @@ def find_vibe_session_dir(session_id: str) -> Path | None:
     return candidates[0] if candidates else None
 
 
+def list_provenance_sessions() -> list[str]:
+    """Return the session ids that currently have a provenance directory."""
+    root = VIBE_HOME / "provenance"
+    if not root.is_dir():
+        return []
+    return sorted(p.name for p in root.iterdir() if p.is_dir())
+
+
+def purge_orphans(referenced_ids: set[str]) -> list[str]:
+    """Delete provenance dirs whose session id is not in *referenced_ids*.
+
+    A garbage-collection sweep so chats deleted in the UI (or sessions that never
+    persisted a thread mapping) don't leak provenance. Returns the purged session
+    ids. Only the provenance directory is removed — vibe transcript dirs are left
+    untouched, because a compaction continuation is named with an id we don't
+    track and could still belong to a live chat.
+    """
+    purged: list[str] = []
+    for session_id in list_provenance_sessions():
+        if session_id not in referenced_ids:
+            shutil.rmtree(provenance_dir(session_id), ignore_errors=True)
+            purged.append(session_id)
+    return purged
+
+
 def purge_session(session_id: str) -> None:
     """Delete all on-disk logs for *session_id*.
 

--- a/src/medmcp/provenance.py
+++ b/src/medmcp/provenance.py
@@ -1,0 +1,394 @@
+"""Tier-1 provenance capture for MedMCP sessions.
+
+Writes a self-contained, append-only record of everything that happened in a
+session into ``.vibe/provenance/<session_id>/``:
+
+- ``manifest.json``  — environment capture: medmcp git commit, installed stack
+  versions, active model + params, OS/python.
+- ``run.jsonl``      — one normalized event per tool call (server, tool, resolved
+  arguments, structured output, permission decision, duration, status).
+- ``permissions.log``— a human-readable mirror of the permission decisions that
+  the ``medmcp.audit`` logger writes to stderr (the stderr trail is unchanged).
+- ``report.md``      — a documentation-grade Markdown rendering, generated on
+  demand from the manifest + run log.
+
+This module is deliberately free of any Chainlit/vibe-acp dependency so it can
+also be driven from the CLI (:mod:`medmcp.provcli`). Callers pass in the data
+they already have (active servers, model name); nothing here reaches back into
+``app.py``. Every write is best-effort at the call site — provenance must never
+break a chat.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import platform
+import re
+import shutil
+import subprocess
+import sys
+import tomllib
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, cast
+
+JsonDict = dict[str, Any]
+
+# Resolve the repo root the same way app.py does: src/medmcp/provenance.py →
+# src/medmcp → src → <root>. VIBE_HOME is module-level so tests can monkeypatch
+# it; all path helpers read it at call time rather than caching a derived path.
+PROJECT_ROOT: Path = Path(__file__).resolve().parents[2]
+VIBE_HOME: Path = PROJECT_ROOT / ".vibe"
+
+
+def _utc_now_iso() -> str:
+    """Return the current UTC time as an ISO-8601 string."""
+    return datetime.now(UTC).isoformat()
+
+
+def provenance_dir(session_id: str) -> Path:
+    """Return the provenance directory for *session_id* (not created)."""
+    return VIBE_HOME / "provenance" / session_id
+
+
+def _ensure_dir(session_id: str) -> Path:
+    """Return the provenance directory for *session_id*, creating it if needed."""
+    d = provenance_dir(session_id)
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+# ── Environment manifest ───────────────────────────────────────────────────
+
+
+def _git(args: list[str]) -> str | None:
+    """Run ``git *args`` in the project root; return stdout or ``None`` on error."""
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        return result.stdout.strip() if result.returncode == 0 else None
+    except Exception:
+        return None
+
+
+def _read_model_config(model_name: str) -> JsonDict:
+    """Return the ``[[models]]`` entry for *model_name* from config.toml, or ``{}``.
+
+    The match is by ``name`` first, then by ``alias`` (the active model in
+    config.toml is referenced by alias, e.g. ``"local"``).
+    """
+    config_path = VIBE_HOME / "config.toml"
+    if not config_path.exists():
+        return {}
+    try:
+        with config_path.open("rb") as f:
+            cfg = tomllib.load(f)
+    except Exception:
+        return {}
+    models = cast("list[JsonDict]", cfg.get("models", []))
+    for model in models:
+        if model.get("name") == model_name or model.get("alias") == model_name:
+            return {k: v for k, v in model.items() if k not in ("input_price", "output_price")}
+    return {}
+
+
+def build_manifest(session_id: str, *, servers: list[JsonDict], model_name: str) -> JsonDict:
+    """Assemble (but do not write) the environment manifest for a session."""
+    return {
+        "session_id": session_id,
+        "created_at": _utc_now_iso(),
+        "medmcp": {
+            "git_commit": _git(["rev-parse", "HEAD"]),
+            "git_branch": _git(["rev-parse", "--abbrev-ref", "HEAD"]),
+        },
+        "stacks": [
+            {
+                "name": s.get("name"),
+                "version": s.get("version"),
+                "command": s.get("command"),
+            }
+            for s in servers
+        ],
+        "model": {"name": model_name, **_read_model_config(model_name)},
+        "platform": {
+            "python": sys.version.split()[0],
+            "platform": platform.platform(),
+            "system": platform.system(),
+        },
+    }
+
+
+def write_manifest(session_id: str, *, servers: list[JsonDict], model_name: str) -> Path:
+    """Write ``manifest.json`` for *session_id* and return its path."""
+    d = _ensure_dir(session_id)
+    manifest = build_manifest(session_id, servers=servers, model_name=model_name)
+    path = d / "manifest.json"
+    path.write_text(json.dumps(manifest, indent=2))
+    return path
+
+
+def read_manifest(session_id: str) -> JsonDict | None:
+    """Read back ``manifest.json`` for *session_id*, or ``None`` if absent/invalid."""
+    path = provenance_dir(session_id) / "manifest.json"
+    if not path.exists():
+        return None
+    try:
+        return cast("JsonDict", json.loads(path.read_text()))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+# ── Run event log ──────────────────────────────────────────────────────────
+
+
+def split_tool_name(name: str, server_names: list[str]) -> tuple[str, str]:
+    """Split a tool name like ``medmcp-neuro_skull_strip`` into (server, tool).
+
+    Matches against known *server_names* first (longest prefix wins so a server
+    name that is itself a prefix of another can't mis-bind). Falls back to
+    ``("builtin", name)`` for vibe-acp tools that carry no server prefix.
+    """
+    for server in sorted(server_names, key=len, reverse=True):
+        prefix = f"{server}_"
+        if name.startswith(prefix):
+            return server, name[len(prefix) :]
+    # Convention fallback for stacks not present in *server_names*: MedMCP stack
+    # tools are named ``medmcp-<stack>_<tool>``.
+    conv = re.match(r"(medmcp-[a-z0-9]+)_(.+)", name)
+    if conv:
+        return conv.group(1), conv.group(2)
+    return "builtin", name
+
+
+def normalize_tool_event(
+    *,
+    tool_call_id: str,
+    title: str | None,
+    server: str,
+    tool: str,
+    raw_input: object,
+    raw_output: object,
+    output_text: str | None,
+    status: str,
+    decision: str | None,
+    risks: list[str] | None,
+    human_readable: str | None,
+    duration_sec: float | None,
+) -> JsonDict:
+    """Build a normalized run-log event dict from the UI's tool-call state."""
+    event: JsonDict = {
+        "tool_call_id": tool_call_id,
+        "server": server,
+        "tool": tool,
+        "status": status,
+    }
+    if title:
+        event["title"] = title
+    if raw_input is not None:
+        event["arguments"] = raw_input
+    if raw_output is not None:
+        event["output"] = raw_output
+    elif output_text is not None:
+        event["output_text"] = output_text
+    if decision is not None:
+        event["permission_decision"] = decision
+    if risks:
+        event["risks"] = risks
+    if human_readable:
+        event["explanation"] = human_readable
+    if duration_sec is not None:
+        event["duration_sec"] = round(duration_sec, 3)
+    return event
+
+
+def append_run_event(session_id: str, event: JsonDict) -> None:
+    """Append a single timestamped event to ``run.jsonl`` for *session_id*."""
+    d = _ensure_dir(session_id)
+    line = json.dumps({"ts": _utc_now_iso(), **event})
+    with (d / "run.jsonl").open("a", encoding="utf-8") as f:
+        f.write(line + "\n")
+
+
+def read_run_events(session_id: str) -> list[JsonDict]:
+    """Read all events from ``run.jsonl`` for *session_id* (skips bad lines)."""
+    path = provenance_dir(session_id) / "run.jsonl"
+    if not path.exists():
+        return []
+    events: list[JsonDict] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            events.append(cast("JsonDict", json.loads(line)))
+        except json.JSONDecodeError:
+            continue
+    return events
+
+
+def log_permission(session_id: str, *, title: str, decision: str) -> None:
+    """Append a permission decision to ``permissions.log`` for *session_id*.
+
+    This is a persisted mirror of the ``medmcp.audit`` stderr trail; the stderr
+    handler in ``app.py`` is unchanged and must not be silenced.
+    """
+    d = _ensure_dir(session_id)
+    with (d / "permissions.log").open("a", encoding="utf-8") as f:
+        f.write(f"{_utc_now_iso()}\t{decision}\t{title}\n")
+
+
+# ── Vibe session lookup ──────────────────────────────────────────────────────
+
+
+def find_vibe_session_dir(session_id: str) -> Path | None:
+    """Locate vibe-acp's log dir for *session_id* under ``.vibe/logs/session/``.
+
+    vibe names directories ``session_<timestamp>_<first8-of-uuid>``, so we glob
+    on the id prefix and confirm the full id via the directory's ``meta.json``.
+    """
+    sessions_root = VIBE_HOME / "logs" / "session"
+    if not sessions_root.is_dir():
+        return None
+    short = session_id[:8]
+    candidates = sorted(sessions_root.glob(f"session_*_{short}"))
+    for candidate in candidates:
+        meta = candidate / "meta.json"
+        if not meta.exists():
+            continue
+        try:
+            data = cast("JsonDict", json.loads(meta.read_text()))
+        except (json.JSONDecodeError, OSError):
+            continue
+        if data.get("session_id") == session_id:
+            return candidate
+    # Fall back to the single prefix match even without a meta confirmation.
+    return candidates[0] if candidates else None
+
+
+def purge_session(session_id: str) -> None:
+    """Delete all on-disk logs for *session_id*.
+
+    Removes both the provenance directory and vibe-acp's session transcript dir,
+    so deleting a chat leaves nothing orphaned on disk. Best-effort: missing
+    paths are ignored.
+    """
+    pdir = provenance_dir(session_id)
+    if pdir.exists():
+        shutil.rmtree(pdir, ignore_errors=True)
+    vibe_dir = find_vibe_session_dir(session_id)
+    if vibe_dir is not None and vibe_dir.exists():
+        shutil.rmtree(vibe_dir, ignore_errors=True)
+
+
+# ── Human-readable report ────────────────────────────────────────────────────
+
+_PATH_KEY_RE = re.compile(r"path|dir|file|output|input", re.IGNORECASE)
+
+
+def _structured_paths(output: object) -> list[str]:
+    """Best-effort extraction of file paths from a tool's structured output."""
+    paths: list[str] = []
+    candidate: JsonDict | None = None
+    if isinstance(output, dict):
+        candidate = cast("JsonDict", output)
+    elif isinstance(output, str):
+        match = re.search(r"structured:\s*(\{.*\})", output, re.DOTALL)
+        if match:
+            try:
+                parsed = ast.literal_eval(match.group(1))
+                if isinstance(parsed, dict):
+                    candidate = cast("JsonDict", parsed)
+            except (ValueError, SyntaxError):
+                candidate = None
+    if candidate is None:
+        return paths
+    for key, value in candidate.items():
+        if isinstance(value, str) and _PATH_KEY_RE.search(str(key)) and "/" in value:
+            paths.append(value)
+    return paths
+
+
+def render_report(session_id: str) -> str:
+    """Render a documentation-grade Markdown report from the provenance record."""
+    manifest = read_manifest(session_id)
+    events = read_run_events(session_id)
+
+    lines: list[str] = ["# MedMCP session report\n", f"**Session:** `{session_id}`\n"]
+
+    if manifest is not None:
+        created = manifest.get("created_at", "unknown")
+        medmcp = cast("JsonDict", manifest.get("medmcp") or {})
+        model = cast("JsonDict", manifest.get("model") or {})
+        stacks = cast("list[JsonDict]", manifest.get("stacks") or [])
+        plat = cast("JsonDict", manifest.get("platform") or {})
+
+        lines.append("## Environment\n")
+        lines.append(f"- **Recorded:** {created}")
+        lines.append(
+            f"- **medmcp:** `{medmcp.get('git_commit') or '?'}` "
+            f"(branch `{medmcp.get('git_branch') or '?'}`)"
+        )
+        model_name = model.get("name", "?")
+        temp = model.get("temperature")
+        thinking = model.get("thinking")
+        model_line = f"- **Model:** `{model_name}`"
+        extras = [
+            f"{k}={v}" for k, v in (("temperature", temp), ("thinking", thinking)) if v is not None
+        ]
+        if extras:
+            model_line += f" ({', '.join(extras)})"
+        lines.append(model_line)
+        if stacks:
+            rendered = ", ".join(
+                f"{s.get('name')} {s.get('version') or ''}".strip() for s in stacks
+            )
+            lines.append(f"- **Stacks:** {rendered}")
+        lines.append(
+            f"- **Platform:** {plat.get('platform', '?')}, Python {plat.get('python', '?')}\n"
+        )
+
+    lines.append(f"## Tool calls ({len(events)})\n")
+    if not events:
+        lines.append("_No tool calls were recorded for this session._")
+    for i, event in enumerate(events, start=1):
+        server = event.get("server", "?")
+        tool = event.get("tool", "?")
+        status = event.get("status", "?")
+        decision = event.get("permission_decision")
+        header = f"### {i}. `{server}:{tool}` — {status}"
+        if decision:
+            header += f" (decision: {decision})"
+        lines.append(header)
+        explanation = event.get("explanation")
+        if isinstance(explanation, str) and explanation:
+            lines.append(f"\n> {explanation}\n")
+        arguments = event.get("arguments")
+        if arguments is not None:
+            rendered_args = json.dumps(arguments, indent=2, default=str)
+            lines.append(f"```json\n{rendered_args}\n```")
+        out_paths = _structured_paths(event.get("output"))
+        if out_paths:
+            lines.append("**Outputs:** " + ", ".join(f"`{p}`" for p in out_paths))
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def write_report(session_id: str) -> Path | None:
+    """Write ``report.md`` for *session_id*; return its path, or ``None`` if empty.
+
+    Returns ``None`` when there is nothing to report (no manifest and no run
+    events), so callers don't create empty files for sessions that never ran.
+    """
+    if read_manifest(session_id) is None and not read_run_events(session_id):
+        return None
+    d = _ensure_dir(session_id)
+    path = d / "report.md"
+    path.write_text(render_report(session_id), encoding="utf-8")
+    return path

--- a/src/medmcp/replay.py
+++ b/src/medmcp/replay.py
@@ -1,0 +1,371 @@
+"""Deterministic replay of a distilled workflow on new data (no LLM).
+
+Loads a :class:`~medmcp.workflow.Recipe`, binds new values to its ``{{in_N}}``
+inputs, and runs each step by calling the MCP tool directly over stdio — no
+vibe-acp, no model reasoning. An output a step produces (its ``produces`` keys)
+is captured from the tool's structured result and substituted into later steps'
+``{{stepM.<key>}}`` placeholders, so a multi-step pipeline chains exactly as it
+did when it was recorded.
+
+This module has no Chainlit/vibe-acp dependency: callers pass in the resolved
+MCP server launch configs (``command``/``args``/``env`` as produced by
+``app._load_mcp_servers``), so it can be driven from the UI or a CLI alike.
+
+Replaying runs real tools with real side effects (file writes, etc.). It is
+deliberately separate from the chat permission flow: callers are expected to
+confirm with the user *before* calling :func:`run` (the UI previews the resolved
+steps first). Built-in vibe-acp tools (``builtin:*`` such as ``bash``) are not
+MCP tools and cannot be replayed; :func:`validate` reports them rather than
+silently skipping a step the pipeline depends on.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+import re
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import AsyncExitStack, asynccontextmanager
+from dataclasses import dataclass, field
+from datetime import timedelta
+from typing import Any, cast
+
+import mcp.types as mcp_types
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+from medmcp.workflow import Recipe
+
+JsonDict = dict[str, Any]
+
+# A callable that runs one tool and returns (ok, structured_output, error_text).
+ToolCaller = Callable[[str, str, JsonDict], Awaitable[tuple[bool, JsonDict, "str | None"]]]
+
+_PLACEHOLDER_RE = re.compile(r"\{\{([^{}]+)\}\}")
+# Imaging tools (registration, segmentation) can run for minutes.
+DEFAULT_TOOL_TIMEOUT_SEC: float = 900.0
+
+
+class ReplayError(Exception):
+    """Raised for engine-level failures (missing stack, bad recipe)."""
+
+
+@dataclass
+class StepResult:
+    """Outcome of replaying a single recipe step."""
+
+    index: int
+    server: str
+    tool: str
+    arguments: JsonDict
+    ok: bool
+    output: JsonDict | None = None
+    error: str | None = None
+    produced: dict[str, str] = field(default_factory=dict[str, str])
+
+
+@dataclass
+class ReplayResult:
+    """Aggregate outcome of a replay run."""
+
+    steps: list[StepResult] = field(default_factory=list[StepResult])
+    ok: bool = True
+    error: str | None = None
+
+
+# ── Placeholder resolution ────────────────────────────────────────────────────
+
+
+def resolve_value(value: object, bindings: dict[str, Any]) -> object:
+    """Substitute ``{{ref}}`` placeholders in *value* using *bindings*.
+
+    A string that is exactly one placeholder is replaced by the bound value with
+    its original type preserved (so a path stays a str, a bound number stays a
+    number). Placeholders embedded in a larger string, or nested in dict/list
+    values, are substituted as text. Unknown refs are left verbatim so the caller
+    can detect them via :func:`unresolved_refs`.
+    """
+    if isinstance(value, str):
+        whole = _PLACEHOLDER_RE.fullmatch(value.strip())
+        if whole is not None:
+            ref = whole.group(1).strip()
+            return bindings.get(ref, value)
+
+        def _sub(match: re.Match[str]) -> str:
+            ref = match.group(1).strip()
+            return str(bindings[ref]) if ref in bindings else match.group(0)
+
+        return _PLACEHOLDER_RE.sub(_sub, value)
+    if isinstance(value, dict):
+        return {k: resolve_value(v, bindings) for k, v in cast("JsonDict", value).items()}
+    if isinstance(value, list):
+        return [resolve_value(v, bindings) for v in cast("list[Any]", value)]
+    return value
+
+
+def resolve_arguments(arguments: JsonDict, bindings: dict[str, Any]) -> JsonDict:
+    """Resolve every argument value against *bindings*."""
+    return {k: resolve_value(v, bindings) for k, v in arguments.items()}
+
+
+def unresolved_refs(value: object) -> set[str]:
+    """Return any ``{{ref}}`` placeholders still present in *value* (recursively)."""
+    found: set[str] = set()
+    if isinstance(value, str):
+        found.update(m.group(1).strip() for m in _PLACEHOLDER_RE.finditer(value))
+    elif isinstance(value, dict):
+        for v in cast("JsonDict", value).values():
+            found |= unresolved_refs(v)
+    elif isinstance(value, list):
+        for v in cast("list[Any]", value):
+            found |= unresolved_refs(v)
+    return found
+
+
+# ── Tool-result interpretation ────────────────────────────────────────────────
+
+
+def _result_text(result: mcp_types.CallToolResult) -> str:
+    """Join the text blocks of a tool result."""
+    return "\n".join(
+        block.text for block in result.content if isinstance(block, mcp_types.TextContent)
+    )
+
+
+def extract_structured(result: mcp_types.CallToolResult) -> JsonDict:
+    """Extract a tool's structured output as a dict.
+
+    Tries, in order:
+
+    1. the protocol-native ``structuredContent`` (newer MCP/stacks with an output
+       schema), unwrapping a lone ``{"result": {...}}`` envelope;
+    2. parsing the text content as JSON (FastMCP returns a tool's dict as a JSON
+       text block);
+    3. a ``structured: {...}`` blob in the text — the shape distillation recorded
+       ``produces`` keys from — so recipes distilled from vibe's rendered results
+       still chain.
+
+    All three surface the same top-level keys, so a recipe's ``produces`` keys
+    resolve regardless of which the stack emits.
+    """
+    structured = result.structuredContent
+    if isinstance(structured, dict) and structured:
+        inner = structured.get("result")
+        if len(structured) == 1 and isinstance(inner, dict):
+            return cast("JsonDict", inner)
+        return structured
+
+    text = _result_text(result).strip()
+    if text:
+        try:
+            parsed_json = json.loads(text)
+        except json.JSONDecodeError:
+            parsed_json = None
+        if isinstance(parsed_json, dict):
+            return cast("JsonDict", parsed_json)
+
+    match = re.search(r"structured:\s*(\{.*\})", text, re.DOTALL)
+    if match is not None:
+        try:
+            parsed = ast.literal_eval(match.group(1))
+        except (ValueError, SyntaxError):
+            return {}
+        if isinstance(parsed, dict):
+            return cast("JsonDict", parsed)
+    return {}
+
+
+def _result_failed(result: mcp_types.CallToolResult) -> bool:
+    """Detect a failed tool call (protocol error flag or known failure markers)."""
+    if result.isError:
+        return True
+    text = _result_text(result)
+    return "ok: False" in text or "returncode: 1" in text
+
+
+# ── MCP transport ─────────────────────────────────────────────────────────────
+
+
+def _server_params(cfg: JsonDict, *, cwd: str | None) -> StdioServerParameters:
+    """Build stdio launch parameters from a discovered server config."""
+    raw_env = cfg.get("env")
+    env: dict[str, str] = {**os.environ}
+    if isinstance(raw_env, dict):
+        env.update({str(k): str(v) for k, v in cast("JsonDict", raw_env).items()})
+    return StdioServerParameters(
+        command=str(cfg["command"]),
+        args=[str(a) for a in cast("list[Any]", cfg.get("args", []))],
+        env=env,
+        cwd=cwd,
+    )
+
+
+@asynccontextmanager
+async def mcp_caller(
+    servers: list[JsonDict],
+    *,
+    cwd: str | None = None,
+    tool_timeout_sec: float = DEFAULT_TOOL_TIMEOUT_SEC,
+) -> AsyncIterator[ToolCaller]:
+    """Yield a :data:`ToolCaller` backed by lazily-spawned MCP stdio servers.
+
+    Each needed stack's server is started on first use and reused for the rest of
+    the run; all are shut down when the context exits.
+    """
+    server_map = {str(s["name"]): s for s in servers}
+    timeout = timedelta(seconds=tool_timeout_sec)
+
+    async with AsyncExitStack() as stack:
+        sessions: dict[str, ClientSession] = {}
+
+        async def _session(server: str) -> ClientSession:
+            if server not in sessions:
+                cfg = server_map.get(server)
+                if cfg is None:
+                    raise ReplayError(f"stack {server!r} is not installed")
+                read, write = await stack.enter_async_context(
+                    stdio_client(_server_params(cfg, cwd=cwd))
+                )
+                session = await stack.enter_async_context(ClientSession(read, write))
+                await session.initialize()
+                sessions[server] = session
+            return sessions[server]
+
+        async def _call(
+            server: str, tool: str, args: JsonDict
+        ) -> tuple[bool, JsonDict, str | None]:
+            session = await _session(server)
+            result = await session.call_tool(tool, args, read_timeout_seconds=timeout)
+            structured = extract_structured(result)
+            if _result_failed(result):
+                return False, structured, _result_text(result) or "tool reported failure"
+            return True, structured, None
+
+        yield _call
+
+
+# ── Validation & execution ────────────────────────────────────────────────────
+
+
+def validate(recipe: Recipe, inputs: dict[str, Any], servers: list[JsonDict]) -> str | None:
+    """Return a human-readable error if *recipe* can't be replayed, else ``None``.
+
+    Checks that every declared input has a value, every referenced stack is
+    installed, and that the recipe has no built-in (non-MCP) tool steps.
+    """
+    missing_inputs = [i.name for i in recipe.inputs if i.name not in inputs]
+    if missing_inputs:
+        return f"missing values for inputs: {', '.join(missing_inputs)}"
+
+    builtin = sorted({f"{s.server}:{s.tool}" for s in recipe.steps if s.server == "builtin"})
+    if builtin:
+        return (
+            "this workflow uses built-in tools that the replay engine can't run "
+            f"deterministically: {', '.join(builtin)}"
+        )
+
+    installed = {str(s["name"]) for s in servers}
+    needed = sorted({s.server for s in recipe.steps} - installed)
+    if needed:
+        return f"required stack(s) not installed: {', '.join(needed)}"
+
+    if not recipe.steps:
+        return "this workflow has no replayable steps"
+    return None
+
+
+async def replay_with_caller(
+    recipe: Recipe,
+    inputs: dict[str, Any],
+    *,
+    caller: ToolCaller,
+    on_step: Callable[[StepResult], Awaitable[None]] | None = None,
+) -> ReplayResult:
+    """Execute *recipe* step-by-step using *caller*; abort on the first failure.
+
+    *inputs* maps placeholder names (``in_1`` …) to concrete values. Outputs a
+    step produces are captured and bound as ``{{stepM.<key>}}`` for later steps.
+    """
+    bindings: dict[str, Any] = dict(inputs)
+    result = ReplayResult()
+
+    for index, step in enumerate(recipe.steps, start=1):
+        args = resolve_arguments(step.arguments, bindings)
+        pending = unresolved_refs(args)
+        if pending:
+            step_result = StepResult(
+                index=index,
+                server=step.server,
+                tool=step.tool,
+                arguments=args,
+                ok=False,
+                error=f"unresolved placeholders: {', '.join(sorted(pending))}",
+            )
+            result.steps.append(step_result)
+            result.ok = False
+            result.error = step_result.error
+            if on_step is not None:
+                await on_step(step_result)
+            break
+
+        try:
+            ok, structured, error = await caller(step.server, step.tool, args)
+        except Exception as exc:
+            # Surface any transport/tool error as a failed step rather than
+            # crashing the whole replay.
+            ok, structured, error = False, {}, str(exc)
+
+        produced: dict[str, str] = {}
+        if ok:
+            for out_key, ref in step.produces.items():
+                if out_key in structured:
+                    bindings[ref] = structured[out_key]
+                    produced[ref] = str(structured[out_key])
+
+        step_result = StepResult(
+            index=index,
+            server=step.server,
+            tool=step.tool,
+            arguments=args,
+            ok=ok,
+            output=structured or None,
+            error=error,
+            produced=produced,
+        )
+        result.steps.append(step_result)
+        if on_step is not None:
+            await on_step(step_result)
+
+        if not ok:
+            result.ok = False
+            result.error = error or f"step {index} ({step.server}:{step.tool}) failed"
+            break
+
+    return result
+
+
+async def run(
+    recipe: Recipe,
+    inputs: dict[str, Any],
+    *,
+    servers: list[JsonDict],
+    cwd: str | None = None,
+    tool_timeout_sec: float = DEFAULT_TOOL_TIMEOUT_SEC,
+    on_step: Callable[[StepResult], Awaitable[None]] | None = None,
+) -> ReplayResult:
+    """Validate and replay *recipe* on *inputs*, spawning the needed MCP stacks.
+
+    Returns a :class:`ReplayResult`; an engine-level problem (failed validation,
+    a stack that won't start) is reported via ``ReplayResult.error`` with an empty
+    or partial ``steps`` list rather than raising.
+    """
+    error = validate(recipe, inputs, servers)
+    if error is not None:
+        return ReplayResult(ok=False, error=error)
+
+    try:
+        async with mcp_caller(servers, cwd=cwd, tool_timeout_sec=tool_timeout_sec) as caller:
+            return await replay_with_caller(recipe, inputs, caller=caller, on_step=on_step)
+    except ReplayError as exc:
+        return ReplayResult(ok=False, error=str(exc))

--- a/src/medmcp/workflow.py
+++ b/src/medmcp/workflow.py
@@ -1,0 +1,83 @@
+"""Schema for distilled, reusable MedMCP workflows (Tier 2).
+
+A :class:`Recipe` is the machine-readable, replayable form of a workflow
+distilled from a session's provenance record (see :mod:`medmcp.distill`). It is
+emitted as ``recipe.yaml`` next to a human/LLM-facing ``SKILL.md`` so the same
+distillation feeds both a deterministic re-run and the existing skill system.
+
+Concrete file paths and devices captured during a session are lifted into named
+placeholders so the recipe can be replayed against new inputs:
+
+- ``{{in_N}}``        — an input the workflow consumes but did not itself produce
+- ``{{stepM.<key>}}`` — an output produced by an earlier step and reused later
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+JsonDict = dict[str, Any]
+
+
+@dataclass
+class WorkflowInput:
+    """A named input the workflow consumes (lifted from a concrete value)."""
+
+    name: str
+    """Placeholder name, e.g. ``in_1`` (referenced as ``{{in_1}}``)."""
+    example: str
+    """The concrete value seen in the originating session, kept as documentation."""
+    description: str = ""
+    """Optional human description of what this input is."""
+
+    def to_dict(self) -> JsonDict:
+        """Return a plain-dict form suitable for YAML/JSON serialization."""
+        out: JsonDict = {"name": self.name, "example": self.example}
+        if self.description:
+            out["description"] = self.description
+        return out
+
+
+@dataclass
+class RecipeStep:
+    """A single tool invocation in a distilled workflow."""
+
+    server: str
+    """MCP server the tool belongs to, or ``"builtin"`` for vibe-acp tools."""
+    tool: str
+    """Tool name without the server prefix (e.g. ``skull_strip``)."""
+    arguments: JsonDict
+    """Resolved arguments, with concrete paths replaced by placeholders."""
+    produces: dict[str, str] = field(default_factory=dict[str, str])
+    """Map of output key → placeholder name for values this step produces."""
+
+    def to_dict(self) -> JsonDict:
+        """Return a plain-dict form suitable for YAML/JSON serialization."""
+        out: JsonDict = {
+            "server": self.server,
+            "tool": self.tool,
+            "arguments": self.arguments,
+        }
+        if self.produces:
+            out["produces"] = self.produces
+        return out
+
+
+@dataclass
+class Recipe:
+    """A distilled, parameterized, replayable workflow."""
+
+    name: str
+    description: str
+    inputs: list[WorkflowInput] = field(default_factory=list[WorkflowInput])
+    steps: list[RecipeStep] = field(default_factory=list[RecipeStep])
+
+    def to_dict(self) -> JsonDict:
+        """Return a plain-dict form suitable for YAML/JSON serialization."""
+        return {
+            "name": self.name,
+            "description": self.description,
+            "inputs": [i.to_dict() for i in self.inputs],
+            "steps": [s.to_dict() for s in self.steps],
+        }

--- a/tests/test_active_servers.py
+++ b/tests/test_active_servers.py
@@ -14,9 +14,12 @@ from medmcp.app import (
     _load_active_server_names,  # pyright: ignore[reportPrivateUsage]
     _load_mcp_servers,  # pyright: ignore[reportPrivateUsage]
     _load_provenance_enabled,  # pyright: ignore[reportPrivateUsage]
+    _load_workflows_enabled,  # pyright: ignore[reportPrivateUsage]
     _save_active_server_names,  # pyright: ignore[reportPrivateUsage]
     _save_provenance_enabled,  # pyright: ignore[reportPrivateUsage]
+    _save_workflows_enabled,  # pyright: ignore[reportPrivateUsage]
     _sync_servers_to_vibe_config,  # pyright: ignore[reportPrivateUsage]
+    _workflow_commands,  # pyright: ignore[reportPrivateUsage]
 )
 
 JsonDict = dict[str, Any]
@@ -143,6 +146,90 @@ class TestProvenanceEnabled:
         path.write_text("not json{{{")
         with patch("medmcp.app._PROVENANCE_ENABLED_PATH", path):
             assert _load_provenance_enabled() is True
+
+
+# ── personal-workflows master toggle ──────────────────────────────────────────
+
+
+class TestWorkflowsEnabled:
+    """_load/_save_workflows_enabled round-trip and default to on."""
+
+    def test_defaults_to_true_when_absent(self, tmp_path: Path) -> None:
+        """Without the file, the workflows feature is enabled by default."""
+        with patch("medmcp.app._WORKFLOWS_ENABLED_PATH", tmp_path / "workflows_enabled.json"):
+            assert _load_workflows_enabled() is True
+
+    def test_round_trip_false(self, tmp_path: Path) -> None:
+        """A saved disabled preference reads back as False."""
+        path = tmp_path / "workflows_enabled.json"
+        with patch("medmcp.app._WORKFLOWS_ENABLED_PATH", path):
+            _save_workflows_enabled(False)
+            assert _load_workflows_enabled() is False
+        assert json.loads(path.read_text()) == {"enabled": False}
+
+    def test_corrupt_file_defaults_to_true(self, tmp_path: Path) -> None:
+        """A corrupt preference file falls back to enabled."""
+        path = tmp_path / "workflows_enabled.json"
+        path.write_text("not json{{{")
+        with patch("medmcp.app._WORKFLOWS_ENABLED_PATH", path):
+            assert _load_workflows_enabled() is True
+
+
+class TestWorkflowCommands:
+    """_workflow_commands gates the composer buttons on the master toggle."""
+
+    def test_returns_buttons_when_enabled(self, tmp_path: Path) -> None:
+        """With the feature on, both Save and Manage buttons are offered."""
+        with patch("medmcp.app._WORKFLOWS_ENABLED_PATH", tmp_path / "workflows_enabled.json"):
+            ids = {cmd["id"] for cmd in _workflow_commands()}
+        assert ids == {"save-workflow", "manage-workflows"}
+
+    def test_empty_when_disabled(self, tmp_path: Path) -> None:
+        """With the feature off, no composer buttons are rendered."""
+        path = tmp_path / "workflows_enabled.json"
+        with patch("medmcp.app._WORKFLOWS_ENABLED_PATH", path):
+            _save_workflows_enabled(False)
+            assert _workflow_commands() == []
+
+
+class TestWorkflowSkillPathsGating:
+    """_sync_servers_to_vibe_config honors the workflows master toggle."""
+
+    def test_enabled_adds_skill_paths(self, tmp_path: Path) -> None:
+        """With the feature on, workflow dirs are added to skill_paths."""
+        _make_workflow(tmp_path, "active", "wf-promoted")
+        _make_workflow(tmp_path, "draft", "wf-draft")
+        cfg_path = tmp_path / "config.toml"
+        with (
+            patch("medmcp.app.VIBE_HOME", tmp_path),
+            patch("medmcp.app._WORKFLOWS_ENABLED_PATH", tmp_path / "workflows_enabled.json"),
+            patch("medmcp.app._ACTIVE_WORKFLOWS_PATH", tmp_path / "active_workflows.json"),
+        ):
+            _sync_servers_to_vibe_config([])
+        cfg = tomllib.loads(cfg_path.read_text())
+        skill_paths = cfg["skill_paths"]
+        assert str(tmp_path / "workflows" / "active") in skill_paths
+        assert str(tmp_path / "workflows" / "draft") in skill_paths
+        # All discovered workflows are active by default, so none disabled.
+        assert cfg["disabled_skills"] == []
+
+    def test_disabled_drops_skill_paths_and_disables_all(self, tmp_path: Path) -> None:
+        """With the feature off, no workflow dir loads and all are disabled."""
+        _make_workflow(tmp_path, "active", "wf-promoted")
+        _make_workflow(tmp_path, "draft", "wf-draft")
+        cfg_path = tmp_path / "config.toml"
+        with (
+            patch("medmcp.app.VIBE_HOME", tmp_path),
+            patch("medmcp.app._WORKFLOWS_ENABLED_PATH", tmp_path / "workflows_enabled.json"),
+            patch("medmcp.app._ACTIVE_WORKFLOWS_PATH", tmp_path / "active_workflows.json"),
+        ):
+            _save_workflows_enabled(False)
+            _sync_servers_to_vibe_config([])
+        cfg = tomllib.loads(cfg_path.read_text())
+        skill_paths = cfg["skill_paths"]
+        assert str(tmp_path / "workflows" / "active") not in skill_paths
+        assert str(tmp_path / "workflows" / "draft") not in skill_paths
+        assert cfg["disabled_skills"] == ["wf-draft", "wf-promoted"]
 
 
 # ── _active_servers ───────────────────────────────────────────────────────────

--- a/tests/test_active_servers.py
+++ b/tests/test_active_servers.py
@@ -10,9 +10,12 @@ from unittest.mock import patch
 
 from medmcp.app import (
     _active_servers,  # pyright: ignore[reportPrivateUsage]
+    _discover_workflows,  # pyright: ignore[reportPrivateUsage]
     _load_active_server_names,  # pyright: ignore[reportPrivateUsage]
     _load_mcp_servers,  # pyright: ignore[reportPrivateUsage]
+    _load_provenance_enabled,  # pyright: ignore[reportPrivateUsage]
     _save_active_server_names,  # pyright: ignore[reportPrivateUsage]
+    _save_provenance_enabled,  # pyright: ignore[reportPrivateUsage]
     _sync_servers_to_vibe_config,  # pyright: ignore[reportPrivateUsage]
 )
 
@@ -113,6 +116,33 @@ class TestSaveActiveServerNames:
             _save_active_server_names({"medmcp-neuro"})
 
         assert path.exists()
+
+
+# ── provenance enabled preference ─────────────────────────────────────────────
+
+
+class TestProvenanceEnabled:
+    """_load/_save_provenance_enabled round-trip and default to on."""
+
+    def test_defaults_to_true_when_absent(self, tmp_path: Path) -> None:
+        """Without the file, provenance is enabled by default."""
+        with patch("medmcp.app._PROVENANCE_ENABLED_PATH", tmp_path / "provenance_enabled.json"):
+            assert _load_provenance_enabled() is True
+
+    def test_round_trip_false(self, tmp_path: Path) -> None:
+        """A saved disabled preference reads back as False."""
+        path = tmp_path / "provenance_enabled.json"
+        with patch("medmcp.app._PROVENANCE_ENABLED_PATH", path):
+            _save_provenance_enabled(False)
+            assert _load_provenance_enabled() is False
+        assert json.loads(path.read_text()) == {"enabled": False}
+
+    def test_corrupt_file_defaults_to_true(self, tmp_path: Path) -> None:
+        """A corrupt preference file falls back to enabled."""
+        path = tmp_path / "provenance_enabled.json"
+        path.write_text("not json{{{")
+        with patch("medmcp.app._PROVENANCE_ENABLED_PATH", path):
+            assert _load_provenance_enabled() is True
 
 
 # ── _active_servers ───────────────────────────────────────────────────────────
@@ -294,6 +324,28 @@ class TestSyncServersToVibeConfig:
 
         assert result.get("skill_paths") == []
 
+    def test_active_workflows_dir_added_to_skill_paths(self, tmp_path: Path) -> None:
+        """A promoted-workflows active/ dir is included in skill_paths."""
+        (tmp_path / "workflows" / "active").mkdir(parents=True)
+        with patch("medmcp.app.VIBE_HOME", tmp_path):
+            _sync_servers_to_vibe_config(_TWO_SERVERS)
+
+        with (tmp_path / "config.toml").open("rb") as f:
+            result = tomllib.load(f)
+
+        assert str(tmp_path / "workflows" / "active") in result["skill_paths"]
+
+    def test_draft_workflows_dir_added_to_skill_paths(self, tmp_path: Path) -> None:
+        """The draft/ dir is included in skill_paths so drafts can be tested."""
+        (tmp_path / "workflows" / "draft").mkdir(parents=True)
+        with patch("medmcp.app.VIBE_HOME", tmp_path):
+            _sync_servers_to_vibe_config(_TWO_SERVERS)
+
+        with (tmp_path / "config.toml").open("rb") as f:
+            result = tomllib.load(f)
+
+        assert str(tmp_path / "workflows" / "draft") in result["skill_paths"]
+
     def test_skill_paths_updated_when_partial_deactivation(self, tmp_path: Path) -> None:
         """skill_paths reflects only the active servers after partial deactivation."""
         cfg_path = tmp_path / "config.toml"
@@ -315,3 +367,89 @@ class TestSyncServersToVibeConfig:
             result = tomllib.load(f)
 
         assert result["skill_paths"] == ["/opt/neuro/skills"]
+
+
+# ── Personal workflows: discovery & disabled_skills sync ──────────────────────
+
+
+def _make_workflow(root: Path, kind: str, name: str, description: str = "") -> None:
+    """Create a minimal <root>/workflows/<kind>/<name>/SKILL.md."""
+    d = root / "workflows" / kind / name
+    d.mkdir(parents=True)
+    front = f"---\nname: {name}\ndescription: {description}\n---\n# {name}\n"
+    (d / "SKILL.md").write_text(front)
+
+
+class TestDiscoverWorkflows:
+    """_discover_workflows scans draft/ and active/ for SKILL.md entries."""
+
+    def test_finds_active_and_draft(self, tmp_path: Path) -> None:
+        """Both promoted and draft workflows are discovered with their kind."""
+        _make_workflow(tmp_path, "active", "brain-mri", "skull strip")
+        _make_workflow(tmp_path, "draft", "spine-seg", "segment spine")
+        with patch("medmcp.app.VIBE_HOME", tmp_path):
+            found = {w["name"]: w for w in _discover_workflows()}
+        assert found["brain-mri"]["kind"] == "active"
+        assert found["brain-mri"]["description"] == "skull strip"
+        assert found["spine-seg"]["kind"] == "draft"
+
+    def test_active_shadows_draft_of_same_name(self, tmp_path: Path) -> None:
+        """A name present in both dirs resolves to the active entry."""
+        _make_workflow(tmp_path, "active", "dup")
+        _make_workflow(tmp_path, "draft", "dup")
+        with patch("medmcp.app.VIBE_HOME", tmp_path):
+            found = [w for w in _discover_workflows() if w["name"] == "dup"]
+        assert len(found) == 1
+        assert found[0]["kind"] == "active"
+
+
+class TestWorkflowDisabledSkills:
+    """Deactivated workflows are written to disabled_skills on config sync."""
+
+    def test_deactivated_workflow_disabled(self, tmp_path: Path) -> None:
+        """A workflow not in the active set is written to disabled_skills."""
+        _make_workflow(tmp_path, "active", "keep-me")
+        _make_workflow(tmp_path, "active", "turn-off")
+        active_path = tmp_path / "active_workflows.json"
+        active_path.write_text(json.dumps({"active": ["keep-me"]}))
+
+        with (
+            patch("medmcp.app.VIBE_HOME", tmp_path),
+            patch("medmcp.app._ACTIVE_WORKFLOWS_PATH", active_path),
+        ):
+            _sync_servers_to_vibe_config([])
+
+        with (tmp_path / "config.toml").open("rb") as f:
+            result = tomllib.load(f)
+        assert result["disabled_skills"] == ["turn-off"]
+
+    def test_all_active_means_none_disabled(self, tmp_path: Path) -> None:
+        """With no active_workflows.json, every workflow is active (none disabled)."""
+        _make_workflow(tmp_path, "active", "a")
+        _make_workflow(tmp_path, "draft", "b")
+        with (
+            patch("medmcp.app.VIBE_HOME", tmp_path),
+            patch("medmcp.app._ACTIVE_WORKFLOWS_PATH", tmp_path / "active_workflows.json"),
+        ):
+            _sync_servers_to_vibe_config([])
+        with (tmp_path / "config.toml").open("rb") as f:
+            result = tomllib.load(f)
+        assert result["disabled_skills"] == []
+
+    def test_preserves_non_workflow_disabled_skills(self, tmp_path: Path) -> None:
+        """A manually-disabled non-workflow skill survives the sync."""
+        _make_workflow(tmp_path, "active", "wf-a")
+        cfg = tmp_path / "config.toml"
+        cfg.write_text('disabled_skills = ["some-builtin"]\n')
+        active_path = tmp_path / "active_workflows.json"
+        active_path.write_text(json.dumps({"active": []}))  # wf-a deactivated
+
+        with (
+            patch("medmcp.app.VIBE_HOME", tmp_path),
+            patch("medmcp.app._ACTIVE_WORKFLOWS_PATH", active_path),
+        ):
+            _sync_servers_to_vibe_config([])
+
+        with cfg.open("rb") as f:
+            result = tomllib.load(f)
+        assert set(result["disabled_skills"]) == {"some-builtin", "wf-a"}

--- a/tests/test_delete_cleanup.py
+++ b/tests/test_delete_cleanup.py
@@ -1,0 +1,62 @@
+"""Tests for the data layer override that purges session logs on thread delete."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+import medmcp.app as app
+from medmcp import provenance
+
+# pyright: reportPrivateUsage=false
+
+JsonDict = dict[str, Any]
+
+
+def _new_data_layer() -> app._MedMcpDataLayer:
+    """Build the data layer without running __init__ (which needs a real DB)."""
+    return object.__new__(app._MedMcpDataLayer)
+
+
+async def _run_delete(monkeypatch: pytest.MonkeyPatch, *, metadata: object) -> list[str]:
+    """Drive delete_thread with a stubbed get_thread; return purged session ids."""
+    purged: list[str] = []
+
+    async def fake_get_thread(self: object, thread_id: str) -> JsonDict:
+        return {"metadata": metadata}
+
+    async def fake_super_delete(self: object, thread_id: str) -> None:
+        return None
+
+    def fake_purge(session_id: str) -> None:
+        purged.append(session_id)
+
+    monkeypatch.setattr(app._MedMcpDataLayer, "get_thread", fake_get_thread, raising=True)
+    monkeypatch.setattr(app.SQLAlchemyDataLayer, "delete_thread", fake_super_delete, raising=True)
+    monkeypatch.setattr(provenance, "purge_session", fake_purge)
+
+    await _new_data_layer().delete_thread("thread-1")
+    return purged
+
+
+@pytest.mark.asyncio
+async def test_purges_when_metadata_is_dict(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A thread whose metadata dict carries vibe_session_id triggers a purge."""
+    purged = await _run_delete(monkeypatch, metadata={"vibe_session_id": "S123"})
+    assert purged == ["S123"]
+
+
+@pytest.mark.asyncio
+async def test_purges_when_metadata_is_json_string(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Metadata stored as a JSON string is parsed before the purge."""
+    purged = await _run_delete(monkeypatch, metadata=json.dumps({"vibe_session_id": "S999"}))
+    assert purged == ["S999"]
+
+
+@pytest.mark.asyncio
+async def test_no_purge_without_session_mapping(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A thread with no vibe_session_id leaves the filesystem untouched."""
+    purged = await _run_delete(monkeypatch, metadata={"other": 1})
+    assert purged == []

--- a/tests/test_delete_cleanup.py
+++ b/tests/test_delete_cleanup.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import sqlite3
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -13,6 +15,15 @@ from medmcp import provenance
 # pyright: reportPrivateUsage=false
 
 JsonDict = dict[str, Any]
+
+
+def _make_threads_db(path: Path, rows: list[tuple[str, str | None]]) -> None:
+    """Create a minimal threads DB with (id, metadata) rows for GC tests."""
+    con = sqlite3.connect(path)
+    con.execute('CREATE TABLE threads ("id" TEXT PRIMARY KEY, "metadata" TEXT)')
+    con.executemany('INSERT INTO threads ("id", "metadata") VALUES (?, ?)', rows)
+    con.commit()
+    con.close()
 
 
 def _new_data_layer() -> app._MedMcpDataLayer:
@@ -60,3 +71,89 @@ async def test_no_purge_without_session_mapping(monkeypatch: pytest.MonkeyPatch)
     """A thread with no vibe_session_id leaves the filesystem untouched."""
     purged = await _run_delete(monkeypatch, metadata={"other": 1})
     assert purged == []
+
+
+# ── fail-safe orphan GC reference reading ─────────────────────────────────────
+
+
+class TestReferencedVibeSessionIds:
+    """_referenced_vibe_session_ids must never under-report (which would over-GC)."""
+
+    def test_collects_ids_from_valid_rows(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Valid metadata rows yield their vibe_session_ids; empty metadata is fine."""
+        db = tmp_path / "threads.db"
+        _make_threads_db(
+            db,
+            [
+                ("t1", json.dumps({"vibe_session_id": "S1"})),
+                ("t2", json.dumps({"vibe_session_id": "S2"})),
+                ("t3", json.dumps({"name": "no session"})),
+                ("t4", None),
+            ],
+        )
+        monkeypatch.setattr(app, "THREADS_DB_PATH", db)
+        assert app._referenced_vibe_session_ids() == {"S1", "S2"}
+
+    def test_none_when_db_missing(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A missing DB returns None (uncertain) so the GC is skipped."""
+        monkeypatch.setattr(app, "THREADS_DB_PATH", tmp_path / "absent.db")
+        assert app._referenced_vibe_session_ids() is None
+
+    def test_none_on_corrupt_metadata_row(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A single unparseable metadata row makes the whole read return None."""
+        db = tmp_path / "threads.db"
+        _make_threads_db(
+            db,
+            [
+                ("t1", json.dumps({"vibe_session_id": "S1"})),
+                ("t2", "not-json{{{"),
+            ],
+        )
+        monkeypatch.setattr(app, "THREADS_DB_PATH", db)
+        assert app._referenced_vibe_session_ids() is None
+
+    def test_none_on_query_failure(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """If the threads table is missing, the read returns None (not empty)."""
+        db = tmp_path / "threads.db"
+        con = sqlite3.connect(db)
+        con.execute("CREATE TABLE other (x TEXT)")  # no `threads` table
+        con.commit()
+        con.close()
+        monkeypatch.setattr(app, "THREADS_DB_PATH", db)
+        assert app._referenced_vibe_session_ids() is None
+
+
+class TestGcOrphanedProvenance:
+    """_gc_orphaned_provenance only deletes when the reference set is certain."""
+
+    def test_skips_when_references_unknown(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When references can't be determined (None), nothing is purged."""
+        called: list[set[str]] = []
+
+        def fake_purge(ids: set[str]) -> list[str]:
+            called.append(ids)
+            return []
+
+        monkeypatch.setattr(app, "_provenance_gc_done", False)
+        monkeypatch.setattr(app, "_referenced_vibe_session_ids", lambda: None)
+        monkeypatch.setattr(provenance, "purge_orphans", fake_purge)
+        app._gc_orphaned_provenance()
+        assert called == []  # purge_orphans never invoked
+
+    def test_purges_when_references_known(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """With a determined set, the GC forwards it to purge_orphans exactly once."""
+        called: list[set[str]] = []
+
+        def fake_purge(ids: set[str]) -> list[str]:
+            called.append(ids)
+            return []
+
+        monkeypatch.setattr(app, "_provenance_gc_done", False)
+        monkeypatch.setattr(app, "_referenced_vibe_session_ids", lambda: {"S1"})
+        monkeypatch.setattr(provenance, "purge_orphans", fake_purge)
+        app._gc_orphaned_provenance()
+        assert called == [{"S1"}]

--- a/tests/test_distill.py
+++ b/tests/test_distill.py
@@ -1,0 +1,399 @@
+"""Tests for Tier-2 distillation (recipe extraction, parameterization, output)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import yaml
+
+# pyright: reportPrivateUsage=false
+from medmcp import distill, provcli, provenance
+from medmcp.workflow import Recipe
+
+JsonDict = dict[str, Any]
+
+SESSION_ID = "abcd1234-1111-2222-3333-444455556666"
+
+
+def _assistant_call(call_id: str, name: str, arguments: JsonDict) -> JsonDict:
+    return {
+        "role": "assistant",
+        "tool_calls": [
+            {"id": call_id, "function": {"name": name, "arguments": json.dumps(arguments)}}
+        ],
+    }
+
+
+def _tool_result(call_id: str, content: str) -> JsonDict:
+    return {"role": "tool", "tool_call_id": call_id, "content": content}
+
+
+# A two-step neuro pipeline: skull-strip a T1, then register the brain to MNI.
+# Plus a read_file (exploratory, dropped) and a failed call (dropped).
+_MESSAGES: list[JsonDict] = [
+    {"role": "user", "content": "Skull strip and register the T1", "injected": False},
+    _assistant_call("c0", "read_file", {"path": "data/x/notes.txt"}),
+    _tool_result("c0", "ok: True\ncontent: hello"),
+    _assistant_call(
+        "c1",
+        "medmcp-neuro_skull_strip",
+        {"device": "cuda", "input_path": "data/x/t1.nii.gz", "output_dir": "data/x"},
+    ),
+    _tool_result(
+        "c1",
+        "ok: True\nstructured: {'brain_path': 'data/x/t1_brain.nii.gz', "
+        "'input_path': 'data/x/t1.nii.gz', 'device': 'cuda'}",
+    ),
+    _assistant_call(
+        "c2",
+        "medmcp-neuro_register_to_template",
+        {"input_path": "data/x/t1_brain.nii.gz", "skull_stripped": True},
+    ),
+    _tool_result("c2", "ok: True\nstructured: {'registered_path': 'data/x/t1_mni.nii.gz'}"),
+    _assistant_call("c3", "medmcp-neuro_coregister", {"input_path": "data/x/flair.nii.gz"}),
+    _tool_result("c3", "ok: False\nerror: boom"),
+]
+
+
+class TestBuildRecipe:
+    """build_recipe extracts and parameterizes the executed pipeline."""
+
+    def _recipe(self) -> Recipe:
+        return distill.build_recipe(
+            _MESSAGES, server_names=["medmcp-neuro"], name="t", description="d"
+        )
+
+    def test_drops_exploratory_and_failed(self) -> None:
+        """read_file (exploratory) and the failed coregister are excluded."""
+        recipe = self._recipe()
+        assert [s.tool for s in recipe.steps] == ["skull_strip", "register_to_template"]
+
+    def test_server_split(self) -> None:
+        """The server prefix is stripped from each step's tool name."""
+        recipe = self._recipe()
+        assert all(s.server == "medmcp-neuro" for s in recipe.steps)
+
+    def test_input_paths_lifted_to_placeholders(self) -> None:
+        """First-seen input paths become workflow inputs."""
+        recipe = self._recipe()
+        step1 = recipe.steps[0]
+        assert step1.arguments["input_path"] == "{{in_1}}"
+        assert step1.arguments["device"] == "cuda"  # non-path left literal
+        examples = {i.example for i in recipe.inputs}
+        assert "data/x/t1.nii.gz" in examples
+
+    def test_step_output_reused_by_later_step(self) -> None:
+        """A path produced by step 1 is referenced symbolically by step 2."""
+        recipe = self._recipe()
+        step2 = recipe.steps[1]
+        assert step2.arguments["input_path"] == "{{step1.brain_path}}"
+        assert step2.arguments["skull_stripped"] is True
+        assert recipe.steps[0].produces["brain_path"] == "step1.brain_path"
+
+    def test_drops_readonly_shell_inspection(self) -> None:
+        """A bash call running a read-only inspection (ls) is excluded as noise."""
+        messages: list[JsonDict] = [
+            _assistant_call("e0", "bash", {"command": "ls -la data/x"}),
+            _tool_result("e0", "ok: True\ncontent: t1.nii.gz"),
+            *_MESSAGES[3:7],  # the two real neuro steps
+        ]
+        recipe = distill.build_recipe(
+            messages, server_names=["medmcp-neuro"], name="t", description="d"
+        )
+        assert [s.tool for s in recipe.steps] == ["skull_strip", "register_to_template"]
+
+    def test_keeps_shell_call_that_writes(self) -> None:
+        """A bash command with output redirection writes, so it is kept."""
+        messages: list[JsonDict] = [
+            _assistant_call("w0", "bash", {"command": "cat a.txt > b.txt"}),
+            _tool_result("w0", "ok: True"),
+        ]
+        recipe = distill.build_recipe(
+            messages, server_names=["medmcp-neuro"], name="t", description="d"
+        )
+        assert [s.tool for s in recipe.steps] == ["bash"]
+
+
+class TestProseParsing:
+    """_parse_prose_response handles fenced and inline JSON."""
+
+    def test_plain_json(self) -> None:
+        """A bare JSON object parses."""
+        parsed = distill._parse_prose_response('{"name": "x", "description": "y"}')
+        assert parsed == {"name": "x", "description": "y"}
+
+    def test_fenced_json(self) -> None:
+        """A ```json fenced block is unwrapped."""
+        parsed = distill._parse_prose_response('```json\n{"name": "x"}\n```')
+        assert parsed == {"name": "x"}
+
+    def test_garbage_returns_none(self) -> None:
+        """Unparseable text returns None."""
+        assert distill._parse_prose_response("not json at all") is None
+
+
+def test_slugify() -> None:
+    """Slugs are lowercased, hyphenated, and bounded."""
+    assert distill._slugify("Skull Strip & Register!") == "skull-strip-register"
+    assert distill._slugify("") == "workflow"
+
+
+class TestRenderSkillMd:
+    """render_skill_md produces a valid SKILL.md with or without prose."""
+
+    def test_mechanical_fallback(self) -> None:
+        """Without prose, steps render mechanically and inputs are listed."""
+        recipe = distill.build_recipe(
+            _MESSAGES, server_names=["medmcp-neuro"], name="my-flow", description="desc"
+        )
+        md = distill.render_skill_md(recipe, None)
+        assert md.startswith("---\nname: my-flow\n")
+        assert "## Steps" in md
+        assert "`medmcp-neuro:skull_strip`" in md
+        assert "## Inputs" in md
+
+    def test_uses_prose_when_present(self) -> None:
+        """Prose name/description/steps override the mechanical defaults."""
+        recipe = distill.build_recipe(
+            _MESSAGES, server_names=["medmcp-neuro"], name="my-flow", description="desc"
+        )
+        prose: JsonDict = {
+            "description": "A nicer description.",
+            "steps_markdown": "1. Do the thing.",
+            "gotchas_markdown": "- Mind the gap.",
+        }
+        md = distill.render_skill_md(recipe, prose)
+        assert "A nicer description." in md
+        assert "Do the thing." in md
+        assert "## Gotchas" in md
+
+    def test_lists_required_tools(self) -> None:
+        """A ## Tools section names every server:tool the workflow needs."""
+        recipe = distill.build_recipe(
+            _MESSAGES, server_names=["medmcp-neuro"], name="my-flow", description="desc"
+        )
+        md = distill.render_skill_md(recipe, None)
+        assert "## Tools" in md
+        assert "`medmcp-neuro:skull_strip` — from the `medmcp-neuro` stack" in md
+        assert "`medmcp-neuro:register_to_template`" in md
+
+    def test_required_tools_dedup_and_builtin(self) -> None:
+        """Distinct tools are listed once; builtin tools are labelled built-in."""
+        messages: list[JsonDict] = [
+            _assistant_call("b0", "bash", {"command": "convert a b"}),
+            _tool_result("b0", "ok: True"),
+            _assistant_call("b1", "bash", {"command": "convert c d"}),
+            _tool_result("b1", "ok: True"),
+        ]
+        recipe = distill.build_recipe(messages, server_names=[], name="f", description="d")
+        tools = distill._required_tools(recipe)
+        assert tools == [("builtin", "bash")]
+        assert "`bash` — built-in tool" in distill.render_skill_md(recipe, None)
+
+
+def _write_fake_session(root: Path) -> None:
+    """Create a minimal vibe session log dir under *root* (a VIBE_HOME)."""
+    sess = root / "logs" / "session" / "session_20260101_000000_abcd1234"
+    sess.mkdir(parents=True)
+    (sess / "meta.json").write_text(json.dumps({"session_id": SESSION_ID}))
+    with (sess / "messages.jsonl").open("w") as f:
+        for msg in _MESSAGES:
+            f.write(json.dumps(msg) + "\n")
+
+
+def test_distill_session_end_to_end(tmp_path: Path) -> None:
+    """distill_session writes recipe.yaml + SKILL.md from a session's raw log."""
+    _write_fake_session(tmp_path)
+    workflows_root = tmp_path / "workflows"
+    with patch.object(provenance, "VIBE_HOME", tmp_path):
+        draft_dir = distill.distill_session(
+            SESSION_ID, use_llm=False, workflows_root=workflows_root
+        )
+
+    assert (draft_dir / "SKILL.md").exists()
+    recipe_yaml = (draft_dir / "recipe.yaml").read_text()
+    recipe = yaml.safe_load(recipe_yaml)
+    assert [s["tool"] for s in recipe["steps"]] == ["skull_strip", "register_to_template"]
+    assert recipe["steps"][1]["arguments"]["input_path"] == "{{step1.brain_path}}"
+
+
+def test_distill_session_missing_log_raises(tmp_path: Path) -> None:
+    """A session with no raw log raises FileNotFoundError."""
+    (tmp_path / "logs" / "session").mkdir(parents=True)
+    with patch.object(provenance, "VIBE_HOME", tmp_path):
+        try:
+            distill.distill_session(SESSION_ID, use_llm=False)
+        except FileNotFoundError:
+            return
+    raise AssertionError("expected FileNotFoundError")
+
+
+def test_promote_moves_draft_to_active(tmp_path: Path) -> None:
+    """Promote relocates a reviewed draft into active/ for skill discovery."""
+    draft = tmp_path / "workflows" / "draft" / "my-flow"
+    draft.mkdir(parents=True)
+    (draft / "SKILL.md").write_text("---\nname: my-flow\n---\n")
+    (draft / "recipe.yaml").write_text("name: my-flow\n")
+    with patch.object(provenance, "VIBE_HOME", tmp_path):
+        rc = provcli._promote("my-flow")
+
+    assert rc == 0
+    active = tmp_path / "workflows" / "active" / "my-flow"
+    assert (active / "SKILL.md").exists()
+    assert not draft.exists()
+
+
+def test_promote_missing_draft_errors(tmp_path: Path) -> None:
+    """Promoting a non-existent draft returns a non-zero exit code."""
+    with patch.object(provenance, "VIBE_HOME", tmp_path):
+        assert provcli._promote("nope") == 1
+
+
+# ── Draft editing: rename / refine / discard ─────────────────────────────────
+
+
+def _make_draft(tmp_path: Path) -> tuple[Path, Path]:
+    """Distill a real (no-LLM) draft; return (workflows_root, draft_dir)."""
+    _write_fake_session(tmp_path)
+    workflows_root = tmp_path / "workflows"
+    with patch.object(provenance, "VIBE_HOME", tmp_path):
+        draft_dir = distill.distill_session(
+            SESSION_ID, use_llm=False, workflows_root=workflows_root
+        )
+    return workflows_root, draft_dir
+
+
+def test_rename_draft_relocates_and_rewrites(tmp_path: Path) -> None:
+    """Rename moves the draft dir and updates the name in recipe.yaml + SKILL.md."""
+    workflows_root, draft_dir = _make_draft(tmp_path)
+    old_name = draft_dir.name
+
+    new_dir = distill.rename_draft(old_name, "Fancy New Name!", workflows_root=workflows_root)
+
+    assert new_dir.name == "fancy-new-name"
+    assert not draft_dir.exists()  # old dir gone
+    recipe = distill.load_recipe(new_dir)
+    assert recipe.name == "fancy-new-name"
+    assert recipe.steps  # the pipeline is preserved across the rename
+    assert (new_dir / "SKILL.md").read_text().startswith("---\nname: fancy-new-name\n")
+
+
+def test_rename_draft_missing_raises(tmp_path: Path) -> None:
+    """Renaming a draft that doesn't exist raises FileNotFoundError."""
+    workflows_root = tmp_path / "workflows"
+    try:
+        distill.rename_draft("nope", "x", workflows_root=workflows_root)
+    except FileNotFoundError:
+        return
+    raise AssertionError("expected FileNotFoundError")
+
+
+def test_discard_draft_removes_dir(tmp_path: Path) -> None:
+    """Discard deletes the draft directory."""
+    workflows_root, draft_dir = _make_draft(tmp_path)
+    distill.discard_draft(draft_dir.name, workflows_root=workflows_root)
+    assert not draft_dir.exists()
+
+
+def test_discard_draft_missing_raises(tmp_path: Path) -> None:
+    """Discarding a non-existent draft raises FileNotFoundError."""
+    try:
+        distill.discard_draft("nope", workflows_root=tmp_path / "workflows")
+    except FileNotFoundError:
+        return
+    raise AssertionError("expected FileNotFoundError")
+
+
+def test_refine_draft_rewrites_prose_keeps_identity(tmp_path: Path) -> None:
+    """Refine regenerates prose (mocked) while keeping the draft's name and steps."""
+    workflows_root, draft_dir = _make_draft(tmp_path)
+    name = draft_dir.name
+    new_prose: JsonDict = {
+        "name": "model-tried-to-rename",  # must be ignored — identity is preserved
+        "description": "Refined description.",
+        "steps_markdown": "1. Refined step.",
+        "gotchas_markdown": "",
+    }
+    with patch.object(distill, "generate_prose", return_value=new_prose):
+        out = distill.refine_draft(name, "make it generic", workflows_root=workflows_root)
+
+    assert out == draft_dir  # same dir; refine never relocates
+    recipe = distill.load_recipe(out)
+    assert recipe.name == name  # identity preserved despite the model's suggestion
+    assert recipe.description == "Refined description."
+    assert "Refined step." in (out / "SKILL.md").read_text()
+
+
+def test_unpromote_moves_active_back_to_draft(tmp_path: Path) -> None:
+    """unpromote_workflow returns a promoted workflow to draft/ for editing."""
+    active = tmp_path / "workflows" / "active" / "flow"
+    active.mkdir(parents=True)
+    (active / "SKILL.md").write_text("---\nname: flow\n---\n")
+    (active / "recipe.yaml").write_text("name: flow\n")
+
+    draft = distill.unpromote_workflow("flow", workflows_root=tmp_path / "workflows")
+
+    assert draft == tmp_path / "workflows" / "draft" / "flow"
+    assert (draft / "SKILL.md").exists()
+    assert not active.exists()
+
+
+def test_unpromote_missing_raises(tmp_path: Path) -> None:
+    """Unpromoting a non-promoted workflow raises FileNotFoundError."""
+    try:
+        distill.unpromote_workflow("nope", workflows_root=tmp_path / "workflows")
+    except FileNotFoundError:
+        return
+    raise AssertionError("expected FileNotFoundError")
+
+
+def test_promote_then_unpromote_round_trips(tmp_path: Path) -> None:
+    """A draft promoted and then unpromoted lands back in draft/ intact."""
+    _, draft_dir = _make_draft(tmp_path)
+    name = draft_dir.name
+    distill.promote_draft(name, workflows_root=tmp_path / "workflows")
+    assert not draft_dir.exists()
+    back = distill.unpromote_workflow(name, workflows_root=tmp_path / "workflows")
+    assert back == draft_dir
+    assert (back / "SKILL.md").exists()
+
+
+def test_delete_workflow_removes_active(tmp_path: Path) -> None:
+    """delete_workflow removes a promoted workflow from active/."""
+    active = tmp_path / "workflows" / "active" / "flow"
+    active.mkdir(parents=True)
+    (active / "SKILL.md").write_text("---\nname: flow\n---\n")
+    removed = distill.delete_workflow("flow", workflows_root=tmp_path / "workflows")
+    assert removed == active
+    assert not active.exists()
+
+
+def test_delete_workflow_removes_draft(tmp_path: Path) -> None:
+    """delete_workflow also removes an unpromoted draft."""
+    _, draft_dir = _make_draft(tmp_path)
+    removed = distill.delete_workflow(draft_dir.name, workflows_root=tmp_path / "workflows")
+    assert removed == draft_dir
+    assert not draft_dir.exists()
+
+
+def test_delete_workflow_missing_raises(tmp_path: Path) -> None:
+    """Deleting a non-existent workflow raises FileNotFoundError."""
+    try:
+        distill.delete_workflow("nope", workflows_root=tmp_path / "workflows")
+    except FileNotFoundError:
+        return
+    raise AssertionError("expected FileNotFoundError")
+
+
+def test_refine_draft_model_failure_raises(tmp_path: Path) -> None:
+    """When the model returns nothing, refine raises rather than silently no-op."""
+    workflows_root, draft_dir = _make_draft(tmp_path)
+    with patch.object(distill, "generate_prose", return_value=None):
+        try:
+            distill.refine_draft(draft_dir.name, "x", workflows_root=workflows_root)
+        except RuntimeError:
+            return
+    raise AssertionError("expected RuntimeError")

--- a/tests/test_distill.py
+++ b/tests/test_distill.py
@@ -93,6 +93,35 @@ class TestBuildRecipe:
         assert step2.arguments["skull_stripped"] is True
         assert recipe.steps[0].produces["brain_path"] == "step1.brain_path"
 
+    def test_inputs_get_usage_descriptions(self) -> None:
+        """Each lifted input is described by the tool/arg that first used it."""
+        recipe = self._recipe()
+        in_1 = next(i for i in recipe.inputs if i.name == "in_1")
+        assert in_1.description == "the input_path for medmcp-neuro:skull_strip"
+
+    def test_drops_rejected_call(self) -> None:
+        """A tool the user rejected is excluded from the recipe."""
+        messages: list[JsonDict] = [
+            _assistant_call("r1", "medmcp-neuro_skull_strip", {"input_path": "data/x/t1.nii.gz"}),
+            _tool_result("r1", "User rejected the tool call, provide an alternative plan"),
+            *_MESSAGES[3:7],  # the two real neuro steps
+        ]
+        recipe = distill.build_recipe(
+            messages, server_names=["medmcp-neuro"], name="t", description="d"
+        )
+        assert [s.tool for s in recipe.steps] == ["skull_strip", "register_to_template"]
+
+    def test_drops_cancelled_call(self) -> None:
+        """A tool call wrapped in the user_cancellation tag is excluded."""
+        messages: list[JsonDict] = [
+            _assistant_call("x1", "medmcp-neuro_skull_strip", {"input_path": "data/a.nii"}),
+            _tool_result("x1", "<user_cancellation>skull_strip</user_cancellation>"),
+        ]
+        recipe = distill.build_recipe(
+            messages, server_names=["medmcp-neuro"], name="t", description="d"
+        )
+        assert recipe.steps == []
+
     def test_drops_readonly_shell_inspection(self) -> None:
         """A bash call running a read-only inspection (ls) is excluded as noise."""
         messages: list[JsonDict] = [

--- a/tests/test_pending_workflow.py
+++ b/tests/test_pending_workflow.py
@@ -1,0 +1,146 @@
+"""Tests for the pending Rename/Refine input routing.
+
+Clicking Rename/Refine arms a pending action in the user session; the user's
+next message is then consumed by ``_consume_pending_workflow_input`` instead of
+being forwarded to the agent. These tests verify that routing without a live
+Chainlit/vibe-acp context by faking the few ``cl`` touchpoints.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import ClassVar
+
+import pytest
+
+import medmcp.app as app
+
+# pyright: reportPrivateUsage=false
+
+
+class _FakeSession:
+    """Minimal stand-in for ``cl.user_session`` backed by a dict."""
+
+    def __init__(self) -> None:
+        self._d: dict[str, object] = {}
+
+    def get(self, key: str, default: object = None) -> object:
+        return self._d.get(key, default)
+
+    def set(self, key: str, value: object) -> None:
+        self._d[key] = value
+
+
+class _FakeMessage:
+    """Captures content of every message ``send()``-ed during a test."""
+
+    sent: ClassVar[list[str]] = []
+
+    def __init__(self, content: str = "", **_: object) -> None:
+        self.content = content
+
+    async def send(self) -> _FakeMessage:
+        _FakeMessage.sent.append(self.content)
+        return self
+
+    async def remove(self) -> None:
+        return None
+
+
+@pytest.fixture
+def session(monkeypatch: pytest.MonkeyPatch) -> _FakeSession:
+    """Patch the cl touchpoints and return the fake user session."""
+    _FakeMessage.sent = []
+    sess = _FakeSession()
+    monkeypatch.setattr(app.cl, "user_session", sess, raising=False)
+    monkeypatch.setattr(app.cl, "Message", _FakeMessage, raising=False)
+
+    previewed: list[Path] = []
+
+    async def fake_preview(draft_dir: Path) -> None:
+        previewed.append(draft_dir)
+
+    monkeypatch.setattr(app, "_send_workflow_preview", fake_preview)
+    sess._d["_previewed"] = previewed  # surface for assertions
+    return sess
+
+
+@pytest.mark.asyncio
+async def test_no_pending_returns_false(session: _FakeSession) -> None:
+    """With nothing armed, the message is not consumed."""
+    assert await app._consume_pending_workflow_input("hello") is False
+
+
+@pytest.mark.asyncio
+async def test_rename_applies_and_previews(
+    session: _FakeSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A pending rename routes the text to rename_draft and re-previews."""
+    calls: list[tuple[str, str]] = []
+
+    def fake_rename(name: str, new_name: str) -> Path:
+        calls.append((name, new_name))
+        return Path("/tmp/draft/new-name")
+
+    monkeypatch.setattr(app.distill, "rename_draft", fake_rename)
+    session.set("pending_workflow", {"action": "rename", "name": "old-name"})
+
+    consumed = await app._consume_pending_workflow_input("New Name")
+
+    assert consumed is True
+    assert calls == [("old-name", "New Name")]
+    assert session.get("pending_workflow") is None  # consumed
+    assert session._d["_previewed"] == [Path("/tmp/draft/new-name")]
+
+
+@pytest.mark.asyncio
+async def test_dash_cancels(session: _FakeSession, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Sending '-' cancels without touching the draft."""
+    called = False
+
+    def fake_rename(name: str, new_name: str) -> Path:
+        nonlocal called
+        called = True
+        return Path("/x")
+
+    monkeypatch.setattr(app.distill, "rename_draft", fake_rename)
+    session.set("pending_workflow", {"action": "rename", "name": "keep-me"})
+
+    assert await app._consume_pending_workflow_input("-") is True
+    assert called is False
+    assert any("cancelled" in m.lower() for m in _FakeMessage.sent)
+
+
+@pytest.mark.asyncio
+async def test_refine_routes_to_refine_draft(
+    session: _FakeSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A pending refine routes the instruction to refine_draft."""
+    calls: list[tuple[str, str]] = []
+
+    def fake_refine(name: str, instruction: str) -> Path:
+        calls.append((name, instruction))
+        return Path("/tmp/draft/flow")
+
+    monkeypatch.setattr(app.distill, "refine_draft", fake_refine)
+    session.set("pending_workflow", {"action": "refine", "name": "flow"})
+
+    assert await app._consume_pending_workflow_input("make it generic") is True
+    assert calls == [("flow", "make it generic")]
+
+
+@pytest.mark.asyncio
+async def test_rename_failure_reports_and_consumes(
+    session: _FakeSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If rename_draft raises, the error is surfaced and the message is consumed."""
+
+    def boom(name: str, new_name: str) -> Path:
+        raise RuntimeError("nope")
+
+    monkeypatch.setattr(app.distill, "rename_draft", boom)
+    session.set("pending_workflow", {"action": "rename", "name": "x"})
+
+    assert await app._consume_pending_workflow_input("y") is True
+    assert any("could not rename" in m.lower() for m in _FakeMessage.sent)
+    assert session.get("pending_workflow") is None

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,240 @@
+"""Tests for Tier-1 provenance capture (manifest, run log, permissions, report)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from medmcp import provenance
+
+SESSION_ID = "abcd1234-1111-2222-3333-444455556666"
+
+
+# ── split_tool_name ──────────────────────────────────────────────────────────
+
+
+class TestSplitToolName:
+    """split_tool_name resolves server/tool from known names or convention."""
+
+    def test_known_server_prefix(self) -> None:
+        """A name matching a known server splits on that prefix."""
+        assert provenance.split_tool_name("medmcp-neuro_skull_strip", ["medmcp-neuro"]) == (
+            "medmcp-neuro",
+            "skull_strip",
+        )
+
+    def test_convention_fallback_without_known_names(self) -> None:
+        """An unknown medmcp-* tool still splits via the naming convention."""
+        assert provenance.split_tool_name("medmcp-dicom_load_series", []) == (
+            "medmcp-dicom",
+            "load_series",
+        )
+
+    def test_builtin_tool(self) -> None:
+        """A bare tool name is attributed to the builtin server."""
+        assert provenance.split_tool_name("bash", ["medmcp-neuro"]) == ("builtin", "bash")
+
+    def test_longest_prefix_wins(self) -> None:
+        """A more specific server name takes precedence over a shorter one."""
+        server, tool = provenance.split_tool_name(
+            "medmcp-neuro-ext_run", ["medmcp-neuro", "medmcp-neuro-ext"]
+        )
+        assert (server, tool) == ("medmcp-neuro-ext", "run")
+
+
+# ── manifest ─────────────────────────────────────────────────────────────────
+
+
+class TestManifest:
+    """write_manifest captures and round-trips the session environment."""
+
+    def test_write_and_read_round_trip(self, tmp_path: Path) -> None:
+        """A written manifest reads back with stacks and model populated."""
+        servers = [{"name": "medmcp-neuro", "version": "0.2.0", "command": "/x/bin/neuro"}]
+        with patch.object(provenance, "VIBE_HOME", tmp_path):
+            path = provenance.write_manifest(
+                SESSION_ID, servers=servers, model_name="gemma4-medmcp"
+            )
+            assert path.exists()
+            manifest = provenance.read_manifest(SESSION_ID)
+
+        assert manifest is not None
+        assert manifest["session_id"] == SESSION_ID
+        assert manifest["stacks"][0]["version"] == "0.2.0"
+        assert manifest["model"]["name"] == "gemma4-medmcp"
+        assert "python" in manifest["platform"]
+
+    def test_model_params_pulled_from_config(self, tmp_path: Path) -> None:
+        """Model temperature/thinking are pulled from config.toml by alias."""
+        (tmp_path / "config.toml").write_text(
+            '[[models]]\nname = "gemma4-medmcp"\nalias = "local"\n'
+            'temperature = 1.0\nthinking = "medium"\ninput_price = 0.0\n'
+        )
+        with patch.object(provenance, "VIBE_HOME", tmp_path):
+            provenance.write_manifest(SESSION_ID, servers=[], model_name="local")
+            manifest = provenance.read_manifest(SESSION_ID)
+
+        assert manifest is not None
+        assert manifest["model"]["thinking"] == "medium"
+        # Price fields are intentionally dropped from the manifest.
+        assert "input_price" not in manifest["model"]
+
+    def test_read_missing_returns_none(self, tmp_path: Path) -> None:
+        """Reading a manifest that was never written returns None."""
+        with patch.object(provenance, "VIBE_HOME", tmp_path):
+            assert provenance.read_manifest(SESSION_ID) is None
+
+
+# ── run log ──────────────────────────────────────────────────────────────────
+
+
+class TestRunLog:
+    """append_run_event / read_run_events / normalize_tool_event."""
+
+    def test_normalize_includes_optional_fields(self) -> None:
+        """Optional fields appear only when provided."""
+        event = provenance.normalize_tool_event(
+            tool_call_id="call_1",
+            title="Skull strip",
+            server="medmcp-neuro",
+            tool="skull_strip",
+            raw_input={"device": "cuda"},
+            raw_output=None,
+            output_text="ok",
+            status="completed",
+            decision="allow",
+            risks=["file_write"],
+            human_readable="Removes the skull.",
+            duration_sec=1.2345,
+        )
+        assert event["server"] == "medmcp-neuro"
+        assert event["arguments"] == {"device": "cuda"}
+        assert event["output_text"] == "ok"
+        assert event["permission_decision"] == "allow"
+        assert event["risks"] == ["file_write"]
+        assert event["duration_sec"] == 1.234
+
+    def test_append_and_read(self, tmp_path: Path) -> None:
+        """Appended events are read back in order with a timestamp added."""
+        with patch.object(provenance, "VIBE_HOME", tmp_path):
+            provenance.append_run_event(SESSION_ID, {"tool": "a", "status": "completed"})
+            provenance.append_run_event(SESSION_ID, {"tool": "b", "status": "failed"})
+            events = provenance.read_run_events(SESSION_ID)
+
+        assert [e["tool"] for e in events] == ["a", "b"]
+        assert all("ts" in e for e in events)
+
+    def test_read_skips_corrupt_lines(self, tmp_path: Path) -> None:
+        """A malformed JSONL line is skipped, not fatal."""
+        with patch.object(provenance, "VIBE_HOME", tmp_path):
+            provenance.append_run_event(SESSION_ID, {"tool": "a"})
+            run_path = provenance.provenance_dir(SESSION_ID) / "run.jsonl"
+            with run_path.open("a") as f:
+                f.write("{not json\n")
+            provenance.append_run_event(SESSION_ID, {"tool": "b"})
+            events = provenance.read_run_events(SESSION_ID)
+
+        assert [e["tool"] for e in events] == ["a", "b"]
+
+
+# ── permissions ──────────────────────────────────────────────────────────────
+
+
+def test_log_permission_appends_lines(tmp_path: Path) -> None:
+    """Permission decisions are appended as tab-separated lines."""
+    with patch.object(provenance, "VIBE_HOME", tmp_path):
+        provenance.log_permission(SESSION_ID, title="bash: rm", decision="reject")
+        provenance.log_permission(SESSION_ID, title="bash: ls", decision="allow")
+        log = (provenance.provenance_dir(SESSION_ID) / "permissions.log").read_text()
+
+    lines = log.strip().splitlines()
+    assert len(lines) == 2
+    assert "\treject\tbash: rm" in lines[0]
+    assert "\tallow\tbash: ls" in lines[1]
+
+
+# ── vibe session lookup ──────────────────────────────────────────────────────
+
+
+def test_find_vibe_session_dir(tmp_path: Path) -> None:
+    """The session dir is located by id prefix and confirmed via meta.json."""
+    sess_dir = tmp_path / "logs" / "session" / "session_20260101_000000_abcd1234"
+    sess_dir.mkdir(parents=True)
+    (sess_dir / "meta.json").write_text(json.dumps({"session_id": SESSION_ID}))
+    with patch.object(provenance, "VIBE_HOME", tmp_path):
+        found = provenance.find_vibe_session_dir(SESSION_ID)
+    assert found == sess_dir
+
+
+def test_find_vibe_session_dir_missing(tmp_path: Path) -> None:
+    """A session with no log dir resolves to None."""
+    (tmp_path / "logs" / "session").mkdir(parents=True)
+    with patch.object(provenance, "VIBE_HOME", tmp_path):
+        assert provenance.find_vibe_session_dir(SESSION_ID) is None
+
+
+def test_purge_session_removes_provenance_and_vibe_logs(tmp_path: Path) -> None:
+    """purge_session deletes both the provenance dir and the vibe transcript dir."""
+    vibe_dir = tmp_path / "logs" / "session" / "session_20260101_000000_abcd1234"
+    vibe_dir.mkdir(parents=True)
+    (vibe_dir / "meta.json").write_text(json.dumps({"session_id": SESSION_ID}))
+    with patch.object(provenance, "VIBE_HOME", tmp_path):
+        provenance.append_run_event(SESSION_ID, {"tool": "a"})
+        prov_dir = provenance.provenance_dir(SESSION_ID)
+        assert prov_dir.exists()
+
+        provenance.purge_session(SESSION_ID)
+
+        assert not prov_dir.exists()
+        assert not vibe_dir.exists()
+
+
+def test_purge_session_is_safe_when_absent(tmp_path: Path) -> None:
+    """Purging a session with nothing on disk does not raise."""
+    (tmp_path / "logs" / "session").mkdir(parents=True)
+    with patch.object(provenance, "VIBE_HOME", tmp_path):
+        provenance.purge_session(SESSION_ID)  # no error
+
+
+# ── report ───────────────────────────────────────────────────────────────────
+
+
+class TestReport:
+    """render_report / write_report build a documentation-grade summary."""
+
+    def test_render_includes_env_and_steps(self, tmp_path: Path) -> None:
+        """The report shows the model, stacks, and each recorded tool call."""
+        servers = [{"name": "medmcp-neuro", "version": "0.2.0", "command": "/x"}]
+        with patch.object(provenance, "VIBE_HOME", tmp_path):
+            provenance.write_manifest(SESSION_ID, servers=servers, model_name="gemma4-medmcp")
+            provenance.append_run_event(
+                SESSION_ID,
+                {
+                    "server": "medmcp-neuro",
+                    "tool": "skull_strip",
+                    "status": "completed",
+                    "permission_decision": "allow",
+                    "arguments": {"device": "cuda"},
+                    "output": "structured: {'brain_path': 'data/x/brain.nii.gz'}",
+                },
+            )
+            report = provenance.render_report(SESSION_ID)
+
+        assert "gemma4-medmcp" in report
+        assert "medmcp-neuro 0.2.0" in report
+        assert "`medmcp-neuro:skull_strip` — completed" in report
+        assert "decision: allow" in report
+        assert "data/x/brain.nii.gz" in report
+
+    def test_write_report_returns_none_when_empty(self, tmp_path: Path) -> None:
+        """No manifest and no events → no report file is written."""
+        with patch.object(provenance, "VIBE_HOME", tmp_path):
+            assert provenance.write_report(SESSION_ID) is None
+
+    def test_write_report_creates_file(self, tmp_path: Path) -> None:
+        """With provenance present, report.md is written to the session dir."""
+        with patch.object(provenance, "VIBE_HOME", tmp_path):
+            provenance.append_run_event(SESSION_ID, {"server": "builtin", "tool": "bash"})
+            path = provenance.write_report(SESSION_ID)
+        assert path is not None and path.name == "report.md" and path.exists()

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -197,6 +197,42 @@ def test_purge_session_is_safe_when_absent(tmp_path: Path) -> None:
         provenance.purge_session(SESSION_ID)  # no error
 
 
+# ── orphan GC ────────────────────────────────────────────────────────────────
+
+
+def test_purge_orphans_removes_unreferenced_only(tmp_path: Path) -> None:
+    """purge_orphans deletes provenance dirs whose id is not referenced."""
+    with patch.object(provenance, "VIBE_HOME", tmp_path):
+        provenance.append_run_event("keep-1", {"tool": "a"})
+        provenance.append_run_event("drop-1", {"tool": "b"})
+        provenance.append_run_event("drop-2", {"tool": "c"})
+
+        purged = provenance.purge_orphans({"keep-1"})
+
+        assert sorted(purged) == ["drop-1", "drop-2"]
+        assert provenance.provenance_dir("keep-1").exists()
+        assert not provenance.provenance_dir("drop-1").exists()
+        assert not provenance.provenance_dir("drop-2").exists()
+
+
+def test_purge_orphans_leaves_vibe_transcripts(tmp_path: Path) -> None:
+    """purge_orphans never touches vibe transcript dirs, only provenance."""
+    vibe_dir = tmp_path / "logs" / "session" / "session_20260101_000000_abcd1234"
+    vibe_dir.mkdir(parents=True)
+    (vibe_dir / "meta.json").write_text(json.dumps({"session_id": SESSION_ID}))
+    with patch.object(provenance, "VIBE_HOME", tmp_path):
+        provenance.append_run_event(SESSION_ID, {"tool": "a"})
+        provenance.purge_orphans(set())  # nothing referenced
+        assert not provenance.provenance_dir(SESSION_ID).exists()
+        assert vibe_dir.exists()
+
+
+def test_purge_orphans_empty_when_no_records(tmp_path: Path) -> None:
+    """With no provenance directory at all, purge_orphans is a no-op."""
+    with patch.object(provenance, "VIBE_HOME", tmp_path):
+        assert provenance.purge_orphans(set()) == []
+
+
 # ── report ───────────────────────────────────────────────────────────────────
 
 

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -1,0 +1,267 @@
+"""Tests for the deterministic workflow replay engine."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import mcp.types as mcp_types
+import pytest
+
+from medmcp import replay
+from medmcp.workflow import Recipe, RecipeStep, WorkflowInput
+
+# pyright: reportPrivateUsage=false
+
+JsonDict = dict[str, Any]
+
+
+# ── placeholder resolution ────────────────────────────────────────────────────
+
+
+class TestResolveValue:
+    """resolve_value substitutes {{ref}} placeholders, preserving types."""
+
+    def test_exact_match_preserves_type(self) -> None:
+        """A whole-string placeholder yields the bound value with its type."""
+        assert replay.resolve_value("{{in_1}}", {"in_1": "/data/x.nii"}) == "/data/x.nii"
+        assert replay.resolve_value("{{n}}", {"n": 5}) == 5
+        assert replay.resolve_value("{{flag}}", {"flag": True}) is True
+
+    def test_embedded_substitutes_as_text(self) -> None:
+        """A placeholder inside a larger string is replaced as text."""
+        assert replay.resolve_value("--out {{step1.path}}", {"step1.path": "/o"}) == "--out /o"
+
+    def test_unknown_ref_left_verbatim(self) -> None:
+        """An unbound ref is left untouched so callers can detect it."""
+        assert replay.resolve_value("{{missing}}", {}) == "{{missing}}"
+
+    def test_recurses_into_dict_and_list(self) -> None:
+        """Nested structures are resolved element-by-element."""
+        out = replay.resolve_value(
+            {"a": "{{in_1}}", "b": ["{{in_2}}", "lit"]}, {"in_1": "X", "in_2": "Y"}
+        )
+        assert out == {"a": "X", "b": ["Y", "lit"]}
+
+    def test_non_string_passthrough(self) -> None:
+        """Non-placeholder scalars pass through unchanged."""
+        assert replay.resolve_value(42, {}) == 42
+
+
+def test_resolve_arguments() -> None:
+    """resolve_arguments resolves each value against the bindings."""
+    args = {"input_path": "{{in_1}}", "device": "cuda", "n": "{{k}}"}
+    assert replay.resolve_arguments(args, {"in_1": "/p", "k": 3}) == {
+        "input_path": "/p",
+        "device": "cuda",
+        "n": 3,
+    }
+
+
+def test_unresolved_refs() -> None:
+    """unresolved_refs reports placeholders still present anywhere in a value."""
+    assert replay.unresolved_refs({"a": "{{x}}", "b": ["lit", "{{y}}"]}) == {"x", "y"}
+    assert replay.unresolved_refs({"a": "done"}) == set()
+
+
+# ── tool-result interpretation ────────────────────────────────────────────────
+
+
+def _result(
+    *, text: str = "", structured: JsonDict | None = None, is_error: bool = False
+) -> mcp_types.CallToolResult:
+    content: list[mcp_types.ContentBlock] = []
+    if text:
+        content.append(mcp_types.TextContent(type="text", text=text))
+    return mcp_types.CallToolResult(content=content, structuredContent=structured, isError=is_error)
+
+
+class TestExtractStructured:
+    """extract_structured prefers structuredContent, falls back to text parsing."""
+
+    def test_prefers_structured_content(self) -> None:
+        """A protocol structuredContent dict is returned directly."""
+        res = _result(structured={"brain_path": "/b.nii"})
+        assert replay.extract_structured(res) == {"brain_path": "/b.nii"}
+
+    def test_parses_json_text(self) -> None:
+        """A JSON dict text block (FastMCP's default) is parsed."""
+        res = _result(text='{"brain_path": "/b.nii", "device": "cuda"}')
+        assert replay.extract_structured(res) == {"brain_path": "/b.nii", "device": "cuda"}
+
+    def test_unwraps_result_envelope(self) -> None:
+        """A lone {'result': {...}} structuredContent envelope is unwrapped."""
+        res = _result(structured={"result": {"brain_path": "/b.nii"}})
+        assert replay.extract_structured(res) == {"brain_path": "/b.nii"}
+
+    def test_falls_back_to_text_blob(self) -> None:
+        """A 'structured: {...}' text blob is parsed when no JSON/structuredContent."""
+        res = _result(text="ok: True\nstructured: {'brain_path': '/b.nii'}")
+        assert replay.extract_structured(res) == {"brain_path": "/b.nii"}
+
+    def test_empty_when_nothing_parseable(self) -> None:
+        """Plain text with no structured blob yields an empty dict."""
+        assert replay.extract_structured(_result(text="done")) == {}
+
+
+class TestResultFailed:
+    """_result_failed flags protocol errors and known failure markers."""
+
+    def test_protocol_error_flag(self) -> None:
+        """The MCP isError flag marks a failure."""
+        assert replay._result_failed(_result(is_error=True)) is True
+
+    def test_ok_false_marker(self) -> None:
+        """An 'ok: False' marker in the text marks a failure."""
+        assert replay._result_failed(_result(text="ok: False")) is True
+
+    def test_returncode_marker(self) -> None:
+        """A 'returncode: 1' marker in the text marks a failure."""
+        assert replay._result_failed(_result(text="returncode: 1")) is True
+
+    def test_success(self) -> None:
+        """A clean 'ok: True' result is not a failure."""
+        assert replay._result_failed(_result(text="ok: True")) is False
+
+
+# ── validation ────────────────────────────────────────────────────────────────
+
+_SERVERS: list[JsonDict] = [{"name": "medmcp-neuro", "command": "neuro", "args": []}]
+
+
+def _recipe(steps: list[RecipeStep], inputs: list[WorkflowInput] | None = None) -> Recipe:
+    return Recipe(name="wf", description="d", inputs=inputs or [], steps=steps)
+
+
+class TestValidate:
+    """validate catches anything that would make a replay impossible."""
+
+    def test_ok(self) -> None:
+        """A recipe with all inputs and an installed stack validates clean."""
+        recipe = _recipe(
+            [RecipeStep(server="medmcp-neuro", tool="skull_strip", arguments={"p": "{{in_1}}"})],
+            inputs=[WorkflowInput(name="in_1", example="/x.nii")],
+        )
+        assert replay.validate(recipe, {"in_1": "/y.nii"}, _SERVERS) is None
+
+    def test_missing_input(self) -> None:
+        """A declared input with no supplied value is reported."""
+        recipe = _recipe(
+            [RecipeStep(server="medmcp-neuro", tool="t", arguments={})],
+            inputs=[WorkflowInput(name="in_1", example="/x")],
+        )
+        msg = replay.validate(recipe, {}, _SERVERS)
+        assert msg is not None and "in_1" in msg
+
+    def test_builtin_step_rejected(self) -> None:
+        """A builtin (non-MCP) step makes the recipe non-replayable."""
+        recipe = _recipe([RecipeStep(server="builtin", tool="bash", arguments={})])
+        msg = replay.validate(recipe, {}, _SERVERS)
+        assert msg is not None and "built-in" in msg
+
+    def test_missing_stack(self) -> None:
+        """A step needing an uninstalled stack is reported."""
+        recipe = _recipe([RecipeStep(server="medmcp-cardiac", tool="t", arguments={})])
+        msg = replay.validate(recipe, {}, _SERVERS)
+        assert msg is not None and "medmcp-cardiac" in msg
+
+    def test_no_steps(self) -> None:
+        """A recipe with no steps has nothing to replay."""
+        msg = replay.validate(_recipe([]), {}, _SERVERS)
+        assert msg is not None and "no replayable steps" in msg
+
+
+# ── execution / chaining ──────────────────────────────────────────────────────
+
+
+def _two_step_recipe() -> Recipe:
+    return _recipe(
+        [
+            RecipeStep(
+                server="medmcp-neuro",
+                tool="skull_strip",
+                arguments={"input_path": "{{in_1}}", "device": "cuda"},
+                produces={"brain_path": "step1.brain_path"},
+            ),
+            RecipeStep(
+                server="medmcp-neuro",
+                tool="register_to_template",
+                arguments={"input_path": "{{step1.brain_path}}"},
+                produces={"registered_path": "step2.registered_path"},
+            ),
+        ],
+        inputs=[WorkflowInput(name="in_1", example="/orig.nii")],
+    )
+
+
+@pytest.mark.asyncio
+async def test_replay_chains_outputs_to_later_steps() -> None:
+    """A produced output is bound and substituted into a later step's argument."""
+    calls: list[tuple[str, str, JsonDict]] = []
+
+    async def caller(server: str, tool: str, args: JsonDict) -> tuple[bool, JsonDict, str | None]:
+        calls.append((server, tool, args))
+        if tool == "skull_strip":
+            return True, {"brain_path": "/new_brain.nii"}, None
+        return True, {"registered_path": "/new_mni.nii"}, None
+
+    result = await replay.replay_with_caller(
+        _two_step_recipe(), {"in_1": "/new.nii"}, caller=caller
+    )
+
+    assert result.ok is True
+    assert calls[0][2]["input_path"] == "/new.nii"  # in_1 bound
+    assert calls[1][2]["input_path"] == "/new_brain.nii"  # step1 output fed forward
+    assert result.steps[1].produced == {"step2.registered_path": "/new_mni.nii"}
+
+
+@pytest.mark.asyncio
+async def test_replay_aborts_on_failed_step() -> None:
+    """A failed step stops the run; later steps never execute."""
+    calls: list[str] = []
+
+    async def caller(server: str, tool: str, args: JsonDict) -> tuple[bool, JsonDict, str | None]:
+        calls.append(tool)
+        return False, {}, "boom"
+
+    result = await replay.replay_with_caller(
+        _two_step_recipe(), {"in_1": "/new.nii"}, caller=caller
+    )
+
+    assert result.ok is False
+    assert calls == ["skull_strip"]  # second step never ran
+    assert result.steps[0].ok is False
+    assert "boom" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_replay_aborts_on_unresolved_placeholder() -> None:
+    """A step whose output never arrived leaves a later ref unresolved → abort."""
+
+    async def caller(server: str, tool: str, args: JsonDict) -> tuple[bool, JsonDict, str | None]:
+        # skull_strip succeeds but produces nothing, so {{step1.brain_path}} stays unbound.
+        return True, {}, None
+
+    result = await replay.replay_with_caller(
+        _two_step_recipe(), {"in_1": "/new.nii"}, caller=caller
+    )
+
+    assert result.ok is False
+    assert result.steps[1].ok is False
+    assert "unresolved" in (result.steps[1].error or "")
+
+
+@pytest.mark.asyncio
+async def test_on_step_callback_invoked_per_step() -> None:
+    """on_step fires once per executed step."""
+    seen: list[int] = []
+
+    async def caller(server: str, tool: str, args: JsonDict) -> tuple[bool, JsonDict, str | None]:
+        return True, {"brain_path": "/b", "registered_path": "/r"}, None
+
+    async def on_step(sr: replay.StepResult) -> None:
+        seen.append(sr.index)
+
+    await replay.replay_with_caller(
+        _two_step_recipe(), {"in_1": "/x"}, caller=caller, on_step=on_step
+    )
+    assert seen == [1, 2]

--- a/tests/test_workflow_command.py
+++ b/tests/test_workflow_command.py
@@ -1,0 +1,20 @@
+"""Tests for the 'Save workflow' composer command definition."""
+
+from __future__ import annotations
+
+from medmcp.app import (
+    MANAGE_WORKFLOWS_COMMAND,
+    SAVE_WORKFLOW_COMMAND,
+    _workflow_commands,  # pyright: ignore[reportPrivateUsage]
+)
+
+
+def test_workflow_command_shape() -> None:
+    """The composer exposes Save and Manage buttons with the expected ids."""
+    commands = _workflow_commands()
+    assert [c["id"] for c in commands] == [SAVE_WORKFLOW_COMMAND, MANAGE_WORKFLOWS_COMMAND]
+    for cmd in commands:
+        assert cmd["button"] is True
+        # Not persistent: one-shot actions, not sticky modes.
+        assert cmd["persistent"] is False
+        assert cmd["description"]

--- a/uv.lock
+++ b/uv.lock
@@ -1287,6 +1287,7 @@ dependencies = [
     { name = "aiosqlite" },
     { name = "chainlit" },
     { name = "mistral-vibe" },
+    { name = "pyyaml" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "tomli-w" },
 ]
@@ -1298,11 +1299,13 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
+    { name = "types-pyyaml" },
 ]
 quality = [
     { name = "pre-commit" },
     { name = "pyright" },
     { name = "ruff" },
+    { name = "types-pyyaml" },
 ]
 test = [
     { name = "pytest" },
@@ -1314,6 +1317,7 @@ requires-dist = [
     { name = "aiosqlite", specifier = ">=0.20" },
     { name = "chainlit", specifier = ">=2.11.1,<3" },
     { name = "mistral-vibe", specifier = ">=2.8.1,<3" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.49,<3" },
     { name = "tomli-w", specifier = ">=1.0" },
 ]
@@ -1325,11 +1329,13 @@ dev = [
     { name = "pytest", specifier = ">=9" },
     { name = "pytest-asyncio", specifier = ">=1.2" },
     { name = "ruff", specifier = ">=0.15.11" },
+    { name = "types-pyyaml", specifier = ">=6.0" },
 ]
 quality = [
     { name = "pre-commit", specifier = ">=4.6.0" },
     { name = "pyright", specifier = ">=1.1.400" },
     { name = "ruff", specifier = ">=0.15.11" },
+    { name = "types-pyyaml", specifier = ">=6.0" },
 ]
 test = [
     { name = "pytest", specifier = ">=9" },
@@ -3289,6 +3295,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/a0/c3050a6277dfcac8c480f514dc4fe49f3f65f0eac68b4702cbaca2584e85/tree_sitter_bash-0.25.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a3332d71c7b7d5f78259b19d02d0ea111fcb82b72712ee4a93aaa5b226d3f0a8", size = 230074, upload-time = "2025-12-02T17:01:05.05Z" },
     { url = "https://files.pythonhosted.org/packages/71/0f/203fe6b27211387f4b9ba8c4a321567ca4ded2624dae6ccdbd2b6e940e17/tree_sitter_bash-0.25.1-cp310-abi3-win_amd64.whl", hash = "sha256:52a6802d9218f86278aa3e8b459c3abdad67eed0fde1f9f13aca5b6c634217a6", size = 195574, upload-time = "2025-12-02T17:01:06.412Z" },
     { url = "https://files.pythonhosted.org/packages/47/75/4ca1a9fabd8fb5aea78cea70f7837ce4dbf2afae115f62051e5fa99cba1c/tree_sitter_bash-0.25.1-cp310-abi3-win_arm64.whl", hash = "sha256:59115057ec2bae319e8082ff29559861045002964c3431ccb0fc92aa4bc9bccb", size = 191196, upload-time = "2025-12-02T17:01:07.486Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/83/4a1afc3fbfcf5b8d46fc390cd95ed6b0dc9010a265f4e9f46314efffa37a/types_pyyaml-6.0.12.20260518.tar.gz", hash = "sha256:d917f83fb38462550338c1297faedd860b3ec83912b96b1e3d73255f7473e466", size = 17850, upload-time = "2026-05-18T06:01:58.675Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl", hash = "sha256:d2150f75a231c9fe9c7463bd29487d93e60bac90400287351384bc2284eba7cd", size = 20312, upload-time = "2026-05-18T06:01:57.368Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Adds a three-tier system for recording what a chat session did, distilling it into a reusable workflow, and replaying that workflow deterministically on new data — plus the logging/cleanup and UI plumbing to manage it safely.

## Related issue
N/A

## Test plan
- [ ] `just check` is green (lint + format-check + typecheck + tests)
- [ ] Run a chat with tool calls, confirm `.vibe/provenance/<session_id>/` gets
  `manifest.json`, `run.jsonl`, and `permissions.log`
- [ ] `just report <session>` renders a readable `report.md`
- [ ] `just distill <session>` produces `recipe.yaml` + `SKILL.md` under
  `.vibe/workflows/draft/`; `--no-llm` falls back to mechanical prose
- [ ] `just promote <name>` moves the draft into `active/` and it loads as a skill
- [ ] Workflow manager **Run** button replays a recipe on new inputs with the
  resolved-steps preview + confirmation
- [ ] Delete a chat in the UI → both provenance dir and vibe transcript are
  purged; a live chat's logs are never touched
- [ ] Toggle "Record provenance" and the workflows master switch off → capture
  stops and composer buttons/Workflows tab disappear

## Screenshots
  N/A

## Security & data handling
  - **New file-write paths:** `.vibe/provenance/` and `.vibe/workflows/` (both
  gitignored). `permissions.log` is a persisted mirror of the `medmcp.audit` stderr
  trail — the stderr handler is unchanged and the audit logger is not silenced.
  - **New network calls:** distillation/explanation POST to the local Ollama
  `/api/chat` only; no new external endpoints.
  - **Replay bypasses the permission flow:** `replay.py` calls MCP tools directly
  (no vibe-acp, no Approve/Reject gate), so the UI confirms with the user and
  previews resolved steps before any run. No auto-approval path was added to the
  normal chat flow.
  - **Patient data:** provenance records resolved tool arguments (which can include
  file paths to imaging data). All state stays local under `.vibe/` and is purged on
  chat delete.

  ## Notes
  - New dependency: `pyyaml` (recipe serialization).
  - New `medmcp` console script (`provcli.py`) alongside the existing `medmcp-ui`
  launcher.
  - Known limitation: vibe-acp regenerates `session_id` on compaction and writes
  continuation transcripts to a new dir with no backlink, so a post-compaction
  transcript can't be located on delete and is left behind; distillation is likewise
  limited to pre-compaction messages.
