### PR TITLE
Deploy robustness: registry login, healthcheck, CI smoke test, in-UI GPU picker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,5 +17,11 @@ MEDMCP_WORKSPACE=/abs/path/to/workspace
 # Pin to a single GPU by index or UUID (`nvidia-smi -L`), e.g.:
 # MEDMCP_GPU=4
 
+# Optional: log in to the registry from inside the core (for hosts whose docker
+# config uses a credential helper, leaving no plaintext auths to mount). Use a
+# read:packages token. Leave unset to rely on the host's `docker login`.
+# GHCR_USER=your-github-user
+# GHCR_TOKEN=ghp_...
+
 # Base image the core/stack builds derive from (default: medmcp-base:dev).
 # MEDMCP_BASE_IMAGE=ghcr.io/medmcp/base:dev

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -27,6 +27,35 @@ jobs:
         run: |
           docker build -f Dockerfile.base --build-arg CUDA_TAG="${CUDA_TAG}" -t medmcp-base:ci .
           docker build --build-arg BASE_IMAGE=medmcp-base:ci -t medmcp-core:ci .
+      - name: Smoke test (entrypoint sanitizer + server boots)
+        run: |
+          # A host-like docker config carrying the leaked context + a credential
+          # helper, mounted where the entrypoint sanitizes it.
+          printf '{"auths":{"ghcr.io":{"auth":"dGVzdA=="}},"currentContext":"rootless","credsStore":"pass"}' \
+            > /tmp/host-docker-config.json
+          docker run -d --name medmcp-smoke \
+            -v /tmp/host-docker-config.json:/run/host-docker-config.json:ro \
+            -e MEDMCP_GPU=all \
+            medmcp-core:ci
+          # Wait for the server to answer /healthz.
+          ok=
+          for _ in $(seq 1 30); do
+            if docker exec medmcp-smoke python3 -c \
+              "import urllib.request; urllib.request.urlopen('http://localhost:8100/healthz')" 2>/dev/null; then
+              ok=1; break
+            fi
+            sleep 2
+          done
+          [ "$ok" = 1 ] || { echo "::error::server never became healthy"; docker logs medmcp-smoke; exit 1; }
+          # The entrypoint must have reduced the mounted config to auths-only.
+          keys=$(docker exec medmcp-smoke python3 -c \
+            "import json; print(sorted(json.load(open('/root/.docker/config.json')).keys()))")
+          echo "sanitized config keys: $keys"
+          [ "$keys" = "['auths']" ] || { echo "::error::config not sanitized: $keys"; docker logs medmcp-smoke; exit 1; }
+          echo "smoke test passed"
+      - name: Smoke test cleanup
+        if: always()
+        run: docker rm -f medmcp-smoke 2>/dev/null || true
       - name: Push to GHCR (main only)
         if: github.event_name != 'pull_request'
         env:

--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -56,6 +56,20 @@ services:
       # GPU the LLM + GPU stacks target (CDI device id). "all" = every GPU; pin
       # with an index/UUID, e.g. MEDMCP_GPU=4.
       MEDMCP_GPU: "${MEDMCP_GPU:-all}"
+      # Optional registry login inside the core — for credential-helper hosts
+      # that mount no plaintext auths. Leave empty to use the mounted config.
+      GHCR_USER: "${GHCR_USER:-}"
+      GHCR_TOKEN: "${GHCR_TOKEN:-}"
+    healthcheck:
+      test:
+        - CMD
+        - python3
+        - -c
+        - import urllib.request; urllib.request.urlopen("http://localhost:8100/healthz")
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
     ports:
       - "127.0.0.1:8100:8100"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,20 @@ services:
       # GPU the LLM + GPU stacks target (CDI device id). "all" = every GPU; pin
       # with an index/UUID, e.g. MEDMCP_GPU=4.
       MEDMCP_GPU: "${MEDMCP_GPU:-all}"
+      # Optional registry login inside the core — for credential-helper hosts
+      # that mount no plaintext auths. Leave empty to use the mounted config.
+      GHCR_USER: "${GHCR_USER:-}"
+      GHCR_TOKEN: "${GHCR_TOKEN:-}"
+    healthcheck:
+      test:
+        - CMD
+        - python3
+        - -c
+        - import urllib.request; urllib.request.urlopen("http://localhost:8100/healthz")
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
     ports:
       - "127.0.0.1:8100:8100"
     volumes:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -53,4 +53,16 @@ if not auths:
 PY
 fi
 
