### PR TITLE
feat: proxy- and rootful-friendly deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,11 @@ MEDMCP_WORKSPACE=/abs/path/to/workspace
 
 # Base image the core/stack builds derive from (default: medmcp-base:dev).
 # MEDMCP_BASE_IMAGE=ghcr.io/medmcp/base:dev
+
+# Docker socket the core mounts to launch sibling stack containers. Defaults to
+# the rootless path ${XDG_RUNTIME_DIR}/docker.sock. On ROOTFUL Docker, set:
+# MEDMCP_DOCKER_SOCK=/var/run/docker.sock
+
+# Behind a TLS-intercepting proxy, add `-f docker-compose.proxy.yml` and point
+# this at a CA bundle that trusts your proxy (the host bundle usually does):
+# MEDMCP_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ MedMCP runs entirely on-premise and is designed to meet the data governance and 
 
 - **OS:** Linux (tested on Ubuntu)
 - **Hardware:** an NVIDIA GPU; ≥ 24 GB VRAM recommended for the local Gemma 4 26B model (~18 GB loaded). CPU-only inference works but is slow.
-- **To run (recommended):** Docker (rootless is supported) + the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/) with a CDI spec (`nvidia-ctk cdi generate`); host driver ≥ R570 (CUDA 12.8); and access to the private image registry — `docker login ghcr.io` with a `read:packages` token.
+- **To run (recommended):** Docker (rootless is supported) + the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/) with a CDI spec (`sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml`) and CDI enabled in the daemon (`"features": { "cdi": true }` in `/etc/docker/daemon.json`, then restart Docker) so `nvidia.com/gpu=all` resolves; host driver ≥ R570 (CUDA 12.8); and access to the private image registry — `docker login ghcr.io` with a `read:packages` token. On rootful Docker, set `MEDMCP_DOCKER_SOCK=/var/run/docker.sock`. Behind a corporate proxy, see [Running behind a proxy](#running-behind-a-proxy).
 - **To develop (build from source):** [uv](https://docs.astral.sh/uv/) and [just](https://github.com/casey/just) (we recommend `uv tool install rust-just`); Node 24 for the frontend.
 
 ### Run with Docker (recommended)
@@ -85,6 +85,46 @@ explorer, medical-image viewer, workflows, chat). See [Workspace UI](#workspace-
 
 > **Developing MedMCP?** The recommended setup is the **dev container** (PyCharm or
 > VS Code) — see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+### Running behind a proxy
+
+Corporate proxies touch MedMCP at three independent layers — configuring only one
+is the usual cause of `TLS handshake timeout` or `certificate signed by unknown
+authority` during install:
+
+1. **Docker daemon** (pulls the MedMCP/Ollama images). The daemon does *not* read
+   your shell's proxy vars — configure it explicitly, e.g. a systemd drop-in
+   `/etc/systemd/system/docker.service.d/http-proxy.conf` with
+   `Environment="HTTPS_PROXY=http://user:pass@proxy:port"` then
+   `systemctl daemon-reload && systemctl restart docker`. (In a systemd unit, a
+   literal `%` in the password must be escaped as `%%`.)
+
+2. **Containers** (the first-run `ollama pull` of `gemma4:26b` reaches out to
+   `registry.ollama.ai`). Set proxy env for containers via `~/.docker/config.json`
+   `"proxies"`, and **add the compose service names to `noProxy`** so
+   container-to-container calls don't get sent to the proxy:
+
+   ```json
+   { "proxies": { "default": {
+       "httpProxy":  "http://user:pass@proxy:port",
+       "httpsProxy": "http://user:pass@proxy:port",
+       "noProxy": "localhost,127.0.0.1,llm,llm-init,medmcp"
+   } } }
+   ```
+
+3. **TLS interception (MITM).** If the proxy re-signs TLS, add the proxy overlay so
+   containers trust its CA — point `MEDMCP_CA_BUNDLE` at a bundle that includes the
+   proxy root (the host's own bundle usually already does):
+
+   ```bash
+   MEDMCP_WORKSPACE="$PWD/data" MEDMCP_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt \
+     docker compose -f docker-compose.ghcr.yml -f docker-compose.proxy.yml up -d
+   ```
+
+**Simplest escape hatch:** pull the model on the host once
+(`ollama pull gemma4:26b`) and set `OLLAMA_MODELS_DIR` to your host store (e.g.
+`~/.ollama`). The container then reuses it and skips the ~18 GB in-container pull
+entirely — sidestepping layers 2 and 3 for the model download.
 
 ---
 

--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -56,8 +56,9 @@ services:
     ports:
       - "127.0.0.1:8100:8100"
     volumes:
-      # Rootless docker socket → core spawns sibling stack containers.
-      - "${XDG_RUNTIME_DIR}/docker.sock:/var/run/docker.sock"
+      # Docker socket → core spawns sibling stack containers. Defaults to the
+      # rootless path; rootful hosts set MEDMCP_DOCKER_SOCK=/var/run/docker.sock.
+      - "${MEDMCP_DOCKER_SOCK:-${XDG_RUNTIME_DIR}/docker.sock}:/var/run/docker.sock"
       # Workspace at an identical absolute path (path parity for nested run -v).
       - "${MEDMCP_WORKSPACE}:${MEDMCP_WORKSPACE}"
       # Host registry credentials (read-only) so the install flow can pull private images.

--- a/docker-compose.proxy.yml
+++ b/docker-compose.proxy.yml
@@ -1,0 +1,25 @@
+# Opt-in overlay for hosts behind a TLS-intercepting (MITM) corporate proxy.
+#
+# The first-run model pull happens *inside* the llm container (ollama pulling
+# gemma4:26b from registry.ollama.ai). Behind a proxy that re-signs TLS, the
+# container's minimal trust store rejects the proxy's certificate. This overlay
+# mounts a CA bundle that includes the proxy's root CA into each service.
+#
+# Point MEDMCP_CA_BUNDLE at a bundle that trusts your proxy (the host's own
+# bundle usually already does, since host git/curl work through the proxy):
+#
+#   MEDMCP_WORKSPACE=/abs/path MEDMCP_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt \
+#     docker compose -f docker-compose.ghcr.yml -f docker-compose.proxy.yml up -d
+#
+# Container proxy env + NO_PROXY come from ~/.docker/config.json "proxies"
+# (NO_PROXY MUST list the service names llm,llm-init,medmcp so container-to-
+# container traffic bypasses the proxy). The daemon's own image pulls use the
+# daemon proxy (systemd drop-in / /etc/docker/daemon.json). See README.
+x-ca: &ca
+  volumes:
+    - "${MEDMCP_CA_BUNDLE:-/etc/ssl/certs/ca-certificates.crt}:/etc/ssl/certs/ca-certificates.crt:ro"
+
+services:
+  llm: *ca
+  llm-init: *ca
+  medmcp: *ca

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,9 +60,9 @@ services:
     ports:
       - "127.0.0.1:8100:8100"
     volumes:
-      # Rootless docker socket → core spawns sibling stack containers.
-      # Rootful hosts: override XDG_RUNTIME_DIR or set the path to /var/run.
-      - "${XDG_RUNTIME_DIR}/docker.sock:/var/run/docker.sock"
+      # Docker socket → core spawns sibling stack containers. Defaults to the
+      # rootless path; rootful hosts set MEDMCP_DOCKER_SOCK=/var/run/docker.sock.
+      - "${MEDMCP_DOCKER_SOCK:-${XDG_RUNTIME_DIR}/docker.sock}:/var/run/docker.sock"
       # Workspace at an identical absolute path (path parity for nested run -v).
       - "${MEDMCP_WORKSPACE}:${MEDMCP_WORKSPACE}"
       # Container-stack manifests (read-write so UI install/uninstall can persist).


### PR DESCRIPTION
## What

Makes the documented two-command Docker install hold up **behind a corporate proxy** and on **rootful Docker**, without changing the default rootless behavior. Motivated by a real install behind a TLS-intercepting institutional proxy, where the only failures were environmental (proxy + host GPU/Docker setup), not the repo — but several were undocumented and cost hours to diagnose.

## Changes

- **Rootful socket** — the docker socket mount becomes `${MEDMCP_DOCKER_SOCK:-${XDG_RUNTIME_DIR}/docker.sock}` in both compose files. Rootless default is unchanged; rootful hosts set `MEDMCP_DOCKER_SOCK=/var/run/docker.sock` instead of overloading `XDG_RUNTIME_DIR`.
- **`docker-compose.proxy.yml`** (new) — opt-in overlay that mounts a CA bundle (`MEDMCP_CA_BUNDLE`) into `llm`/`llm-init`/`medmcp` so the first-run in-container `ollama pull` trusts a TLS-intercepting proxy. No-op unless you pass the extra `-f`.
- **`.env.example`** — documents `MEDMCP_DOCKER_SOCK` and `MEDMCP_CA_BUNDLE`.
- **README** — adds the CDI daemon feature flag (`"features": {"cdi": true}`) to Prerequisites, and a **Running behind a proxy** section covering the three proxy layers (daemon image pulls / container egress + `noProxy` service names / MITM CA) plus the `OLLAMA_MODELS_DIR` escape hatch to skip the in-container model pull.

## Why these specifically

The three highest-friction, least-obvious gotchas, each now documented or papered over:
1. The Docker **daemon** ignores shell proxy vars (image pulls fail) — needs its own proxy config.
2. Container `noProxy` **must** list the compose service names (`llm,llm-init,medmcp`) or container-to-container calls get routed to the proxy and fail.
3. A TLS-intercepting proxy breaks the in-container model pull until the proxy CA is trusted inside the container.

## Testing

- `docker compose -f docker-compose.ghcr.yml -f docker-compose.proxy.yml config` validates; CA mount + socket resolve onto all three services.
- `docker compose -f docker-compose.yml config` still validates (rootless default unchanged).
- Verified end-to-end on a rootful host behind a MITM proxy: images pulled, `gemma4-medmcp` built, core serving on `127.0.0.1:8100`.

## Notes

- Pure site-specific config (proxy credentials, systemd drop-in, `~/.docker/config.json` proxy block) is intentionally **not** committed — only the hooks + docs are.