### PR TITLE
feat(deploy): instant-on LLM + one-line install from a published compose artifact

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -68,3 +68,17 @@ jobs:
             docker push "ghcr.io/medmcp/$img:${{ github.sha }}"
             docker push "ghcr.io/medmcp/$img:main"
           done
+      - name: Publish deploy compose as an OCI artifact (main only)
+        if: github.event_name != 'pull_request'
+        run: |
+          # Publish the self-contained deploy compose so nodes can run it with no
+          # checkout:  docker compose -f oci://ghcr.io/medmcp/compose:main up -d
+          # Reuses the docker login from the push step above. MEDMCP_WORKSPACE is
+          # set only to satisfy publish-time interpolation of its required
+          # ${...:?} value; it is NOT baked into the artifact (no --with-env), so
+          # consumers still supply their own path at `up` time.
+          for tag in "${{ github.sha }}" main; do
+            MEDMCP_WORKSPACE=/run/medmcp \
+              docker compose -f docker-compose.ghcr.yml publish \
+              "ghcr.io/medmcp/compose:$tag" -y
+          done

--- a/README.md
+++ b/README.md
@@ -36,35 +36,33 @@ MedMCP runs entirely on-premise and is designed to meet the data governance and 
 
 ### Run with Docker (recommended)
 
