### PR TITLE
fix(ci): make the compose OCI publish actually push

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -77,8 +77,11 @@ jobs:
           # set only to satisfy publish-time interpolation of its required
           # ${...:?} value; it is NOT baked into the artifact (no --with-env), so
           # consumers still supply their own path at `up` time.
+          # `yes |` answers the separate "publish these bind mount declarations?"
+          # prompt, which -y does not cover; without it the TTY-less runner reads
+          # EOF, defaults to No, and silently skips the publish (exit 0).
           for tag in "${{ github.sha }}" main; do
-            MEDMCP_WORKSPACE=/run/medmcp \
+            yes | MEDMCP_WORKSPACE=/run/medmcp \
               docker compose -f docker-compose.ghcr.yml publish \
               "ghcr.io/medmcp/compose:$tag" -y
           done


### PR DESCRIPTION
## Summary
The CI step that publishes the deploy compose as an OCI artifact has been silently no-op'ing. `docker compose publish` prompts a *second* time to confirm bind-mount declarations, which `-y` does not cover; in the TTY-less runner it reads EOF, defaults to **No**, skips the push, and still exits 0. The result was a green step that created no `ghcr.io/medmcp/compose` artifact (so the published `oci://…compose:main` one-liner 404s). Piping `yes` answers that prompt so the publish actually happens.

## Test plan
- [x] Reproduced: `ghcr.io/medmcp/compose:main` returns 404 after the prior green run; the step log shows the unanswered `Are you ok to publish these bind mount declarations? [y/N]:` prompt
- [x] A probe publish with `yes | … publish … -y` succeeds and creates the artifact
- [x] Stored artifact keeps `${…}` templates verbatim — consumed with a *different* `MEDMCP_WORKSPACE`, the consumer value wins (3×), the publish-time value leaks in 0×, and `image: ghcr.io/medmcp/core:main` resolves
- [ ] After merge, the Images run on `main` publishes `ghcr.io/medmcp/compose:{main,<sha>}`; `docker compose -f oci://ghcr.io/medmcp/compose:main up -d` boots on a clean node

## Security & data handling
No posture change — same publish, same registry login carried over from the image-push step. The artifact stores only the compose template (no `--with-env`, no secrets), and the verified round-trip confirms no host-specific paths are baked in.

## Notes
- Housekeeping: a throwaway `ghcr.io/medmcp/compose:_probe` tag from the verification above is still in the registry and should be deleted (needs a `delete:packages` token or the Packages web UI).
