### PR TITLE
Deploy compose for running the published GHCR images

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Once installed, the stack is auto-discovered via its `[medmcp.stacks]` entry poi
 **Private images (GHCR).** CI (`.github/workflows/images.yml`) builds and pushes the base, core, and stack images to the **private** registry `ghcr.io/medmcp/*` (packages are private by default; the base package must grant the stack repos read access). For a private fleet:
 
 1. `docker login ghcr.io` on each node (a `read:packages` token); compose mounts the host's docker credentials so the in-UI install can pull.
-2. Point the catalog at the published images: `MEDMCP_CATALOG_URL=/app/catalog.ghcr.json` (bundled), or your own catalog of `ghcr.io/medmcp/*:<sha>` refs.
+2. Run the **published** images (pulls the core, builds nothing) with the deploy compose — `just compose-up-ghcr`, i.e. `docker compose -f docker-compose.ghcr.yml up -d`. It defaults `MEDMCP_CATALOG_URL` to the bundled `/app/catalog.ghcr.json`; pin a release with `MEDMCP_TAG=<git-sha>`. A node needs only this file + `Modelfile.gemma4`.
 
 Air-gapped sites mirror the images into an internal registry and point the catalog there instead. No image data leaves the machine either way — these are inbound pulls.
 

--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -1,0 +1,68 @@
+# Deployment compose: runs the PUBLISHED images from the private GHCR — builds
+# nothing. For nodes that only pull (no source checkout). Self-contained; run it
+# on its own (not merged with docker-compose.yml):
+#
+#   docker login ghcr.io                       # read:packages token
+#   MEDMCP_WORKSPACE=/abs/path \
+#     docker compose -f docker-compose.ghcr.yml up -d
+#
+# (or `just compose-up-ghcr`). Pin a release with MEDMCP_TAG=<git-sha> (default
+# :main). A node needs this file + Modelfile.gemma4 (for the one-time model build);
+# everything else is pulled. GPU uses CDI (rootless); rootful hosts set the docker
+# socket path to /var/run.
+name: medmcp
+
+services:
+  llm:
+    image: ${OLLAMA_IMAGE:-ollama/ollama:latest}
+    devices:
+      - "nvidia.com/gpu=all"
+    volumes:
+      - "${OLLAMA_MODELS_DIR:-ollama-models}:/root/.ollama"
+    healthcheck:
+      test: ["CMD", "ollama", "list"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+    restart: unless-stopped
+
+  llm-init:
+    image: ${OLLAMA_IMAGE:-ollama/ollama:latest}
+    depends_on:
+      llm:
+        condition: service_healthy
+    environment:
+      OLLAMA_HOST: "http://llm:11434"
+    volumes:
+      - "./Modelfile.gemma4:/Modelfile.gemma4:ro"
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - 'ollama list | grep -q gemma4-medmcp || { ollama pull gemma4:26b && ollama create gemma4-medmcp -f /Modelfile.gemma4; }'
+    restart: "no"
+
+  medmcp:
+    image: ghcr.io/medmcp/core:${MEDMCP_TAG:-main}
+    pull_policy: always
+    depends_on:
+      llm:
+        condition: service_healthy
+      llm-init:
+        condition: service_completed_successfully
+    environment:
+      OLLAMA_BASE_URL: "http://llm:11434"
+      MEDMCP_WORKSPACE: "${MEDMCP_WORKSPACE:?set MEDMCP_WORKSPACE to an absolute host path}"
+      # Default to the GHCR catalog baked into the core image.
+      MEDMCP_CATALOG_URL: "${MEDMCP_CATALOG_URL:-/app/catalog.ghcr.json}"
+    ports:
+      - "127.0.0.1:8100:8100"
+    volumes:
+      # Rootless docker socket → core spawns sibling stack containers.
+      - "${XDG_RUNTIME_DIR}/docker.sock:/var/run/docker.sock"
+      # Workspace at an identical absolute path (path parity for nested run -v).
+      - "${MEDMCP_WORKSPACE}:${MEDMCP_WORKSPACE}"
+      # Host registry credentials (read-only) so the install flow can pull private images.
+      - "${HOME}/.docker/config.json:/root/.docker/config.json:ro"
+    restart: unless-stopped
+
+volumes:
+  ollama-models:

--- a/justfile
+++ b/justfile
@@ -198,6 +198,13 @@ compose-up:
     OLLAMA_MODELS_DIR="${OLLAMA_MODELS_DIR:-$HOME/.ollama}" \
     docker compose up -d --build
 
+# Bring up the stack from the PUBLISHED GHCR images (pulls core, builds nothing).
+# Run `docker login ghcr.io` first. Pin a release with MEDMCP_TAG=<git-sha>.
+compose-up-ghcr:
+    MEDMCP_WORKSPACE="${MEDMCP_WORKSPACE:-$(pwd)/data}" \
+    OLLAMA_MODELS_DIR="${OLLAMA_MODELS_DIR:-$HOME/.ollama}" \
+    docker compose -f docker-compose.ghcr.yml up -d --pull always
+
 # Tear down the stack.
 compose-down:
     MEDMCP_WORKSPACE="${MEDMCP_WORKSPACE:-$(pwd)/data}" docker compose down


### PR DESCRIPTION
## Summary

Add a standalone deployment compose (`docker-compose.ghcr.yml`) that runs the **published** private GHCR images — pulls `ghcr.io/medmcp/core` and builds nothing — for nodes with no source checkout. Closes the gap where the only way to run the core was a local build.

## Related issue

N/A

## Test plan

- [x] `docker compose -f docker-compose.ghcr.yml config` valid; `medmcp` resolves to `image: ghcr.io/medmcp/core:main`, `pull_policy: always`, `MEDMCP_CATALOG_URL=/app/catalog.ghcr.json`, and no `build:`
- [ ] Full pull-only bring-up on a node (`docker login ghcr.io` → `just compose-up-ghcr` → install a stack from the catalog) — pending a `read:packages` docker login

## Screenshots

N/A

## Security & data handling

- Same posture as the dev compose: localhost-only port publish, rootless docker-socket mount (unprivileged), host docker credentials mounted read-only for private pulls. No new surface.

## Notes

- Standalone (not a `-f` override) to avoid Compose's `!reset` custom tag, which the `check-yaml` pre-commit hook can't parse — and so a node needs only this file + `Modelfile.gemma4`.
- `just compose-up-ghcr` wraps it; `MEDMCP_TAG=<git-sha>` pins a release instead of `:main`.