+# If a registry token is supplied, log in inside the core. This covers hosts
+# whose docker config uses a credential helper (so the mounted config carries no
+# plaintext auths) — docker login writes the auth into /root/.docker/config.json.
+if [ -n "${GHCR_TOKEN:-}" ]; then
+    if printf '%s' "$GHCR_TOKEN" | docker login "${GHCR_REGISTRY:-ghcr.io}" \
+        -u "${GHCR_USER:-medmcp}" --password-stdin >/dev/null 2>&1; then
+        echo "medmcp-entrypoint: logged in to ${GHCR_REGISTRY:-ghcr.io}"
+    else
+        echo "medmcp-entrypoint: WARNING: docker login to ${GHCR_REGISTRY:-ghcr.io} failed" >&2
+    fi
+fi
+
 exec medmcp-workspace

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,5 +1,6 @@
 import type {
   CatalogEntry,
+  GpuInfo,
   InstalledStack,
   ReplayPreviewStep,
   SessionInfo,
@@ -84,11 +85,19 @@ export async function saveSettings(state: SettingsState): Promise<boolean> {
     explain_tools: state.explain_tools,
     record_provenance: state.record_provenance,
     workflows_enabled: state.workflows_enabled,
+    gpu: state.gpu,
     stacks: state.stacks.map((s) => ({ name: s.name, active: s.active })),
     workflows: state.workflows.map((w) => ({ name: w.name, active: w.active })),
   })
   const body = (await res.json()) as { restarted: boolean }
   return body.restarted
+}
+
+/** Best-effort list of GPUs for the settings picker (may be empty). */
+export async function fetchGpus(): Promise<GpuInfo[]> {
+  const res = await check(await fetch('/api/gpus'))
+  const body = (await res.json()) as { gpus: GpuInfo[] }
+  return body.gpus
 }
 
 // ── Container stacks (install / uninstall) ───────────────────

--- a/frontend/src/components/SettingsDrawer.tsx
+++ b/frontend/src/components/SettingsDrawer.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useState } from 'react'
 import {
   fetchCatalog,
+  fetchGpus,
   fetchInstalledStacks,
   fetchSettings,
   saveSettings,
   uninstallStack,
 } from '../api'
