### PR TITLE
Settings UI: de-duplicate stacks, fix uninstall, leaner GPU picker, aligned headers

### DIFF
--- a/frontend/src/components/SettingsDrawer.tsx
+++ b/frontend/src/components/SettingsDrawer.tsx
@@ -234,11 +234,7 @@ export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
               <div className="settings-row">
                 <div className="settings-row-text">
                   <div className="settings-row-label">GPU</div>
-                  <div className="settings-row-hint">
-                    Imaging stacks use this immediately. The chat model uses the GPU set at
-                    startup{state.llm_gpu ? ` (currently ${state.llm_gpu})` : ''}; change
-                    MEDMCP_GPU and restart to move it.
-                  </div>
+                  <div className="settings-row-hint">Imaging stacks; chat model set at startup.</div>
                 </div>
                 <select
                   className="wf-input gpu-select"
@@ -249,7 +245,7 @@ export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
                   <option value="all">All GPUs</option>
                   {gpus.map((g) => (
                     <option key={g.uuid} value={g.index}>
-                      GPU {g.index} — {g.name}
+                      GPU {g.index}
                     </option>
                   ))}
                   {state.gpu !== 'all' && !gpus.some((g) => g.index === state.gpu) && (
@@ -301,32 +297,35 @@ export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
               })}
 
               <div className="settings-section">Available</div>
-              {catalog.map((c) => (
-                <div className="settings-row" key={`cat-${c.name}`}>
-                  <div className="settings-row-text">
-                    <div className="settings-row-label">
-                      {c.name}
-                      {c.gpu && <span className="stack-badge">GPU</span>}
+              {catalog.length > 0 && catalog.every((c) => c.installed) && (
+                <div className="settings-row-hint">All available stacks are installed.</div>
+              )}
+              {catalog
+                .filter((c) => !c.installed)
+                .map((c) => (
+                  <div className="settings-row" key={`cat-${c.name}`}>
+                    <div className="settings-row-text">
+                      <div className="settings-row-label">
+                        {c.name}
+                        {c.gpu && <span className="stack-badge">GPU</span>}
+                      </div>
+                      {c.description && <div className="settings-row-hint">{c.description}</div>}
                     </div>
-                    {c.description && <div className="settings-row-hint">{c.description}</div>}
+                    <div className="stack-row-actions">
+                      {installingImage === c.image ? (
+                        <InstallProgress line={installProgress} />
+                      ) : (
+                        <button
+                          className="btn-primary btn-sm"
+                          disabled={installing}
+                          onClick={() => performInstall(c.image)}
+                        >
+                          Install
+                        </button>
+                      )}
+                    </div>
                   </div>
-                  <div className="stack-row-actions">
-                    {installingImage === c.image ? (
-                      <InstallProgress line={installProgress} />
-                    ) : c.installed ? (
-                      <span className="settings-row-hint">Installed</span>
-                    ) : (
-                      <button
-                        className="btn-primary btn-sm"
-                        disabled={installing}
-                        onClick={() => performInstall(c.image)}
-                      >
-                        Install
-                      </button>
-                    )}
-                  </div>
-                </div>
-              ))}
+                ))}
               <div className="stack-install">
                 <input
                   className="wf-input"

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -213,7 +213,10 @@ button:hover {
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  padding: 8px 14px;
+  /* Fixed height so all four panel headers line up regardless of whether they
+     hold buttons/menus (taller) or just a title; content centers vertically. */
+  min-height: 44px;
+  padding: 6px 14px;
   background: var(--dark2);
   border-bottom: 1px solid var(--border);
   flex-shrink: 0;
@@ -997,7 +1000,7 @@ button:hover {
   top: 0;
   right: 0;
   bottom: 0;
-  width: 380px;
+  width: 460px;
   max-width: 90vw;
   background: var(--dark2);
   border-left: 1px solid var(--border2);

--- a/src/medmcp/settings.py
+++ b/src/medmcp/settings.py
@@ -323,6 +323,13 @@ def load_mcp_servers() -> list[JsonDict]:
                     "Skipping stale config.toml entry %r (command not found: %s)", name, command
                 )
                 continue
+            # A container-stack entry (command "docker") reaching here is an orphan:
+            # a present stacks.d manifest would have claimed its name in source #2, so
+            # this is a leftover written into config.toml by a prior sync before the
+            # stack was uninstalled. Drop it so uninstalls actually take effect.
+            if command and Path(command).name == "docker":
+                log.debug("Skipping orphaned container-stack config.toml entry %r", name)
+                continue
             servers[name] = {
                 "name": name,
                 "command": command,

--- a/tests/test_load_mcp_servers.py
+++ b/tests/test_load_mcp_servers.py
@@ -238,6 +238,26 @@ class TestConfigTomlFallback:
         names = {s["name"] for s in servers}
         assert names == {"medmcp-neuro", "medmcp-cardiac"}
 
+    def test_orphaned_docker_entry_dropped(self, tmp_path: Path) -> None:
+        """A leftover container-stack entry (command "docker") with no manifest is dropped.
+
+        sync_servers_to_vibe_config writes active container stacks into config.toml;
+        once the stacks.d manifest is uninstalled, that entry must not resurrect the
+        stack via the config.toml fallback (the uninstall-doesn't-stick bug).
+        """
+        cfg = tmp_path / "config.toml"
+        cfg.write_text(
+            '[[mcp_servers]]\nname = "medmcp-neuro"\n'
+            'command = "docker"\nargs = ["run", "--rm", "-i", "medmcp-neuro:dev"]\n'
+        )
+        with (
+            patch("medmcp.settings.get_uv_tool_dir", return_value=None),
+            patch("medmcp.settings.VIBE_HOME", tmp_path),
+        ):
+            servers = load_mcp_servers()
+
+        assert servers == []
+
     def test_no_tools_no_config_returns_empty(self, tmp_path: Path) -> None:
         """Nothing installed and no config → empty list."""
         with (


### PR DESCRIPTION
Small UI/UX fixes in the settings drawer plus a backend discovery bug behind the stack list.

## Changes
- **Uninstall now sticks.** `load_mcp_servers` discovery dropped uninstalled *uv-tool* entries from `config.toml` (absolute path gone) but not container stacks — `sync_servers_to_vibe_config` writes those as `command = "docker"`, and after the `stacks.d` manifest was deleted, source #3 re-read the leftover entry and resurrected the stack. Discovery now also drops orphaned `docker`-command entries, so uninstalling removes the stack from the list.
- **No more doubling.** The "Available" catalog list now shows only *not-installed* stacks. An installed stack appears only under "Stacks"; it returns to "Available" when uninstalled.
- **Leaner GPU selector.** One-line hint; option labels trimmed to `GPU <n>` (dropped the repeated model string).
- **Aligned panel headers.** All four panel headers get a fixed `min-height` so they line up.

## Testing
- New regression test: an orphaned `docker`-command `config.toml` entry with no manifest is dropped (`test_orphaned_docker_entry_dropped`).
- 205 unit tests + ruff + pyright pass; frontend `tsc`+eslint+vite build clean.
- Verified live: install→uninstall round-trip leaves the Stacks list empty and flips the catalog `installed` flag back; headers/drawer/GPU-picker render as intended.