-MedMCP ships as prebuilt images on the private registry `ghcr.io/medmcp` — a node
-**pulls** them, nothing is built locally. You only need two files from this repo:
-`docker-compose.ghcr.yml` and `Modelfile.gemma4` (clone the repo, or copy just those).
+MedMCP runs as prebuilt images — there's nothing to build and no source to download.
+You just need Docker with GPU access (see [Prerequisites](#prerequisites)) and a
+registry login.
 
-1. **Authenticate** to the registry (once per node — see [Prerequisites](#prerequisites)):
+1. **Sign in to the registry** (once per machine):
 
    ```bash
    docker login ghcr.io   # username: your GitHub user · password: a read:packages token
    ```
 
-2. **Start it** — set `MEDMCP_WORKSPACE` to the absolute host folder holding your imaging data:
+2. **Start MedMCP.** `MEDMCP_WORKSPACE` is the folder on your machine where your imaging
+   data lives and where results are saved — use any absolute path:
 
    ```bash
-   MEDMCP_WORKSPACE="$PWD/data" docker compose -f docker-compose.ghcr.yml up -d
-   # from a repo checkout you can use:  just compose-up-ghcr
+   MEDMCP_WORKSPACE="$HOME/medmcp-data" \
+     docker compose -f oci://ghcr.io/medmcp/compose:main up -d
    ```
 
-   This pulls the CPU-only **core** plus a bundled **Ollama** GPU service and, on first
-   run, builds the `gemma4-medmcp` model (~18 GB pull). Open **http://localhost:8100**.
+   The first start downloads the model (~18 GB), so give it a few minutes. Then open
+   **http://localhost:8100**.
 
-3. **Add tools** — in the UI, open **Settings → Stacks → Available** and install the
-   imaging stacks you need (e.g. `dicom`, `neuro`); each pulls its GPU image on demand
-   and is then launched by the core when the agent calls it.
+3. **Add imaging tools.** In the UI, open **Settings → Stacks → Available** and install
+   the stacks you need (e.g. `dicom`, `neuro`). Each one downloads on demand the first
+   time the agent uses it.
 
-The workspace folder is bind-mounted at the **same absolute path** inside the container,
-so the agent's outputs land back on your host. Pin a specific release with
-`MEDMCP_TAG=<git-sha>` (default `:main`). Tear down with
-`docker compose -f docker-compose.ghcr.yml down`. Air-gapped sites mirror the images
-into an internal registry — see [Imaging Stacks](#imaging-stacks).
+**Stop** with `docker compose -f oci://ghcr.io/medmcp/compose:main down`. **Update** by
+re-running the start command with `--pull always`.
 
 ### Run from source (development)
 
@@ -167,7 +165,7 @@ Once installed, the stack is auto-discovered via its `[medmcp.stacks]` entry poi
 **Private images (GHCR).** CI (`.github/workflows/images.yml`) builds and pushes the base, core, and stack images to the **private** registry `ghcr.io/medmcp/*` (packages are private by default; the base package must grant the stack repos read access). For a private fleet:
 
 1. `docker login ghcr.io` on each node (a `read:packages` token); compose mounts the host's docker credentials so the in-UI install can pull.
-2. Run the **published** images (pulls the core, builds nothing) with the deploy compose — `just compose-up-ghcr`, i.e. `docker compose -f docker-compose.ghcr.yml up -d`. It defaults `MEDMCP_CATALOG_URL` to the bundled `/app/catalog.ghcr.json`; pin a release with `MEDMCP_TAG=<git-sha>`. A node needs only this file + `Modelfile.gemma4`.
+2. Run the **published** images (pulls the core, builds nothing) with the deploy compose, published as an OCI artifact — `docker compose -f oci://ghcr.io/medmcp/compose:main up -d` (no checkout needed). It defaults `MEDMCP_CATALOG_URL` to the bundled `/app/catalog.ghcr.json`; pin a release with `MEDMCP_TAG=<git-sha>`. From a checkout, `just compose-up-ghcr` uses the local file.
 
 Air-gapped sites mirror the images into an internal registry and point the catalog there instead. No image data leaves the machine either way — these are inbound pulls.
 

--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -1,15 +1,15 @@
 # Deployment compose: runs the PUBLISHED images from the private GHCR — builds
-# nothing. For nodes that only pull (no source checkout). Self-contained; run it
-# on its own (not merged with docker-compose.yml):
+# nothing. Fully self-contained (the Modelfile is inlined into llm-init below),
+# so a node needs NO repo checkout. This file is also published as an OCI artifact
+# by CI, so it can run straight from the registry:
 #
 #   docker login ghcr.io                       # read:packages token
 #   MEDMCP_WORKSPACE=/abs/path \
-#     docker compose -f docker-compose.ghcr.yml up -d
+#     docker compose -f oci://ghcr.io/medmcp/compose:main up -d
 #
-# (or `just compose-up-ghcr`). Pin a release with MEDMCP_TAG=<git-sha> (default
-# :main). A node needs this file + Modelfile.gemma4 (for the one-time model build);
-# everything else is pulled. GPU uses CDI (rootless); rootful hosts set the docker
-# socket path to /var/run.
+# From a checkout you can equivalently point at this file (`just compose-up-ghcr`).
+# Pin a release with MEDMCP_TAG=<git-sha> (default :main). GPU uses CDI (rootless);
+# rootful hosts set the docker socket path to /var/run.
 name: medmcp
 
 services:
@@ -38,11 +38,25 @@ services:
         condition: service_healthy
     environment:
       OLLAMA_HOST: "http://llm:11434"
-    volumes:
-      - "./Modelfile.gemma4:/Modelfile.gemma4:ro"
     entrypoint: ["/bin/sh", "-c"]
+    # The Modelfile is inlined (not bind-mounted) so this compose file is fully
+    # self-contained and can run straight from the OCI registry with no checkout.
+    # Keep these PARAMETERs in sync with Modelfile.gemma4 — the source of truth
+    # for the host-native `just pull-model` path.
     command:
-      - 'ollama list | grep -q gemma4-medmcp || { ollama pull gemma4:26b && ollama create gemma4-medmcp -f /Modelfile.gemma4; }'
+      - |
+        if ollama list | grep -q gemma4-medmcp; then exit 0; fi
+        ollama pull gemma4:26b
+        printf '%s\n' \
+          'FROM gemma4:26b' \
+          'PARAMETER num_ctx 131072' \
+          'PARAMETER temperature 0.3' \
+          'PARAMETER top_p 0.95' \
+          'PARAMETER top_k 64' \
+          'PARAMETER repeat_penalty 1.15' \
+          'PARAMETER repeat_last_n 256' \
+          > /tmp/Modelfile.gemma4
+        ollama create gemma4-medmcp -f /tmp/Modelfile.gemma4
     restart: "no"
 
   llm-warmup:

--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -15,6 +15,11 @@ name: medmcp
 services:
   llm:
     image: ${OLLAMA_IMAGE:-ollama/ollama:latest}
+    environment:
+      # Keep gemma4-medmcp resident in VRAM (-1) so it isn't evicted after the
+      # 5-minute idle default and reloaded on the next prompt. Override with a
+      # duration (e.g. 30m) on shared GPUs to release VRAM when idle.
+      OLLAMA_KEEP_ALIVE: "${OLLAMA_KEEP_ALIVE:--1}"
     devices:
       - "nvidia.com/gpu=${MEDMCP_GPU:-all}"
     volumes:
@@ -38,6 +43,23 @@ services:
     entrypoint: ["/bin/sh", "-c"]
     command:
       - 'ollama list | grep -q gemma4-medmcp || { ollama pull gemma4:26b && ollama create gemma4-medmcp -f /Modelfile.gemma4; }'
+    restart: "no"
+
+  llm-warmup:
+    image: ${OLLAMA_IMAGE:-ollama/ollama:latest}
+    depends_on:
+      llm:
+        condition: service_healthy
+      llm-init:
+        condition: service_completed_successfully
+    environment:
+      OLLAMA_HOST: "http://llm:11434"
+    entrypoint: ["/bin/sh", "-c"]
+    # Preload the model into VRAM at startup so the first prompt is instant
+    # instead of paying the cold-load latency. Nothing depends on this service,
+    # so the core UI still comes up immediately while the model warms.
+    command:
+      - 'ollama run gemma4-medmcp "ok" </dev/null >/dev/null 2>&1 || true'
     restart: "no"
 
   medmcp:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,11 @@ name: medmcp
 services:
   llm:
     image: ${OLLAMA_IMAGE:-ollama/ollama:latest}
+    environment:
+      # Keep gemma4-medmcp resident in VRAM (-1) so it isn't evicted after the
+      # 5-minute idle default and reloaded on the next prompt. Override with a
+      # duration (e.g. 30m) on shared GPUs to release VRAM when idle.
+      OLLAMA_KEEP_ALIVE: "${OLLAMA_KEEP_ALIVE:--1}"
     devices:
       - "nvidia.com/gpu=${MEDMCP_GPU:-all}"
     volumes:
@@ -37,6 +42,23 @@ services:
     entrypoint: ["/bin/sh", "-c"]
     command:
       - 'ollama list | grep -q gemma4-medmcp || { ollama pull gemma4:26b && ollama create gemma4-medmcp -f /Modelfile.gemma4; }'
+    restart: "no"
+
+  llm-warmup:
+    image: ${OLLAMA_IMAGE:-ollama/ollama:latest}
+    depends_on:
+      llm:
+        condition: service_healthy
+      llm-init:
+        condition: service_completed_successfully
+    environment:
+      OLLAMA_HOST: "http://llm:11434"
+    entrypoint: ["/bin/sh", "-c"]
+    # Preload the model into VRAM at startup so the first prompt is instant
+    # instead of paying the cold-load latency. Nothing depends on this service,
+    # so the core UI still comes up immediately while the model warms.
+    command:
+      - 'ollama run gemma4-medmcp "ok" </dev/null >/dev/null 2>&1 || true'
     restart: "no"
 
   medmcp:


### PR DESCRIPTION
## Summary
Make the deployed GHCR stack instant-on and runnable with no repo checkout. The `gemma4-medmcp` model is kept resident in VRAM (no reload between prompts) and preloaded at startup, and the deploy compose is published as an OCI artifact so a node can start MedMCP with a single command.

## Test plan
- [x] `OLLAMA_KEEP_ALIVE=-1` verified live — recreated `llm`, `ollama ps` shows the model resident with `UNTIL = Forever` (was evicted after the 5-min idle default before)
- [x] Warmup load command runs non-interactively (`exit 0`) and leaves the model resident
- [x] `docker compose -f docker-compose.ghcr.yml config` parses with the inlined Modelfile and no host mount
- [x] `docker compose ... publish --dry-run ghcr.io/medmcp/compose:dryrun` succeeds
- [ ] First CI run on `main` publishes `ghcr.io/medmcp/compose:{main,<sha>}`; pull it and confirm `MEDMCP_WORKSPACE` stays a `${...}` placeholder (not the publish-time dummy) and `docker compose -f oci://ghcr.io/medmcp/compose:main up -d` boots

## Security & data handling
No change to the security posture: no new tool surface, no new agent capabilities, no auto-approval path, and no new network calls beyond the existing GHCR image pulls. The workspace is still bind-mounted at an identical absolute path and the UI is still published only to host loopback. The CI publish step reuses the registry login from the image-push step.

## Notes
- `OLLAMA_KEEP_ALIVE` is overridable (e.g. `30m`) to release VRAM when idle on shared GPUs; defaults to `-1` (stay resident).
- The deploy compose is now self-contained — the Modelfile is built inline in `llm-init` instead of bind-mounted. `Modelfile.gemma4` remains the source of truth for the host-native `just pull-model` path; `docker-compose.yml` (build-from-source) still mounts the real file to avoid a third copy.
- The `:<sha>` and `:main` compose artifacts are published alongside the images on push to `main`.