-import type { CatalogEntry, InstalledStack, SettingsState } from '../types'
+import type { CatalogEntry, GpuInfo, InstalledStack, SettingsState } from '../types'
 import { XIcon } from './icons'
 
 interface SettingsDrawerProps {
@@ -82,6 +83,7 @@ export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
   const [state, setState] = useState<SettingsState | null>(null)
   const [installed, setInstalled] = useState<InstalledStack[]>([])
   const [catalog, setCatalog] = useState<CatalogEntry[]>([])
+  const [gpus, setGpus] = useState<GpuInfo[]>([])
   const [installImage, setInstallImage] = useState('')
   const [installing, setInstalling] = useState(false)
   const [installingImage, setInstallingImage] = useState<string | null>(null)
@@ -92,11 +94,12 @@ export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
 
   useEffect(() => {
     if (!open) return
-    Promise.all([fetchSettings(), fetchInstalledStacks(), fetchCatalog()])
-      .then(([s, inst, cat]) => {
+    Promise.all([fetchSettings(), fetchInstalledStacks(), fetchCatalog(), fetchGpus()])
+      .then(([s, inst, cat, gpuList]) => {
         setState(s)
         setInstalled(inst)
         setCatalog(cat)
+        setGpus(gpuList)
         setError(null)
         setNotice(null)
       })
@@ -228,6 +231,32 @@ export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
                 checked={state.workflows_enabled}
                 onChange={(v) => apply({ ...state, workflows_enabled: v })}
               />
+              <div className="settings-row">
+                <div className="settings-row-text">
+                  <div className="settings-row-label">GPU</div>
+                  <div className="settings-row-hint">
+                    Imaging stacks use this immediately. The chat model uses the GPU set at
+                    startup{state.llm_gpu ? ` (currently ${state.llm_gpu})` : ''}; change
+                    MEDMCP_GPU and restart to move it.
+                  </div>
+                </div>
+                <select
+                  className="wf-input gpu-select"
+                  value={state.gpu}
+                  disabled={saving}
+                  onChange={(e) => apply({ ...state, gpu: e.target.value })}
+                >
+                  <option value="all">All GPUs</option>
+                  {gpus.map((g) => (
+                    <option key={g.uuid} value={g.index}>
+                      GPU {g.index} — {g.name}
+                    </option>
+                  ))}
+                  {state.gpu !== 'all' && !gpus.some((g) => g.index === state.gpu) && (
+                    <option value={state.gpu}>{state.gpu}</option>
+                  )}
+                </select>
+              </div>
 
               <div className="settings-section">Stacks</div>
               {state.stacks.length === 0 && (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1146,6 +1146,11 @@ button:hover {
   text-overflow: ellipsis;
 }
 
+.gpu-select {
+  max-width: 200px;
+  flex: none;
+}
+
 /* ── Chats menu (chat-header dropdown) ── */
 
 .chats-menu {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -87,8 +87,19 @@ export interface SettingsState {
   explain_tools: boolean
   record_provenance: boolean
   workflows_enabled: boolean
+  /** Selected GPU (CDI device id) for container stacks; "all" = every GPU. */
+  gpu: string
+  /** GPU the LLM container was created with (deploy-time; read-only here). */
+  llm_gpu: string
   stacks: StackInfo[]
   workflows: WorkflowInfo[]
+}
+
+/** One GPU from GET /api/gpus (best-effort enumeration). */
+export interface GpuInfo {
+  index: string
+  uuid: string
+  name: string
 }
 
 /** One workflow row from GET /api/workflows. */

--- a/src/medmcp/server.py
+++ b/src/medmcp/server.py
@@ -237,6 +237,8 @@ class SettingsPayload(BaseModel):
     explain_tools: bool
     record_provenance: bool
     workflows_enabled: bool
+    # Selected GPU (CDI device id) for container stacks; "" = leave unchanged.
+    gpu: str = ""
     stacks: list[ToggleEntry]
     workflows: list[ToggleEntry]
 
@@ -251,6 +253,8 @@ def _settings_state() -> JsonDict:
         "explain_tools": settings.load_explain_enabled(),
         "record_provenance": settings.load_provenance_enabled(),
         "workflows_enabled": settings.load_workflows_enabled(),
+        "gpu": settings.load_gpu_selection(),
+        "llm_gpu": settings.LLM_GPU,
         "stacks": [
             {"name": s["name"], "version": s.get("version"), "active": s["name"] in active}
             for s in stacks
@@ -287,6 +291,11 @@ async def put_settings(payload: SettingsPayload) -> JsonDict:
         old_workflows = settings.load_active_workflow_names()
         old_wf_enabled = settings.load_workflows_enabled()
 
+        # An empty gpu means "leave unchanged"; a new value re-pins stack containers.
+        gpu_changed = bool(payload.gpu) and payload.gpu != settings.load_gpu_selection()
+        if gpu_changed:
+            settings.save_gpu_selection(payload.gpu)
+
         settings.save_explain_enabled(payload.explain_tools)
         settings.save_provenance_enabled(payload.record_provenance)
         settings.save_workflows_enabled(payload.workflows_enabled)
@@ -305,6 +314,7 @@ async def put_settings(payload: SettingsPayload) -> JsonDict:
             new_stacks != old_stacks
             or new_workflows != old_workflows
             or payload.workflows_enabled != old_wf_enabled
+            or gpu_changed
         )
         if restart:
             settings.sync_servers_to_vibe_config(settings.active_servers())
@@ -347,6 +357,12 @@ def _apply_stack_change() -> None:
 async def healthz() -> JsonDict:
     """Liveness probe for container healthchecks (touches no dependencies)."""
     return {"status": "ok"}
+
+
+@app.get("/api/gpus")
+async def get_gpus() -> JsonDict:
+    """Best-effort GPU list for the settings picker (empty if not enumerable)."""
+    return {"gpus": await asyncio.to_thread(settings.list_gpus)}
 
 
 @app.get("/api/stacks")

--- a/src/medmcp/server.py
+++ b/src/medmcp/server.py
@@ -343,6 +343,12 @@ def _apply_stack_change() -> None:
     settings.sync_servers_to_vibe_config(settings.active_servers())
 
 
+@app.get("/healthz")
+async def healthz() -> JsonDict:
+    """Liveness probe for container healthchecks (touches no dependencies)."""
+    return {"status": "ok"}
+
+
 @app.get("/api/stacks")
 async def get_stacks() -> JsonDict:
     """List installed container stacks (from ``stacks.d`` manifests)."""

--- a/src/medmcp/settings.py
+++ b/src/medmcp/settings.py
@@ -48,8 +48,21 @@ OLLAMA_MODEL: str = os.environ.get("OLLAMA_MODEL", "gemma4-medmcp")
 
 # GPU selector (CDI device id) substituted into container-stack manifests' ${MEDMCP_GPU}.
 # Default so os.path.expandvars (no ":-" support) never leaves the literal placeholder;
-# "all" = every GPU, override with an index/UUID (e.g. "4") to pin.
+# "all" = every GPU, override with an index/UUID (e.g. "4") to pin. LLM_GPU captures
+# the value the LLM container was created with (deploy-time) before a persisted runtime
+# selection overrides MEDMCP_GPU for stacks (see load/save_gpu_selection).
 os.environ.setdefault("MEDMCP_GPU", "all")
+LLM_GPU: str = os.environ["MEDMCP_GPU"]
+GPU_SELECTION_PATH: Path = VIBE_HOME / "gpu_selection.json"
+if GPU_SELECTION_PATH.exists():
+    try:
+        _gpu_sel = str(
+            cast("dict[str, Any]", json.loads(GPU_SELECTION_PATH.read_text())).get("gpu", "")
+        ).strip()
+    except (json.JSONDecodeError, OSError):
+        _gpu_sel = ""
+    if _gpu_sel:
+        os.environ["MEDMCP_GPU"] = _gpu_sel
 
 # Context window size used when Ollama hasn't been queried (yet) — the value
 # set in Modelfile.gemma4.
@@ -752,6 +765,84 @@ def load_explain_enabled() -> bool:
 def save_explain_enabled(enabled: bool) -> None:
     """Persist the explain-tool-calls on/off preference to disk."""
     _save_flag(EXPLAIN_ENABLED_PATH, enabled)
+
+
+def load_gpu_selection() -> str:
+    """Effective GPU (CDI device id) for container stacks (persisted, else boot default)."""
+    return os.environ.get("MEDMCP_GPU", "all")
+
+
+def save_gpu_selection(gpu: str) -> None:
+    """Persist the stack GPU selection and apply it to this process.
+
+    Clears the discovery cache so the next :func:`load_mcp_servers` re-expands the
+    ``${MEDMCP_GPU}`` ``--device`` arg; the caller should re-sync vibe-acp config and
+    restart it so newly spawned stacks pick up the device. Does not move the LLM —
+    its GPU is fixed at container creation (see :data:`LLM_GPU`).
+    """
+    value = gpu.strip() or "all"
+    _atomic_write_json(GPU_SELECTION_PATH, {"gpu": value})
+    os.environ["MEDMCP_GPU"] = value
+    load_mcp_servers.cache_clear()
+
+
+def _llm_image() -> str:
+    """Image of the running LLM container (a present CUDA image), or "" if unknown."""
+    override = os.environ.get("OLLAMA_IMAGE", "").strip()
+    if override:
+        return override
+    try:
+        ps = _run_docker(
+            [
+                "ps",
+                "--filter",
+                "label=com.docker.compose.service=llm",
+                "--format",
+                "{{.Image}}",
+            ],
+            timeout=10,
+        )
+    except RuntimeError:
+        return ""
+    return next((n.strip() for n in ps.stdout.splitlines() if n.strip()), "")
+
+
+def list_gpus() -> list[JsonDict]:
+    """Best-effort list of GPUs as ``{index, uuid, name}`` for the settings picker.
+
+    The CPU-only core can't enumerate GPUs itself, so it runs ``nvidia-smi`` in a
+    throwaway container with *every* GPU exposed (``--device nvidia.com/gpu=all``) so
+    the real host indices/UUIDs come back — querying the (possibly pinned) LLM
+    container would only show its own GPU(s), renumbered. Reuses the LLM image (a
+    present CUDA image). Returns ``[]`` when not enumerable — the UI falls back to
+    free text.
+    """
+    image = _llm_image()
+    if not image:
+        return []
+    try:
+        smi = _run_docker(
+            [
+                "run",
+                "--rm",
+                "--device",
+                "nvidia.com/gpu=all",
+                "--entrypoint",
+                "nvidia-smi",
+                image,
+                "--query-gpu=index,uuid,name",
+                "--format=csv,noheader",
+            ],
+            timeout=30,
+        )
+    except RuntimeError:
+        return []
+    gpus: list[JsonDict] = []
+    for line in smi.stdout.splitlines():
+        parts = [p.strip() for p in line.split(",")]
+        if len(parts) >= 3 and parts[0]:
+            gpus.append({"index": parts[0], "uuid": parts[1], "name": parts[2]})
+    return gpus
 
 
 # Serializes the config.toml read-modify-write within this process: the

--- a/src/medmcp/settings.py
+++ b/src/medmcp/settings.py
@@ -468,11 +468,21 @@ def _pull_streaming(image: str, on_progress: ProgressFn | None) -> None:
     except FileNotFoundError as exc:
         raise RuntimeError("docker CLI not found") from exc
     assert proc.stdout is not None
+    tail: list[str] = []
     for raw in proc.stdout:
         line = raw.split("\r")[-1].strip()
-        if line and on_progress:
-            on_progress(line)
+        if line:
+            tail = [*tail[-4:], line]
+            if on_progress:
+                on_progress(line)
     if proc.wait() != 0:
+        blob = " ".join(tail).lower()
+        auth_markers = ("denied", "unauthorized", "authentication required", "forbidden")
+        if any(k in blob for k in auth_markers):
+            raise RuntimeError(
+                f"not authorized to pull {image} — log in to the registry on the host "
+                "(`docker login ghcr.io`) or set GHCR_USER/GHCR_TOKEN."
+            )
         raise RuntimeError(f"docker pull {image} failed")
 
 

--- a/tests/test_gpu_selection.py
+++ b/tests/test_gpu_selection.py
@@ -1,0 +1,39 @@
+"""Tests for the runtime GPU selection (settings.load/save_gpu_selection)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from medmcp import settings
+
+
+def test_load_defaults_to_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without a persisted file, the selection follows MEDMCP_GPU."""
+    monkeypatch.setenv("MEDMCP_GPU", "all")
+    assert settings.load_gpu_selection() == "all"
+    monkeypatch.setenv("MEDMCP_GPU", "4")
+    assert settings.load_gpu_selection() == "4"
+
+
+def test_save_persists_and_applies(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Save writes the file and applies the value to the process env."""
+    sel = tmp_path / "gpu_selection.json"
+    monkeypatch.setenv("MEDMCP_GPU", "all")
+    with patch("medmcp.settings.GPU_SELECTION_PATH", sel):
+        settings.save_gpu_selection("5")
+        assert json.loads(sel.read_text()) == {"gpu": "5"}
+    assert settings.load_gpu_selection() == "5"
+
+
+def test_save_blank_falls_back_to_all(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A blank selection is normalised to "all" (every GPU)."""
+    sel = tmp_path / "gpu_selection.json"
+    monkeypatch.setenv("MEDMCP_GPU", "3")
+    with patch("medmcp.settings.GPU_SELECTION_PATH", sel):
+        settings.save_gpu_selection("   ")
+        assert json.loads(sel.read_text()) == {"gpu": "all"}
+    assert settings.load_gpu_selection() == "all"


### PR DESCRIPTION
Follow-ups to the GPU/sanitizer/progress-bar work already on main, addressing "will this work for others?" and "let users choose the GPU easily."

## Changes

**Registry login fallback + healthcheck + clearer error** (`c63f08a`)
- `GHCR_USER`/`GHCR_TOKEN`: the entrypoint runs `docker login` inside the core, so hosts whose docker config uses a *credential helper* (no plaintext auths to mount) can still pull private stacks — the remaining portability gap after the `currentContext` fix.
- `/healthz` + a compose healthcheck on the core service, so a crashed server isn't reported "Up".
- An auth-denied `docker pull` now returns an actionable message instead of a generic "pull failed".

**CI smoke test for the container path** (`a6fcf8d`)
- `images.yml` builds the core, boots it with a host-like config (leaked `currentContext` + `credsStore`), waits for `/healthz`, and asserts the entrypoint reduced the mounted config to `auths`-only. Runs on PRs and gates the GHCR push.

**In-UI GPU picker** (`6f2113a`)
- A GPU dropdown in Settings. `GET /api/gpus` enumerates host GPUs via a throwaway all-GPU `nvidia-smi` container (the CPU-only core can't see GPUs, and the pinned LLM container only sees its own). Selecting one persists to `gpu_selection.json`, re-pins stack containers on their next spawn, and restarts vibe-acp.
- The chat model's GPU stays a deploy-time setting (`MEDMCP_GPU`); the picker shows it read-only and notes a restart is needed to move it (a container's device can't change at runtime).

## Testing
- 204 unit tests + ruff + pyright pass; frontend `tsc`+eslint+vite build clean.
- Verified live on a multi-GPU host: `/api/gpus` lists all 8 GPUs, the `gpu` PUT round-trips and persists, the core reports `healthy`, and the entrypoint sanitizer + `/healthz` pass in a rebuilt image.