### PR TITLE
Replay batch reuse + workspace UI responsiveness

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Group, Panel, Separator } from 'react-resizable-panels'
 import { Chat } from './components/Chat'
 import { FileExplorer } from './components/FileExplorer'
@@ -26,14 +26,39 @@ export default function App() {
   // calls, replay steps) so the explorer/viewer reload their file tree.
   const [fsVersion, setFsVersion] = useState(0)
   const notifyFsChanged = useCallback(() => setFsVersion((v) => v + 1), [])
-  // True while a separator that borders the viewer is being dragged. The viewer
-  // is the only WebGL/iframe panel; compositing it every frame is what makes
-  // such a drag feel heavy, so we hide its canvas (via the `is-resizing` class)
-  // until the layout settles. onLayoutChange fires per pointer move (drag in
-  // progress); onLayoutChanged fires once the drag ends.
+  // True while a separator is being dragged. The viewer is the only WebGL panel;
+  // its canvas is a large GPU layer that's expensive to composite every frame, so
+  // we drop it (via the `is-resizing` class) for the whole drag and let it redraw
+  // once on release.
+  //
+  // The flag must stay true for the ENTIRE pointer drag. We can't clear it on the
+  // library's `onLayoutChanged`: that fires on layout "settles" mid-drag (e.g.
+  // when you pause), which would un-hide the canvas and make it lag again — the
+  // exact "fine, then janky" symptom. So we set it on `onLayoutChange` (per move)
+  // and clear it on the real pointer release, with a timed fallback for keyboard
+  // resizes that have no pointerup.
   const [resizing, setResizing] = useState(false)
-  const startResize = useCallback(() => setResizing(true), [])
-  const endResize = useCallback(() => setResizing(false), [])
+  const resizeEndTimer = useRef<number | null>(null)
+  const startResize = useCallback(() => {
+    setResizing(true)
+    if (resizeEndTimer.current != null) clearTimeout(resizeEndTimer.current)
+    resizeEndTimer.current = window.setTimeout(() => setResizing(false), 400)
+  }, [])
+  useEffect(() => {
+    const end = () => {
+      if (resizeEndTimer.current != null) {
+        clearTimeout(resizeEndTimer.current)
+        resizeEndTimer.current = null
+      }
+      setResizing(false)
+    }
+    window.addEventListener('pointerup', end, true)
+    window.addEventListener('pointercancel', end, true)
+    return () => {
+      window.removeEventListener('pointerup', end, true)
+      window.removeEventListener('pointercancel', end, true)
+    }
+  }, [])
   // Chat session continuity: on load resume the last session (auto), and let
   // the user start a fresh one. `resumeId` is what the next Chat mount should
   // resume (stored id, or null for new); bumping `chatKey` remounts <Chat/> so
@@ -76,25 +101,24 @@ export default function App() {
         className="app-main"
         resizeTargetMinimumSize={{ fine: 8, coarse: 24 }}
         onLayoutChange={startResize}
-        onLayoutChanged={endResize}
       >
         <Panel defaultSize="60%" minSize="20%">
           <Group
             orientation="horizontal"
             resizeTargetMinimumSize={{ fine: 8, coarse: 24 }}
             onLayoutChange={startResize}
-            onLayoutChanged={endResize}
           >
             <Panel defaultSize="25%" minSize="12%">
               <FileExplorer
                 onOpenFile={setOpenPath}
                 refreshSignal={fsVersion}
                 onSelectionChange={setSelectedPaths}
+                isResizing={resizing}
               />
             </Panel>
             <Separator className="sep sep-v" />
             <Panel minSize="30%">
-              <Viewer path={openPath} refreshSignal={fsVersion} />
+              <Viewer path={openPath} refreshSignal={fsVersion} isResizing={resizing} />
             </Panel>
           </Group>
         </Panel>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -105,6 +105,7 @@ export default function App() {
               <WorkflowPanel
                 distillSessionId={distillSessionId}
                 onWorkspaceChanged={notifyFsChanged}
+                onOpenFile={setOpenPath}
                 selectedPaths={selectedPaths}
               />
             </Panel>

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useRef, useState } from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import { ChatSocket } from '../chatSocket'
 import type { ChatSocketStatus } from '../chatSocket'
@@ -82,12 +82,66 @@ function ContextMeter({ used, size }: { used: number; size: number | null }) {
   )
 }
 
-const AssistantMessage = memo(function AssistantMessage({ text }: { text: string }) {
+// Split markdown into blocks at blank lines, but never inside a fenced code
+// block (``` / ~~~), so a code block containing blank lines stays one block.
+// Used to keep settled blocks stable while a message streams in.
+function splitMarkdownBlocks(text: string): string[] {
+  const blocks: string[] = []
+  let current: string[] = []
+  let inFence = false
+  const flush = () => {
+    if (current.length > 0) {
+      blocks.push(current.join('\n'))
+      current = []
+    }
+  }
+  for (const line of text.split('\n')) {
+    if (/^\s*(```|~~~)/.test(line)) {
+      inFence = !inFence
+      current.push(line)
+    } else if (!inFence && line.trim() === '') {
+      flush()
+    } else {
+      current.push(line)
+    }
+  }
+  flush()
+  return blocks
+}
+
+// One markdown block, memoized on its source: a settled block never re-parses
+// once its text stops changing.
+const MarkdownBlock = memo(function MarkdownBlock({ source }: { source: string }) {
+  return <ReactMarkdown>{source}</ReactMarkdown>
+})
+
+const AssistantMessage = memo(function AssistantMessage({
+  text,
+  streaming,
+}: {
+  text: string
+  streaming: boolean
+}) {
+  // Re-parsing the whole (growing) message through react-markdown on every
+  // 50ms chunk flush is ~O(n²) and is what makes a long answer feel heavy. While
+  // streaming, split off the settled blocks (rendered as one memoized document
+  // so list numbering etc. stay correct) from the still-growing trailing block,
+  // so only that small tail re-parses per flush. A settled message renders as a
+  // single document — fully correct, parsed once.
+  const { head, tail } = useMemo(() => {
+    if (!streaming) return { head: text, tail: '' }
+    const blocks = splitMarkdownBlocks(text)
+    return {
+      head: blocks.slice(0, -1).join('\n\n'),
+      tail: blocks.length > 0 ? blocks[blocks.length - 1] : '',
+    }
+  }, [text, streaming])
   return (
     <div className="msg msg-ai">
       <div className="msg-avatar avatar-ai">AI</div>
       <div className="msg-bubble bubble-ai">
-        <ReactMarkdown>{text}</ReactMarkdown>
+        {head && <MarkdownBlock source={head} />}
+        {tail && <MarkdownBlock source={tail} />}
       </div>
     </div>
   )
@@ -143,8 +197,60 @@ function PermissionCard({
   )
 }
 
+// The message composer, split out (with its own draft state) so a keystroke
+// re-renders only this textarea — not the whole transcript above it. Memoized,
+// so a streaming flush in the parent doesn't re-render it either. Enter sends
+// even while busy (the server supersedes the in-flight prompt).
+const ChatInput = memo(function ChatInput({
+  busy,
+  canSend,
+  onSend,
+  onCancel,
+}: {
+  busy: boolean
+  canSend: boolean
+  onSend: (text: string) => void
+  onCancel: () => void
+}) {
+  const [input, setInput] = useState('')
+  const submit = () => {
+    const text = input.trim()
+    if (!text || !canSend) return
+    onSend(text)
+    setInput('')
+  }
+  return (
+    <div className="chat-input-row">
+      <textarea
+        value={input}
+        placeholder="Message the agent… (Enter to send, Shift+Enter for newline)"
+        rows={2}
+        onChange={(e) => setInput(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault()
+            submit()
+          }
+        }}
+      />
+      {busy ? (
+        <button className="btn-danger" onClick={onCancel}>
+          Stop
+        </button>
+      ) : (
+        <button className="btn-primary" onClick={submit} disabled={!canSend}>
+          Send
+        </button>
+      )}
+    </div>
+  )
+})
+
 /** The agent chat: streaming transcript, tool-call cards, permission prompts. */
-export function Chat({
+// Memoized: App bumps `fsVersion` on every completed tool call to refresh the
+// explorer/viewer, which would otherwise re-render the whole transcript here on
+// each one. Chat's props from App are all stable refs, so memo skips those.
+export const Chat = memo(function Chat({
   onPromptedSession,
   viewedPath,
   onToolActivity,
@@ -178,7 +284,6 @@ export function Chat({
   const [model, setModel] = useState<string | null>(null)
   const [usage, setUsage] = useState<{ used: number; size: number | null } | null>(null)
   const [permission, setPermission] = useState<PermissionRequest | null>(null)
-  const [input, setInput] = useState('')
   const socketRef = useRef<ChatSocket | null>(null)
   const sessionIdRef = useRef<string | null>(null)
   const bottomRef = useRef<HTMLDivElement>(null)
@@ -358,15 +463,19 @@ export function Chat({
     bottomRef.current?.scrollIntoView({ behavior: busy ? 'auto' : 'smooth' })
   }, [items, permission, busy])
 
-  const send = () => {
-    const text = input.trim()
-    if (!text || status !== 'open') return
-    setItems((prev) => [...prev, { kind: 'user', text }])
-    setInput('')
-    setBusy(true)
-    socketRef.current?.sendPrompt(text, viewedPath)
-    if (sessionIdRef.current) onPromptedSession?.(sessionIdRef.current)
-  }
+  // Stable so the memoized ChatInput doesn't re-render on every streaming flush;
+  // the trim/empty + open-socket guards live in ChatInput now.
+  const send = useCallback(
+    (text: string) => {
+      setItems((prev) => [...prev, { kind: 'user', text }])
+      setBusy(true)
+      socketRef.current?.sendPrompt(text, viewedPath)
+      if (sessionIdRef.current) onPromptedSession?.(sessionIdRef.current)
+    },
+    [viewedPath, onPromptedSession],
+  )
+
+  const cancel = useCallback(() => socketRef.current?.cancel(), [])
 
   const decide = (optionId: string | null) => {
     if (permission) {
@@ -419,35 +528,17 @@ export function Chat({
               </div>
             )
           }
-          return <AssistantMessage key={i} text={item.text} />
+          // The actively-streaming message is the last item while busy; it
+          // renders block-split. Everything else renders as a settled document.
+          return (
+            <AssistantMessage key={i} text={item.text} streaming={busy && i === items.length - 1} />
+          )
         })}
         {permission && <PermissionCard perm={permission} onDecide={decide} />}
         {busy && !permission && <div className="thinking">●●●</div>}
         <div ref={bottomRef} />
       </div>
-      <div className="chat-input-row">
-        <textarea
-          value={input}
-          placeholder="Message the agent… (Enter to send, Shift+Enter for newline)"
-          rows={2}
-          onChange={(e) => setInput(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' && !e.shiftKey) {
-              e.preventDefault()
-              send()
-            }
-          }}
-        />
-        {busy ? (
-          <button className="btn-danger" onClick={() => socketRef.current?.cancel()}>
-            Stop
-          </button>
-        ) : (
-          <button className="btn-primary" onClick={send} disabled={status !== 'open'}>
-            Send
-          </button>
-        )}
-      </div>
+      <ChatInput busy={busy} canSend={status === 'open'} onSend={send} onCancel={cancel} />
     </div>
   )
-}
+})

--- a/frontend/src/components/FileExplorer.tsx
+++ b/frontend/src/components/FileExplorer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { memo, useEffect, useRef, useState } from 'react'
 import type { MouseEvent as ReactMouseEvent } from 'react'
 import { Tree } from 'react-arborist'
 import type { NodeApi, NodeRendererProps } from 'react-arborist'
@@ -23,6 +23,8 @@ interface FileExplorerProps {
   refreshSignal?: number
   /** Reports the selected file paths (multi-select via ctrl/shift-click). */
   onSelectionChange?: (paths: string[]) => void
+  /** True while a separator is being dragged; defer tree resize until it ends. */
+  isResizing?: boolean
 }
 
 function parentDir(path: string): string {
@@ -105,13 +107,27 @@ function removeFromTree(nodes: TreeNode[], ids: Set<string>): TreeNode[] {
 }
 
 /** Workspace file tree with open/rename/move/delete/upload. */
-export function FileExplorer({ onOpenFile, refreshSignal, onSelectionChange }: FileExplorerProps) {
+// Memoized so a separator drag — which re-renders the panel content every frame
+// via react-resizable-panels — doesn't re-run react-arborist's tree on each
+// frame. Props from App are stable refs (refreshSignal changes only on fs
+// activity, not during a drag).
+export const FileExplorer = memo(function FileExplorer({
+  onOpenFile,
+  refreshSignal,
+  onSelectionChange,
+  isResizing,
+}: FileExplorerProps) {
   const [data, setData] = useState<TreeNode[]>([])
   const [error, setError] = useState<string | null>(null)
   const [size, setSize] = useState({ width: 280, height: 400 })
   const [menu, setMenu] = useState<{ x: number; y: number; node: NodeApi<TreeNode> } | null>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
+  // Read inside the mount-once observer effect without re-subscribing.
+  const isResizingRef = useRef(isResizing)
+  useEffect(() => {
+    isResizingRef.current = isResizing
+  }, [isResizing])
 
   const reload = () => {
     fetchTree()
@@ -138,14 +154,19 @@ export function FileExplorer({ onOpenFile, refreshSignal, onSelectionChange }: F
     return () => window.removeEventListener('focus', reload)
   }, [])
 
-  // Trailing debounce: re-rendering the tree on every observer tick adds
-  // React work to each frame of a separator drag; once it settles is enough.
+  // Resize the (virtualized) tree to its container. While a separator is being
+  // dragged we skip entirely — re-rendering react-arborist mid-drag is what made
+  // those drags janky — and resync once when the drag ends (the effect below).
+  // The trailing debounce covers non-drag resizes (window, drawer).
   useEffect(() => {
     const el = containerRef.current
     if (!el) return
     let timer: number | null = null
     const obs = new ResizeObserver(() => {
+      // Clear first so a resize scheduled in the frame before `isResizing`
+      // commits can't fire mid-drag; then skip entirely while dragging.
       if (timer != null) window.clearTimeout(timer)
+      if (isResizingRef.current) return
       timer = window.setTimeout(() => {
         timer = null
         setSize({ width: el.clientWidth, height: el.clientHeight })
@@ -157,6 +178,17 @@ export function FileExplorer({ onOpenFile, refreshSignal, onSelectionChange }: F
       if (timer != null) window.clearTimeout(timer)
     }
   }, [])
+
+  // A separator drag changed our size while the observer was skipping; sync once
+  // on the next frame after it ends (when the layout has settled).
+  useEffect(() => {
+    if (isResizing) return
+    const id = requestAnimationFrame(() => {
+      const el = containerRef.current
+      if (el) setSize({ width: el.clientWidth, height: el.clientHeight })
+    })
+    return () => cancelAnimationFrame(id)
+  }, [isResizing])
 
   const run = (op: Promise<void>) => {
     op.then(reload).catch((e: unknown) => {
@@ -326,4 +358,4 @@ export function FileExplorer({ onOpenFile, refreshSignal, onSelectionChange }: F
       </div>
     </div>
   )
-}
+})

--- a/frontend/src/components/FileExplorer.tsx
+++ b/frontend/src/components/FileExplorer.tsx
@@ -97,6 +97,13 @@ function NodeRow({
   )
 }
 
+/** Drop the nodes with the given ids from a tree (for optimistic delete). */
+function removeFromTree(nodes: TreeNode[], ids: Set<string>): TreeNode[] {
+  return nodes
+    .filter((n) => !ids.has(n.id))
+    .map((n) => (n.children ? { ...n, children: removeFromTree(n.children, ids) } : n))
+}
+
 /** Workspace file tree with open/rename/move/delete/upload. */
 export function FileExplorer({ onOpenFile, refreshSignal, onSelectionChange }: FileExplorerProps) {
   const [data, setData] = useState<TreeNode[]>([])
@@ -158,6 +165,20 @@ export function FileExplorer({ onOpenFile, refreshSignal, onSelectionChange }: F
     })
   }
 
+  // Delete one or more paths: drop them from the tree immediately so they vanish
+  // without waiting on a full refetch, fire the deletes together, then reconcile
+  // with a single reload (which also restores anything whose delete failed).
+  const deleteMany = (ids: string[]) => {
+    if (ids.length === 0) return
+    const idSet = new Set(ids)
+    setData((d) => removeFromTree(d, idSet))
+    void Promise.allSettled(ids.map((id) => deletePath(id))).then((results) => {
+      const failed = results.filter((r) => r.status === 'rejected').length
+      if (failed > 0) setError(`failed to delete ${failed} item(s)`)
+      reload()
+    })
+  }
+
   // Any click/Escape outside the menu dismisses it; the menu itself stops
   // mousedown propagation so its buttons still receive their click.
   useEffect(() => {
@@ -183,7 +204,9 @@ export function FileExplorer({ onOpenFile, refreshSignal, onSelectionChange }: F
   const openMenu = (e: ReactMouseEvent, node: NodeApi<TreeNode>) => {
     e.preventDefault()
     e.stopPropagation()
-    node.select()
+    // Keep an existing multi-selection if the right-clicked row is part of it, so
+    // Delete can act on every selected row; otherwise select just this one.
+    if (!node.isSelected) node.select()
     setMenu({ x: e.clientX, y: e.clientY, node })
   }
 
@@ -248,9 +271,10 @@ export function FileExplorer({ onOpenFile, refreshSignal, onSelectionChange }: F
             }
           }}
           onDelete={({ nodes }) => {
-            const names = nodes.map((n) => n.data.name).join(', ')
-            if (window.confirm(`Delete ${names}?`)) {
-              for (const node of nodes) run(deletePath(node.data.id))
+            if (nodes.length === 0) return
+            const label = nodes.length > 1 ? `${nodes.length} items` : (nodes[0]?.data.name ?? '')
+            if (window.confirm(`Delete ${label}?`)) {
+              deleteMany(nodes.map((n) => n.data.id))
             }
           }}
         >
@@ -279,16 +303,24 @@ export function FileExplorer({ onOpenFile, refreshSignal, onSelectionChange }: F
               </button>
             )}
             <button onClick={menuAction(() => void menu.node.edit())}>Rename</button>
-            <button
-              className="danger"
-              onClick={menuAction(() => {
-                if (window.confirm(`Delete ${menu.node.data.name}?`)) {
-                  run(deletePath(menu.node.data.id))
-                }
-              })}
-            >
-              Delete
-            </button>
+            {(() => {
+              const sel = menu.node.tree.selectedNodes
+              const targets =
+                sel.length > 1 && sel.some((n) => n.id === menu.node.id) ? sel : [menu.node]
+              const label = targets.length > 1 ? `${targets.length} items` : menu.node.data.name
+              return (
+                <button
+                  className="danger"
+                  onClick={menuAction(() => {
+                    if (window.confirm(`Delete ${label}?`)) {
+                      deleteMany(targets.map((n) => n.data.id))
+                    }
+                  })}
+                >
+                  {targets.length > 1 ? `Delete ${targets.length} items` : 'Delete'}
+                </button>
+              )
+            })()}
           </div>
         )}
       </div>

--- a/frontend/src/components/Viewer.tsx
+++ b/frontend/src/components/Viewer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { memo, useEffect, useRef, useState } from 'react'
 import { Niivue, SHOW_RENDER, SLICE_TYPE } from '@niivue/niivue'
 import { fetchTree, rawUrl } from '../api'
 import { getDraggedFilePath } from '../dragState'
@@ -57,6 +57,10 @@ const LABEL_COLORMAP = labelColorMap()
 // use its numeric value.
 const COLORMAP_TYPE_TRANSPARENT_BELOW_MIN = 1
 
+// Persist the display convention across volumes/sessions. Default false =
+// neurological (Niivue's default: image-left is patient-left).
+const RADIOLOGICAL_KEY = 'medmcp.radiologicalView'
+
 type FileKind = 'volume' | 'pdf' | 'image' | 'text' | 'other'
 
 function classify(path: string): FileKind {
@@ -87,39 +91,69 @@ function collectVolumePaths(nodes: TreeNode[], out: string[] = []): string[] {
  * overlay is rendered with a label colormap (distinct color per integer label)
  * and adjustable opacity.
  */
-function VolumeView({ path, refreshSignal }: { path: string; refreshSignal?: number }) {
+function VolumeView({
+  path,
+  refreshSignal,
+  isResizing,
+}: {
+  path: string
+  refreshSignal?: number
+  isResizing?: boolean
+}) {
   const url = rawUrl(path)
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const sizerRef = useRef<HTMLDivElement>(null)
   const dropRef = useRef<HTMLDivElement>(null)
   const nvRef = useRef<Niivue | null>(null)
   const [loadError, setLoadError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
   const [volumePaths, setVolumePaths] = useState<string[]>([])
   const [overlayPath, setOverlayPath] = useState<string>('')
   const [overlayOpacity, setOverlayOpacity] = useState(0.5)
   const [dragOver, setDragOver] = useState(false)
-
-  // Decouple the canvas box from the panel layout: Niivue's own ResizeObserver
-  // does a full WebGL redraw (multiplanar + 3D ray cast) on every resize tick,
-  // which makes separator drags janky whenever a volume is loaded. The sizer
-  // div tracks the panel; the dropzone (Niivue's observed parent) gets an
-  // explicit pixel size that only syncs on a trailing debounce, so the canvas
-  // stays frozen during the drag and redraws once when it settles.
+  const [radiological, setRadiological] = useState(
+    () => localStorage.getItem(RADIOLOGICAL_KEY) === 'true',
+  )
+  // Read inside the url-keyed load effect without making it a dependency (a
+  // toggle must not tear down and reload the volume).
+  const radiologicalRef = useRef(radiological)
   useEffect(() => {
+    radiologicalRef.current = radiological
+  }, [radiological])
+  // Read inside the mount-once observer effect without re-subscribing.
+  const isResizingRef = useRef(isResizing)
+  useEffect(() => {
+    isResizingRef.current = isResizing
+  }, [isResizing])
+
+  // Size the dropzone (Niivue's observed parent) to the panel. We NEVER do this
+  // during a separator drag: Niivue leaks GPU resources each time its canvas
+  // resizes, so resizing the live instance is what made the viewer degrade. The
+  // sizer tracks the panel; the dropzone gets an explicit pixel size synced only
+  // while NOT dragging. After a drag the Viewer remounts this view fresh at the
+  // new size instead (see `resizeGen`). This observer therefore only matters for
+  // the initial mount and non-drag resizes (window/drawer).
+  const syncCanvasSize = () => {
     const sizer = sizerRef.current
     const drop = dropRef.current
-    if (!sizer || !drop) return
-    let timer: number | null = null
-    const sync = () => {
+    if (sizer && drop) {
       drop.style.width = `${sizer.clientWidth}px`
       drop.style.height = `${sizer.clientHeight}px`
     }
-    sync()
+  }
+  useEffect(() => {
+    const sizer = sizerRef.current
+    if (!sizer) return
+    let timer: number | null = null
+    syncCanvasSize()
     const obs = new ResizeObserver(() => {
+      // Clear first so a sync scheduled in the frame before `isResizing` commits
+      // can't fire mid-drag; then skip entirely while dragging.
       if (timer != null) window.clearTimeout(timer)
+      if (isResizingRef.current) return // never resize the WebGL canvas mid-drag
       timer = window.setTimeout(() => {
         timer = null
-        sync()
+        syncCanvasSize()
       }, 120)
     })
     obs.observe(sizer)
@@ -130,13 +164,22 @@ function VolumeView({ path, refreshSignal }: { path: string; refreshSignal?: num
   }, [])
 
   // Base volume: one Niivue instance per mounted view (remounted via key on
-  // path change), so overlay state always starts clean for a new image.
+  // path change, and on resize-settle), so overlay state always starts clean.
   useEffect(() => {
     const canvas = canvasRef.current
     if (!canvas) return
     const nv = new Niivue({
       multiplanarShowRender: SHOW_RENDER.ALWAYS,
-      backColor: [0.051, 0.059, 0.078, 1],
+      // Render at 1× pixel ratio instead of the display's HiDPI/Retina ratio.
+      // On a 2× display that's 4× fewer pixels per frame — the single biggest
+      // GPU saving, and it costs no data fidelity: slices are sampled from the
+      // volume, so screen pixels beyond the data resolution are wasted work.
+      // (-1 = block high DPI; this is what was overloading the Intel iGPU.)
+      forceDevicePixelRatio: -1,
+      backColor: [0, 0, 0, 1],
+      // Suppress Niivue's own canvas "loading ..." text — our spinner overlay
+      // is the single loading affordance.
+      loadingText: '',
       // Niivue's own canvas drop handler stopPropagation()s every drop (to load
       // OS files as a new base image). We handle overlay drops ourselves in the
       // capture phase, so disable Niivue's to avoid it hijacking the base image.
@@ -145,12 +188,27 @@ function VolumeView({ path, refreshSignal }: { path: string; refreshSignal?: num
     nvRef.current = nv
     let cancelled = false
     const load = async () => {
+      setLoading(true)
+      setLoadError(null)
       try {
-        await nv.attachToCanvas(canvas)
+        // Disable MSAA: it multiplies the framebuffer's GPU memory, which is the
+        // likely trigger for the WebGL context loss on a memory-starved Intel
+        // iGPU. AA only smooths edges — it doesn't affect slice/data resolution.
+        await nv.attachToCanvas(canvas, false)
         nv.setSliceType(SLICE_TYPE.MULTIPLANAR)
+        // Niivue streams the download/inflate, but parsing the volume and the
+        // initial WebGL upload + 3D render run synchronously on the main thread
+        // — a big volume briefly freezes the tab. Yield a frame here so the
+        // loading overlay actually paints before that blocking work starts,
+        // instead of the viewer just appearing hung.
+        await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))
+        if (cancelled) return
         await nv.loadVolumes([{ url }])
+        nv.setRadiologicalConvention(radiologicalRef.current)
       } catch (e) {
         if (!cancelled) setLoadError(String(e))
+      } finally {
+        if (!cancelled) setLoading(false)
       }
     }
     // Seed the overlay-op chain with the base load so an overlay dropped
@@ -159,6 +217,17 @@ function VolumeView({ path, refreshSignal }: { path: string; refreshSignal?: num
     return () => {
       cancelled = true
       nvRef.current = null
+      // Each opened file (and each resize-settle) remounts this view and builds
+      // a fresh Niivue + WebGL context. cleanup() removes Niivue's observers and
+      // listeners, then we force-release the GL context: browsers cap live
+      // contexts (~16) and drop the oldest once exceeded, which janks the whole
+      // tab — so a long session must not leak them.
+      try {
+        nv.cleanup()
+        nv.gl?.getExtension('WEBGL_lose_context')?.loseContext()
+      } catch {
+        // best-effort teardown
+      }
     }
   }, [url])
 
@@ -228,6 +297,12 @@ function VolumeView({ path, refreshSignal }: { path: string; refreshSignal?: num
     }
   }
 
+  const setConvention = (value: boolean) => {
+    setRadiological(value)
+    localStorage.setItem(RADIOLOGICAL_KEY, String(value))
+    nvRef.current?.setRadiologicalConvention(value)
+  }
+
   // A path is a valid overlay if it's a volume other than the base image.
   const isOverlayCandidate = (p: string | null): p is string =>
     !!p && p !== path && VOLUME_EXT.test(p.toLowerCase())
@@ -292,6 +367,17 @@ function VolumeView({ path, refreshSignal }: { path: string; refreshSignal?: num
             </button>
           </>
         )}
+        <button
+          className="btn-plain conv-toggle"
+          title={
+            radiological
+              ? 'Radiological convention (image-left = patient-right) — click for neurological'
+              : 'Neurological convention (image-left = patient-left) — click for radiological'
+          }
+          onClick={() => setConvention(!radiological)}
+        >
+          {radiological ? 'Radiological' : 'Neurological'}
+        </button>
       </div>
       {loadError && <div className="panel-error">{loadError}</div>}
       <div className="niivue-sizer" ref={sizerRef}>
@@ -306,6 +392,15 @@ function VolumeView({ path, refreshSignal }: { path: string; refreshSignal?: num
           {dragOver && <div className="dropzone-hint">Drop to overlay</div>}
         </div>
       </div>
+      {/* Covers the whole volume view (overlay bar + canvas) so it centers in
+          the same box as the Viewer's rebuild spinner — otherwise the wheel
+          jumps when one hands off to the other across a resize-rebuild. */}
+      {loading && (
+        <div className="volume-loading">
+          <span className="volume-spinner" />
+          <span>Loading volume…</span>
+        </div>
+      )}
     </div>
   )
 }
@@ -326,21 +421,56 @@ function TextView({ url }: { url: string }) {
 }
 
 /** Routes the selected file to the right renderer (volume / PDF / image / text). */
-export function Viewer({
+// Memoized so a separator drag doesn't re-render the viewer (and its WebGL/React
+// subtree) every frame; props from App are stable except when the open file or
+// fs version actually changes.
+export const Viewer = memo(function Viewer({
   path,
   refreshSignal,
+  isResizing,
 }: {
   path: string | null
   /** Bumped when the workspace may have changed; refreshes the overlay list. */
   refreshSignal?: number
+  /** True while a separator is being dragged; freezes the volume canvas size. */
+  isResizing?: boolean
 }) {
+  // Niivue leaks GPU memory each time its canvas is resized, so we never resize
+  // the live instance — we rebuild it fresh at the new size once a separator
+  // drag settles. `resizeGen` is part of the VolumeView key; bumping it remounts
+  // the volume (same mechanism that resets it when you open a file). Debounced so
+  // a burst of adjustments collapses into one rebuild; gated by `didResize` so
+  // mount / non-resize renders don't trigger a spurious reload.
+  const [resizeGen, setResizeGen] = useState(0)
+  // True from the moment a resize drag ends until the fresh view has remounted,
+  // so we hide the stale (wrong-size) canvas and show the spinner instead of
+  // letting the old image flash at the wrong size during the debounce window.
+  const [rebuilding, setRebuilding] = useState(false)
+  const didResizeRef = useRef(false)
+  useEffect(() => {
+    if (isResizing) {
+      didResizeRef.current = true
+      return
+    }
+    if (!didResizeRef.current) return
+    didResizeRef.current = false
+    setRebuilding(true)
+    const t = window.setTimeout(() => {
+      setResizeGen((g) => g + 1)
+      setRebuilding(false)
+    }, 250)
+    return () => window.clearTimeout(t)
+  }, [isResizing])
+
   if (!path) {
     return (
       <div className="panel">
         <div className="panel-header">
           <span>Viewer</span>
         </div>
-        <div className="viewer-message">Select a file in the explorer to view it here.</div>
+        <div className="panel-body viewer-body">
+          <div className="viewer-message">Select a file in the explorer to view it here.</div>
+        </div>
       </div>
     )
   }
@@ -359,7 +489,22 @@ export function Viewer({
         </span>
       </div>
       <div className="panel-body viewer-body">
-        {kind === 'volume' && <VolumeView key={path} path={path} refreshSignal={refreshSignal} />}
+        {kind === 'volume' && (
+          <div className={`volume-slot${rebuilding ? ' rebuilding' : ''}`}>
+            <VolumeView
+              key={`${path}#${resizeGen}`}
+              path={path}
+              refreshSignal={refreshSignal}
+              isResizing={isResizing}
+            />
+            {rebuilding && (
+              <div className="volume-loading">
+                <span className="volume-spinner" />
+                <span>Loading volume…</span>
+              </div>
+            )}
+          </div>
+        )}
         {kind === 'pdf' && <iframe className="pdf-frame" src={url} title={path} />}
         {kind === 'image' && <img className="image-view" src={url} alt={path} />}
         {kind === 'text' && <TextView key={url} url={url} />}
@@ -374,4 +519,4 @@ export function Viewer({
       </div>
     </div>
   )
-}
+})

--- a/frontend/src/components/WorkflowPanel.tsx
+++ b/frontend/src/components/WorkflowPanel.tsx
@@ -53,6 +53,7 @@ type Mode =
       total: number
       stepsPerItem: number
       startedAt: number
+      lastStepAt: number
       items: ItemResult[]
       log: ReplayStepFrame[]
     }
@@ -110,13 +111,25 @@ function itemLabel(runs: Record<string, string>[], batchInput: string | null, i:
   return v ? basename(v) : `Item ${i + 1}`
 }
 
-/** Elapsed time, plus a rough ETA for a batch once at least one item is done. */
+/** 1-based step number currently in progress for the active item. */
+function currentStep(m: Extract<Mode, { kind: 'running' }>): number {
+  const prevSteps = m.items.reduce((acc, it) => acc + it.steps, 0)
+  return Math.min(m.log.length - prevSteps + 1, m.stepsPerItem)
+}
+
+/** Elapsed time, plus a counting-down ETA extrapolated from finished steps. */
 function runTiming(m: Extract<Mode, { kind: 'running' }>, now: number): string {
   const elapsed = now - m.startedAt
   let label = `elapsed ${formatDuration(elapsed)}`
-  if (m.total > 1 && m.items.length > 0 && m.items.length < m.total) {
-    const remaining = (elapsed / m.items.length) * (m.total - m.items.length)
-    label += ` · ~${formatDuration(remaining)} left`
+  const totalSteps = m.total * m.stepsPerItem
+  const doneSteps = m.log.length
+  // Average over *finished* step time only (lastStepAt), not total elapsed —
+  // otherwise a long in-flight step inflates the average and the ETA climbs.
+  // Then count down: remaining = estimated total − elapsed. Rough, hence "~".
+  if (doneSteps > 0 && doneSteps < totalSteps) {
+    const avgPerStep = (m.lastStepAt - m.startedAt) / doneSteps
+    const remaining = avgPerStep * totalSteps - elapsed
+    if (remaining > 0) label += ` · ~${formatDuration(remaining)} left`
   }
   return label
 }
@@ -254,11 +267,11 @@ function RunLog({
   return <div className="wf-runlog">{rows}</div>
 }
 
-function ProgressBar({ frac, label }: { frac: number; label: string }) {
+function ProgressBar({ frac, label, active }: { frac: number; label: string; active?: boolean }) {
   const pct = Math.round(Math.min(Math.max(frac, 0), 1) * 100)
   return (
     <div className="wf-progress" title={`${pct}%`}>
-      <span className="wf-progress-bar">
+      <span className={active ? 'wf-progress-bar active' : 'wf-progress-bar'}>
         <span className="wf-progress-fill" style={{ width: `${pct}%` }} />
       </span>
       <span className="wf-progress-label">{label}</span>
@@ -349,8 +362,12 @@ export function WorkflowPanel({
   const detailForRef = useRef<string | null>(null)
 
   const openDetail = async (name: string) => {
-    runWs.current?.close()
-    setMode({ kind: 'view' })
+    // Leave an in-flight or finished run alone when toggling rows — its card is
+    // pinned at the panel top, so collapsing/switching no longer aborts or hides it.
+    if (mode.kind !== 'running' && mode.kind !== 'done') {
+      runWs.current?.close()
+      setMode({ kind: 'view' })
+    }
     if (expanded === name) {
       detailForRef.current = null
       setExpanded(null)
@@ -473,6 +490,7 @@ export function WorkflowPanel({
       total: runs.length,
       stepsPerItem,
       startedAt,
+      lastStepAt: startedAt,
       items: [],
       log: [],
     })
@@ -488,7 +506,9 @@ export function WorkflowPanel({
       onWorkspaceChanged?.()
       if (frame.type === 'step') {
         const step = frame
-        setMode((m) => (m.kind === 'running' ? { ...m, log: [...m.log, step] } : m))
+        setMode((m) =>
+          m.kind === 'running' ? { ...m, log: [...m.log, step], lastStepAt: Date.now() } : m,
+        )
       } else if (frame.type === 'item_result') {
         const res = frame
         setMode((m) => {
@@ -560,6 +580,44 @@ export function WorkflowPanel({
       batchInput: null,
     })
   }
+
+  const renderRunning = (m: Extract<Mode, { kind: 'running' }>) => (
+    <div className="wf-form">
+      <div className="wf-hint">Replaying… step results appear as they finish.</div>
+      <ProgressBar
+        frac={runProgress(m)}
+        active
+        label={
+          m.total > 1
+            ? `item ${Math.min(m.items.length + 1, m.total)} of ${m.total}`
+            : `step ${Math.min(m.log.length + 1, m.stepsPerItem)} of ${m.stepsPerItem}`
+        }
+      />
+      <div className="wf-active">
+        {m.items.length < m.total ? (
+          m.batchInput ? (
+            <span>
+              Processing <strong>{basename(m.runs[m.items.length]?.[m.batchInput] ?? '')}</strong> —
+              item {m.items.length + 1} of {m.total} · step {currentStep(m)} of {m.stepsPerItem}
+            </span>
+          ) : (
+            <span>
+              Running step {currentStep(m)} of {m.stepsPerItem}
+            </span>
+          )
+        ) : (
+          <span>Finishing…</span>
+        )}
+      </div>
+      <div className="wf-timing">{runTiming(m, now)}</div>
+      <RunLog log={m.log} total={m.total} runs={m.runs} batchInput={m.batchInput} />
+      <div className="wf-actions">
+        <button className="btn-danger" onClick={() => runWs.current?.close()}>
+          <StopSquareIcon size={12} /> Stop
+        </button>
+      </div>
+    </div>
+  )
 
   const renderDone = (m: Extract<Mode, { kind: 'done' }>) => {
     const succeeded = m.items.filter((it) => it.ok).length
@@ -880,28 +938,6 @@ export function WorkflowPanel({
         </div>
       )}
 
-      {mode.kind === 'running' && (
-        <div className="wf-form">
-          <div className="wf-hint">Replaying… step results appear as they finish.</div>
-          <ProgressBar
-            frac={runProgress(mode)}
-            label={
-              mode.total > 1
-                ? `item ${Math.min(mode.items.length + 1, mode.total)} of ${mode.total}`
-                : `step ${Math.min(mode.log.length + 1, mode.stepsPerItem)} of ${mode.stepsPerItem}`
-            }
-          />
-          <div className="wf-timing">{runTiming(mode, now)}</div>
-          <RunLog log={mode.log} total={mode.total} runs={mode.runs} batchInput={mode.batchInput} />
-          <div className="wf-actions">
-            <button className="btn-danger" onClick={() => runWs.current?.close()}>
-              <StopSquareIcon size={12} /> Stop
-            </button>
-          </div>
-        </div>
-      )}
-
-      {mode.kind === 'done' && renderDone(mode)}
     </div>
   )
 
@@ -937,6 +973,14 @@ export function WorkflowPanel({
         {busy && (
           <div className="wf-busy">
             <span className="status-dot busy" /> {busy}
+          </div>
+        )}
+        {(mode.kind === 'running' || mode.kind === 'done') && (
+          <div className="wf-run-card">
+            <div className="wf-run-card-head">
+              <PlayIcon size={12} /> {mode.name}
+            </div>
+            {mode.kind === 'running' ? renderRunning(mode) : renderDone(mode)}
           </div>
         )}
         {enabled && workflows !== null && workflows.length === 0 && !busy && (

--- a/frontend/src/components/WorkflowPanel.tsx
+++ b/frontend/src/components/WorkflowPanel.tsx
@@ -47,14 +47,24 @@ type Mode =
     }
   | {
       kind: 'running'
+      name: string
+      runs: Record<string, string>[]
+      batchInput: string | null
       total: number
       stepsPerItem: number
+      startedAt: number
       items: ItemResult[]
       log: ReplayStepFrame[]
     }
   | {
       kind: 'done'
+      name: string
+      runs: Record<string, string>[]
+      batchInput: string | null
       total: number
+      stepsPerItem: number
+      startedAt: number
+      finishedAt: number
       items: ItemResult[]
       log: ReplayStepFrame[]
       ok: boolean
@@ -80,6 +90,64 @@ function buildRuns(
     return batchValues.map((v) => ({ ...values, [batchInput]: v }))
   }
   return [values]
+}
+
+/** "1m 23s" / "45s" from a millisecond duration. */
+function formatDuration(ms: number): string {
+  const s = Math.max(0, Math.round(ms / 1000))
+  if (s < 60) return `${s}s`
+  return `${Math.floor(s / 60)}m ${String(s % 60).padStart(2, '0')}s`
+}
+
+function basename(p: string): string {
+  const i = p.lastIndexOf('/')
+  return i >= 0 ? p.slice(i + 1) : p
+}
+
+/** Short label for batch item *i* — its batched input's filename, else "Item N". */
+function itemLabel(runs: Record<string, string>[], batchInput: string | null, i: number): string {
+  const v = batchInput ? runs[i]?.[batchInput] : undefined
+  return v ? basename(v) : `Item ${i + 1}`
+}
+
+/** Elapsed time, plus a rough ETA for a batch once at least one item is done. */
+function runTiming(m: Extract<Mode, { kind: 'running' }>, now: number): string {
+  const elapsed = now - m.startedAt
+  let label = `elapsed ${formatDuration(elapsed)}`
+  if (m.total > 1 && m.items.length > 0 && m.items.length < m.total) {
+    const remaining = (elapsed / m.items.length) * (m.total - m.items.length)
+    label += ` · ~${formatDuration(remaining)} left`
+  }
+  return label
+}
+
+/** Produced file paths, clickable to open in the viewer when a handler is given. */
+function OutputLinks({
+  paths,
+  onOpenFile,
+}: {
+  paths: string[]
+  onOpenFile?: (path: string) => void
+}) {
+  return (
+    <span className="wf-output-list">
+      {paths.map((p) =>
+        onOpenFile ? (
+          <button
+            key={p}
+            type="button"
+            className="wf-output-link"
+            title="Open in viewer"
+            onClick={() => onOpenFile(p)}
+          >
+            {p}
+          </button>
+        ) : (
+          <code key={p}>{p}</code>
+        ),
+      )}
+    </span>
+  )
 }
 
 /** One replay input field; accepts a file drag from the explorer. */
@@ -142,15 +210,27 @@ function StepList({ steps }: { steps: { server: string; tool: string }[] }) {
   )
 }
 
-function RunLog({ log, total = 1 }: { log: ReplayStepFrame[]; total?: number }) {
+function RunLog({
+  log,
+  total = 1,
+  runs,
+  batchInput,
+}: {
+  log: ReplayStepFrame[]
+  total?: number
+  runs?: Record<string, string>[]
+  batchInput?: string | null
+}) {
   const rows: ReactNode[] = []
   let lastItem = -1
   for (const s of log) {
     const item = s.item ?? 0
     if (total > 1 && item !== lastItem) {
+      const file = runs && batchInput ? basename(runs[item]?.[batchInput] ?? '') : ''
       rows.push(
         <div key={`item-${item}`} className="wf-runitem">
           Item {item + 1} of {total}
+          {file && ` · ${file}`}
         </div>,
       )
       lastItem = item
@@ -217,11 +297,14 @@ function BatchSelection({ paths }: { paths: string[] }) {
 export function WorkflowPanel({
   distillSessionId,
   onWorkspaceChanged,
+  onOpenFile,
   selectedPaths = [],
 }: {
   distillSessionId: string | null
   /** Called when a replay step may have written files into the workspace. */
   onWorkspaceChanged?: () => void
+  /** Open a produced file in the viewer. */
+  onOpenFile?: (path: string) => void
   /** Files multi-selected in the explorer — offered to the batch editor. */
   selectedPaths?: string[]
 }) {
@@ -232,6 +315,7 @@ export function WorkflowPanel({
   const [mode, setMode] = useState<Mode>({ kind: 'view' })
   const [busy, setBusy] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [now, setNow] = useState(0)
   const runWs = useRef<WebSocket | null>(null)
 
   const reload = useCallback(
@@ -250,6 +334,13 @@ export function WorkflowPanel({
     void reload()
     return () => runWs.current?.close()
   }, [reload])
+
+  // Tick once a second while a run is live so the elapsed/ETA readout updates.
+  useEffect(() => {
+    if (mode.kind !== 'running') return
+    const id = setInterval(() => setNow(Date.now()), 1000)
+    return () => clearInterval(id)
+  }, [mode.kind])
 
   // The workflow whose detail the panel currently wants. Guards against a
   // slow response for a previously clicked row overwriting the current one —
@@ -363,11 +454,28 @@ export function WorkflowPanel({
       setMode({ kind: 'preview', values, batchInput, batchValues, steps: res.steps })
     })
 
-  const startRun = (name: string, runs: Record<string, string>[], stepsPerItem: number) => {
+  const startRun = (
+    name: string,
+    runs: Record<string, string>[],
+    stepsPerItem: number,
+    batchInput: string | null,
+    startedAt: number,
+  ) => {
     const proto = location.protocol === 'https:' ? 'wss' : 'ws'
     const ws = new WebSocket(`${proto}://${location.host}/ws/replay`)
     runWs.current = ws
-    setMode({ kind: 'running', total: runs.length, stepsPerItem, items: [], log: [] })
+    setNow(startedAt)
+    setMode({
+      kind: 'running',
+      name,
+      runs,
+      batchInput,
+      total: runs.length,
+      stepsPerItem,
+      startedAt,
+      items: [],
+      log: [],
+    })
     let finished = false
     ws.onopen = () => ws.send(JSON.stringify({ name, runs }))
     ws.onmessage = (ev: MessageEvent<string>) => {
@@ -401,7 +509,13 @@ export function WorkflowPanel({
           m.kind === 'running'
             ? {
                 kind: 'done',
+                name: m.name,
+                runs: m.runs,
+                batchInput: m.batchInput,
                 total: m.total,
+                stepsPerItem: m.stepsPerItem,
+                startedAt: m.startedAt,
+                finishedAt: Date.now(),
                 items: m.items,
                 log: m.log,
                 ok: result.ok,
@@ -417,7 +531,13 @@ export function WorkflowPanel({
           m.kind === 'running'
             ? {
                 kind: 'done',
+                name: m.name,
+                runs: m.runs,
+                batchInput: m.batchInput,
                 total: m.total,
+                stepsPerItem: m.stepsPerItem,
+                startedAt: m.startedAt,
+                finishedAt: Date.now(),
                 items: m.items,
                 log: m.log,
                 ok: false,
@@ -439,6 +559,83 @@ export function WorkflowPanel({
       values: Object.fromEntries(d.inputs.map((i) => [i.name, ''])),
       batchInput: null,
     })
+  }
+
+  const renderDone = (m: Extract<Mode, { kind: 'done' }>) => {
+    const succeeded = m.items.filter((it) => it.ok).length
+    const failedRan = m.items.filter((it) => !it.ok).length
+    const notRun = m.total - m.items.length
+    const retryRuns = m.runs.filter((_, i) => !m.items[i]?.ok)
+    const duration = m.finishedAt - m.startedAt
+    return (
+      <div className="wf-form">
+        {m.total > 1 && (
+          <div className="wf-run-summary">
+            <span className="tally-ok">{succeeded} done</span>
+            {failedRan > 0 && <span className="tally-fail">{failedRan} failed</span>}
+            {notRun > 0 && <span className="tally-muted">{notRun} not run</span>}
+            <span className="tally-muted">in {formatDuration(duration)}</span>
+          </div>
+        )}
+        <RunLog log={m.log} total={m.total} runs={m.runs} batchInput={m.batchInput} />
+        {m.total > 1 && (
+          <div className="wf-batch-summary">
+            {m.items.map((it, i) => (
+              <div key={i} className={it.ok ? 'wf-runstep ok' : 'wf-runstep fail'}>
+                <span className={`status-dot ${it.ok ? 'ok' : 'fail'}`} />
+                <span>
+                  {itemLabel(m.runs, m.batchInput, i)}:{' '}
+                  {it.ok ? (
+                    it.outputs.length > 0 ? (
+                      <>
+                        done → <OutputLinks paths={it.outputs} onOpenFile={onOpenFile} />
+                      </>
+                    ) : (
+                      'done'
+                    )
+                  ) : (
+                    (it.error ?? 'failed')
+                  )}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+        {m.ok ? (
+          <div className="wf-result ok">
+            {m.total > 1
+              ? `Batch complete — all ${m.items.length} item(s) succeeded in ${formatDuration(duration)}.`
+              : `Replay complete in ${formatDuration(duration)} — ${m.log.length} step(s) ran.`}
+            {m.total === 1 && m.items.some((it) => it.outputs.length > 0) && (
+              <div className="wf-outputs">
+                Outputs:
+                <OutputLinks paths={m.items.flatMap((it) => it.outputs)} onOpenFile={onOpenFile} />
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="wf-result fail">
+            {m.total > 1 && succeeded > 0
+              ? `${succeeded} of ${m.total} item(s) succeeded — ${retryRuns.length} need a retry.`
+              : `Replay failed. ${m.error ?? ''}`}
+          </div>
+        )}
+        <div className="wf-actions">
+          {retryRuns.length > 0 && (
+            <button
+              className="btn-primary"
+              title="Re-run only the items that failed or didn't finish"
+              onClick={() => startRun(m.name, retryRuns, m.stepsPerItem, m.batchInput, Date.now())}
+            >
+              <RefreshIcon size={12} /> Retry {retryRuns.length}
+            </button>
+          )}
+          <button className="btn-plain" onClick={() => setMode({ kind: 'view' })}>
+            Close
+          </button>
+        </div>
+      </div>
+    )
   }
 
   const renderDetail = (d: WorkflowDetail) => (
@@ -662,6 +859,8 @@ export function WorkflowPanel({
                   d.name,
                   buildRuns(mode.values, mode.batchInput, mode.batchValues),
                   d.steps.length,
+                  mode.batchInput,
+                  Date.now(),
                 )
               }
             >
@@ -692,7 +891,8 @@ export function WorkflowPanel({
                 : `step ${Math.min(mode.log.length + 1, mode.stepsPerItem)} of ${mode.stepsPerItem}`
             }
           />
-          <RunLog log={mode.log} total={mode.total} />
+          <div className="wf-timing">{runTiming(mode, now)}</div>
+          <RunLog log={mode.log} total={mode.total} runs={mode.runs} batchInput={mode.batchInput} />
           <div className="wf-actions">
             <button className="btn-danger" onClick={() => runWs.current?.close()}>
               <StopSquareIcon size={12} /> Stop
@@ -701,50 +901,7 @@ export function WorkflowPanel({
         </div>
       )}
 
-      {mode.kind === 'done' && (
-        <div className="wf-form">
-          <RunLog log={mode.log} total={mode.total} />
-          {mode.total > 1 && (
-            <div className="wf-batch-summary">
-              {mode.items.map((it, i) => (
-                <div key={i} className={it.ok ? 'wf-runstep ok' : 'wf-runstep fail'}>
-                  <span className={`status-dot ${it.ok ? 'ok' : 'fail'}`} />
-                  <span>
-                    Item {i + 1}:{' '}
-                    {it.ok
-                      ? it.outputs.length > 0
-                        ? `done → ${it.outputs.join(', ')}`
-                        : 'done'
-                      : (it.error ?? 'failed')}
-                  </span>
-                </div>
-              ))}
-            </div>
-          )}
-          {mode.ok ? (
-            <div className="wf-result ok">
-              {mode.total > 1
-                ? `Batch complete — ${mode.items.length} item(s) ran.`
-                : `Replay complete — ${mode.log.length} step(s) ran.`}
-              {mode.total === 1 && mode.items.some((it) => it.outputs.length > 0) && (
-                <div className="wf-outputs">
-                  Outputs:
-                  {mode.items.flatMap((it) => it.outputs).map((o) => (
-                    <code key={o}>{o}</code>
-                  ))}
-                </div>
-              )}
-            </div>
-          ) : (
-            <div className="wf-result fail">Replay failed. {mode.error ?? ''}</div>
-          )}
-          <div className="wf-actions">
-            <button className="btn-plain" onClick={() => setMode({ kind: 'view' })}>
-              Close
-            </button>
-          </div>
-        </div>
-      )}
+      {mode.kind === 'done' && renderDone(mode)}
     </div>
   )
 

--- a/frontend/src/components/WorkflowPanel.tsx
+++ b/frontend/src/components/WorkflowPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { memo, useCallback, useEffect, useRef, useState } from 'react'
 import type { ReactNode } from 'react'
 import {
   deleteWorkflow,
@@ -307,7 +307,12 @@ function BatchSelection({ paths }: { paths: string[] }) {
  * review/promote/refine drafts, and replay a recipe deterministically (no
  * LLM) on new inputs with a preview + explicit confirmation.
  */
-export function WorkflowPanel({
+// Memoized: App bumps `fsVersion` on every completed tool call / turn end to
+// refresh the explorer and viewer, but this panel doesn't read it — memo keeps
+// those bumps (frequent during an agent turn) from re-rendering it, and keeps
+// it from re-rendering each frame while a separator is dragged. Its props from
+// App are stable refs.
+export const WorkflowPanel = memo(function WorkflowPanel({
   distillSessionId,
   onWorkspaceChanged,
   onOpenFile,
@@ -1013,4 +1018,4 @@ export function WorkflowPanel({
       </div>
     </div>
   )
-}
+})

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -156,7 +156,12 @@ button:hover {
   font-weight: 800;
   font-size: 15px;
   letter-spacing: -0.03em;
-  color: #fff;
+  /* Brand wordmark gradient, matching the marketing site's .nav-logo. */
+  background: linear-gradient(110deg, var(--red) 0%, #d96090 45%, var(--blue-l) 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
 }
 
 .app-subtitle {
@@ -374,6 +379,7 @@ button:hover {
   display: flex;
   align-items: stretch;
   justify-content: stretch;
+  background: #000;
 }
 
 .viewer-title {
@@ -400,7 +406,23 @@ button:hover {
   color: var(--blue-xl);
 }
 
+/* Wraps the volume view so the rebuild spinner can overlay it; while rebuilding
+ * (after a resize, before the fresh view mounts) the stale canvas is hidden so
+ * it can't flash at the wrong size. */
+.volume-slot {
+  position: relative;
+  flex: 1;
+  display: flex;
+  min-width: 0;
+  min-height: 0;
+}
+
+.volume-slot.rebuilding .niivue-canvas {
+  display: none !important;
+}
+
 .volume-view {
+  position: relative;
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -441,6 +463,25 @@ button:hover {
 .overlay-select:focus {
   outline: none;
   border-color: rgba(127, 168, 245, 0.4);
+}
+
+/* Display-convention toggle, pushed to the right edge of the overlay bar. */
+.conv-toggle {
+  margin-left: auto;
+  flex-shrink: 0;
+  background: var(--card);
+  border: 1px solid var(--border2);
+  border-radius: 6px;
+  padding: 3px 10px;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  font-weight: 500;
+  color: var(--muted2);
+}
+
+.conv-toggle:hover {
+  border-color: var(--blue-l);
+  color: var(--text);
 }
 
 .overlay-opacity-label {
@@ -503,6 +544,39 @@ button:hover {
   flex: 1;
 }
 
+/* Shown while Niivue parses/uploads a volume (a big one briefly blocks the
+ * main thread); a frame is yielded before that work so this paints first. */
+.volume-loading {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  background: rgba(13, 15, 20, 0.72);
+  color: var(--muted2);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  pointer-events: none;
+}
+
+.volume-spinner {
+  width: 30px;
+  height: 30px;
+  border: 3px solid var(--border2);
+  border-top-color: var(--blue-xl);
+  border-radius: 50%;
+  animation: volume-spin 0.8s linear infinite;
+}
+
+@keyframes volume-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .pdf-frame {
   width: 100%;
   height: 100%;
@@ -510,11 +584,20 @@ button:hover {
   background: #fff;
 }
 
-/* While a viewer-bordering separator is dragged (App sets `is-resizing`), skip
- * painting the WebGL canvas and PDF frame — compositing them each frame is what
- * makes the drag heavy. They reappear, and the viewer redraws once, on release.
- * (Hiding the iframe also stops it swallowing the drag's pointer events.) */
-.is-resizing .niivue-canvas,
+/* While a viewer-bordering separator is dragged (App sets `is-resizing`), drop
+ * the WebGL canvas's compositor layer entirely. `visibility: hidden` stops it
+ * painting but Chrome keeps the (large, GPU-backed) canvas as its own layer and
+ * re-evaluates it every frame as the panel resizes — that compositing is what
+ * made the drag heavy. `display: none` removes the layer; the canvas reappears
+ * and the viewer redraws once on release (the size resync in VolumeView).
+ * `!important` is required: Niivue sets `canvas.style.display = "block"` inline,
+ * which a plain class rule can't override. */
+.is-resizing .niivue-canvas {
+  display: none !important;
+}
+
+/* The PDF iframe only needs to stop painting / swallowing the drag's pointer
+ * events; visibility avoids an iframe reload that display:none can trigger. */
 .is-resizing .pdf-frame {
   visibility: hidden;
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1658,6 +1658,56 @@ textarea.wf-input {
   word-break: break-all;
 }
 
+.wf-run-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 12px;
+  align-items: baseline;
+  font-size: 12.5px;
+  font-weight: 600;
+}
+
+.wf-run-summary .tally-ok {
+  color: var(--ok);
+}
+
+.wf-run-summary .tally-fail {
+  color: var(--red-tint);
+}
+
+.wf-run-summary .tally-muted {
+  color: var(--muted);
+  font-weight: 500;
+  font-size: 11.5px;
+}
+
+.wf-timing {
+  color: var(--muted);
+  font-size: 11.5px;
+}
+
+.wf-output-list {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 2px 8px;
+}
+
+.wf-output-link {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--blue-xl);
+  background: none;
+  border: none;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
+  word-break: break-all;
+}
+
+.wf-output-link:hover {
+  text-decoration: underline;
+}
+
 /* ── Context meter (chat header) ────────────────────────── */
 
 .ctx-meter {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1563,6 +1563,26 @@ textarea.wf-input {
   border-radius: 4px;
   background: var(--card2);
   overflow: hidden;
+  position: relative;
+}
+
+/* A sweeping highlight while a run is active, so the bar reads as alive even
+   during a long step that hasn't reported back yet. */
+.wf-progress-bar.active::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, transparent, rgba(127, 168, 245, 0.55), transparent);
+  animation: wf-shimmer 1.1s linear infinite;
+}
+
+@keyframes wf-shimmer {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
 }
 
 .wf-progress-fill {
@@ -1579,6 +1599,44 @@ textarea.wf-input {
   font-variant-numeric: tabular-nums;
   color: var(--muted);
   white-space: nowrap;
+}
+
+.wf-active {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 12px;
+  color: var(--muted2);
+}
+
+.wf-active strong {
+  font-family: var(--mono);
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--muted2);
+  word-break: break-all;
+}
+
+/* The active/finished run, pinned at the panel top so it survives collapsing or
+   switching workflow rows. */
+.wf-run-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px;
+  margin-bottom: 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--card2);
+}
+
+.wf-run-card-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--muted2);
 }
 
 .wf-batch-selection {

--- a/src/medmcp/replay.py
+++ b/src/medmcp/replay.py
@@ -378,3 +378,64 @@ async def run(
             return await replay_with_caller(recipe, inputs, caller=caller, on_step=on_step)
     except ReplayError as exc:
         return ReplayResult(ok=False, error=str(exc))
+
+
+async def run_batch(
+    recipe: Recipe,
+    runs: list[dict[str, Any]],
+    *,
+    servers: list[JsonDict],
+    cwd: str | None = None,
+    tool_timeout_sec: float = DEFAULT_TOOL_TIMEOUT_SEC,
+    on_step: Callable[[int, StepResult], Awaitable[None]] | None = None,
+    on_item: Callable[[int, ReplayResult], Awaitable[None]] | None = None,
+) -> list[ReplayResult]:
+    """Replay *recipe* once per input binding in *runs*, sharing one set of stacks.
+
+    Like calling :func:`run` for each item, but the needed MCP servers are spawned
+    **once** and reused across every item — a batch of N items pays the
+    server-startup cost once, not N times. Items run sequentially; a failed item
+    does not stop the rest. Each item is validated against its own inputs, and an
+    item that fails validation is recorded as a failed :class:`ReplayResult`
+    without running a step. ``on_step``/``on_item`` stream progress tagged with the
+    item's index in *runs*; the return value is one :class:`ReplayResult` per item,
+    in order.
+
+    Because the MCP sessions are shared, a stack that crashes mid-batch stays down
+    for the remaining items (they fail rather than respawn) — :func:`run`'s per-item
+    isolation is traded for the startup saving.
+    """
+    pre = [validate(recipe, inputs, servers) for inputs in runs]
+    results: list[ReplayResult] = []
+
+    async def _emit(item: int, res: ReplayResult) -> None:
+        results.append(res)
+        if on_item is not None:
+            await on_item(item, res)
+
+    # Nothing can run (a built-in step, an uninstalled stack, or no items at all):
+    # report each item's failure without paying to spawn the stacks.
+    if all(err is not None for err in pre):
+        for item, err in enumerate(pre):
+            await _emit(item, ReplayResult(ok=False, error=err))
+        return results
+
+    try:
+        async with mcp_caller(servers, cwd=cwd, tool_timeout_sec=tool_timeout_sec) as caller:
+            for item, (inputs, err) in enumerate(zip(runs, pre, strict=True)):
+                if err is not None:
+                    await _emit(item, ReplayResult(ok=False, error=err))
+                    continue
+
+                async def _step(sr: StepResult, _item: int = item) -> None:
+                    if on_step is not None:
+                        await on_step(_item, sr)
+
+                res = await replay_with_caller(recipe, inputs, caller=caller, on_step=_step)
+                await _emit(item, res)
+    except ReplayError as exc:
+        # Engine-level failure mid-batch (e.g. a stack teardown error): fail the
+        # items that had not run yet rather than raising.
+        for item in range(len(results), len(runs)):
+            await _emit(item, ReplayResult(ok=False, error=str(exc)))
+    return results

--- a/src/medmcp/replay.py
+++ b/src/medmcp/replay.py
@@ -26,7 +26,7 @@ import json
 import os
 import re
 from collections.abc import AsyncGenerator, Awaitable, Callable
-from contextlib import AsyncExitStack, asynccontextmanager
+from contextlib import AsyncExitStack, asynccontextmanager, suppress
 from dataclasses import dataclass, field
 from datetime import timedelta
 from typing import Any, cast
@@ -220,24 +220,50 @@ async def mcp_caller(
     """Yield a :data:`ToolCaller` backed by lazily-spawned MCP stdio servers.
 
     Each needed stack's server is started on first use and reused for the rest of
-    the run; all are shut down when the context exits.
+    the run. A transport error (the server process dying) evicts that server, so
+    the next call re-spawns a fresh one rather than reusing a broken session — a
+    crash on one batch item does not sink the items that follow. Every live server
+    is shut down when the context exits (including on cancellation/Stop).
     """
     server_map = {str(s["name"]): s for s in servers}
     timeout = timedelta(seconds=tool_timeout_sec)
 
     async with AsyncExitStack() as stack:
+        # Each server keeps its own exit stack so a dead one can be torn down
+        # individually, without disturbing the others.
         sessions: dict[str, ClientSession] = {}
+        server_stacks: dict[str, AsyncExitStack] = {}
+
+        async def _evict(server: str) -> None:
+            sessions.pop(server, None)
+            sstack = server_stacks.pop(server, None)
+            if sstack is not None:
+                with suppress(Exception):
+                    await sstack.aclose()
+
+        async def _evict_all() -> None:
+            for server in list(server_stacks):
+                await _evict(server)
+
+        # Shut every live server down on exit (normal or cancellation/Stop).
+        stack.push_async_callback(_evict_all)
 
         async def _session(server: str) -> ClientSession:
             if server not in sessions:
                 cfg = server_map.get(server)
                 if cfg is None:
                     raise ReplayError(f"stack {server!r} is not installed")
-                read, write = await stack.enter_async_context(
-                    stdio_client(_server_params(cfg, cwd=cwd))
-                )
-                session = await stack.enter_async_context(ClientSession(read, write))
-                await session.initialize()
+                sstack = AsyncExitStack()
+                try:
+                    read, write = await sstack.enter_async_context(
+                        stdio_client(_server_params(cfg, cwd=cwd))
+                    )
+                    session = await sstack.enter_async_context(ClientSession(read, write))
+                    await session.initialize()
+                except BaseException:
+                    await sstack.aclose()  # don't leak a half-started server
+                    raise
+                server_stacks[server] = sstack
                 sessions[server] = session
             return sessions[server]
 
@@ -245,7 +271,15 @@ async def mcp_caller(
             server: str, tool: str, args: JsonDict
         ) -> tuple[bool, JsonDict, str | None]:
             session = await _session(server)
-            result = await session.call_tool(tool, args, read_timeout_seconds=timeout)
+            try:
+                result = await session.call_tool(tool, args, read_timeout_seconds=timeout)
+            except Exception:
+                # Transport-level failure: the server process is probably dead, so
+                # drop it — the next call spawns a fresh one instead of reusing a
+                # broken session. (A tool that merely *reports* failure returns a
+                # result and is handled below; its session stays healthy.)
+                await _evict(server)
+                raise
             structured = extract_structured(result)
             if _result_failed(result):
                 return False, structured, _result_text(result) or "tool reported failure"
@@ -401,9 +435,9 @@ async def run_batch(
     item's index in *runs*; the return value is one :class:`ReplayResult` per item,
     in order.
 
-    Because the MCP sessions are shared, a stack that crashes mid-batch stays down
-    for the remaining items (they fail rather than respawn) — :func:`run`'s per-item
-    isolation is traded for the startup saving.
+    The MCP servers are shared across items for speed, but one that crashes is
+    re-spawned for the next item (see :func:`mcp_caller`), so a single failure does
+    not cascade to the rest of the batch.
     """
     pre = [validate(recipe, inputs, servers) for inputs in runs]
     results: list[ReplayResult] = []

--- a/src/medmcp/server.py
+++ b/src/medmcp/server.py
@@ -693,40 +693,42 @@ async def ws_replay(ws: WebSocket) -> None:
         )
 
         async def _run_batch() -> None:
-            all_outputs: list[str] = []
-            failed = 0
-            for item, inputs in enumerate(runs):
-
-                async def _on_step(sr: replay.StepResult, item: int = item) -> None:
-                    await ws.send_json(
-                        {
-                            "type": "step",
-                            "item": item,
-                            "index": sr.index,
-                            "server": sr.server,
-                            "tool": sr.tool,
-                            "ok": sr.ok,
-                            "error": sr.error,
-                            "produced": sr.produced,
-                        }
-                    )
-
-                result = await replay.run(
-                    recipe, inputs, servers=servers, cwd=str(WORKSPACE_ROOT), on_step=_on_step
+            async def _on_step(item: int, sr: replay.StepResult) -> None:
+                await ws.send_json(
+                    {
+                        "type": "step",
+                        "item": item,
+                        "index": sr.index,
+                        "server": sr.server,
+                        "tool": sr.tool,
+                        "ok": sr.ok,
+                        "error": sr.error,
+                        "produced": sr.produced,
+                    }
                 )
-                outputs = [v for sr in result.steps for v in sr.produced.values()]
-                all_outputs.extend(outputs)
-                if not result.ok:
-                    failed += 1
+
+            async def _on_item(item: int, result: replay.ReplayResult) -> None:
                 await ws.send_json(
                     {
                         "type": "item_result",
                         "item": item,
                         "ok": result.ok,
                         "error": result.error,
-                        "outputs": outputs,
+                        "outputs": [v for sr in result.steps for v in sr.produced.values()],
                     }
                 )
+
+            # One shared set of stacks across all items (spawned once, not per item).
+            results = await replay.run_batch(
+                recipe,
+                runs,
+                servers=servers,
+                cwd=str(WORKSPACE_ROOT),
+                on_step=_on_step,
+                on_item=_on_item,
+            )
+            all_outputs = [v for r in results for sr in r.steps for v in sr.produced.values()]
+            failed = sum(1 for r in results if not r.ok)
             ok = failed == 0
             batch_error = None if ok else f"{failed} of {len(runs)} item(s) failed"
             _audit.info("replay finished: %s ok=%s", name, ok)
@@ -737,7 +739,7 @@ async def ws_replay(ws: WebSocket) -> None:
         # Race the batch against a socket watcher. The client sends nothing
         # after the first message, so anything receive returns — and above all
         # a disconnect — means "abort". Cancelling the batch task unwinds
-        # replay.run's exit stack, killing the in-flight MCP server and its
+        # run_batch's shared exit stack, killing the in-flight MCP server and its
         # running tool; without the watcher, Stop would only take effect at
         # the next frame send, after the current step finished.
         batch_task = asyncio.create_task(_run_batch())

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -372,3 +372,44 @@ async def test_run_batch_streams_item_indexed_callbacks(monkeypatch: pytest.Monk
 
     assert steps == [(0, 1), (0, 2), (1, 1), (1, 2)]
     assert items == [0, 1]
+
+
+@pytest.mark.asyncio
+async def test_mcp_caller_respawns_after_transport_crash(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A transport error evicts the dead session; the next call spawns a fresh one."""
+    spawns = [0]
+    calls = [0]
+
+    @contextlib.asynccontextmanager
+    async def fake_stdio_client(_params: object) -> AsyncGenerator[tuple[None, None]]:
+        spawns[0] += 1
+        yield (None, None)
+
+    class FakeSession:
+        def __init__(self, *_args: object, **_kwargs: object) -> None: ...
+
+        async def __aenter__(self) -> FakeSession:
+            return self
+
+        async def __aexit__(self, *_args: object) -> None: ...
+
+        async def initialize(self) -> None: ...
+
+        async def call_tool(
+            self, tool: str, args: JsonDict, read_timeout_seconds: object = None
+        ) -> mcp_types.CallToolResult:
+            calls[0] += 1
+            if calls[0] == 1:
+                raise ConnectionError("server died")
+            return _result(structured={"brain_path": "/b"})
+
+    monkeypatch.setattr(replay, "stdio_client", fake_stdio_client)
+    monkeypatch.setattr(replay, "ClientSession", FakeSession)
+
+    async with replay.mcp_caller(_neuro_servers()) as call:
+        with pytest.raises(ConnectionError):
+            await call("medmcp-neuro", "skull_strip", {})  # crash → session evicted
+        outcome = await call("medmcp-neuro", "skull_strip", {})  # fresh server, succeeds
+
+    assert spawns[0] == 2  # the dead server was re-spawned, not reused
+    assert outcome == (True, {"brain_path": "/b"}, None)

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import contextlib
+from collections.abc import AsyncGenerator, Callable
 from typing import Any
 
 import mcp.types as mcp_types
@@ -265,3 +267,108 @@ async def test_on_step_callback_invoked_per_step() -> None:
         _two_step_recipe(), {"in_1": "/x"}, caller=caller, on_step=on_step
     )
     assert seen == [1, 2]
+
+
+# ── batch replay (run_batch) ──────────────────────────────────────────────────
+
+
+def _neuro_servers() -> list[JsonDict]:
+    return [{"name": "medmcp-neuro", "command": "x", "args": []}]
+
+
+def _fake_mcp_caller(
+    caller: replay.ToolCaller, spawns: list[int]
+) -> Callable[..., contextlib.AbstractAsyncContextManager[replay.ToolCaller]]:
+    """A drop-in for ``replay.mcp_caller`` that counts spawns and yields *caller*."""
+
+    @contextlib.asynccontextmanager
+    async def _cm(*_args: object, **_kwargs: object) -> AsyncGenerator[replay.ToolCaller]:
+        spawns[0] += 1
+        yield caller
+
+    return _cm
+
+
+@pytest.mark.asyncio
+async def test_run_batch_spawns_stacks_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A batch reuses one mcp_caller — the stacks are spawned a single time."""
+    spawns = [0]
+
+    async def caller(server: str, tool: str, args: JsonDict) -> tuple[bool, JsonDict, str | None]:
+        return True, {"brain_path": "/b", "registered_path": "/r"}, None
+
+    monkeypatch.setattr(replay, "mcp_caller", _fake_mcp_caller(caller, spawns))
+
+    runs = [{"in_1": f"/scan{i}.nii"} for i in range(3)]
+    results = await replay.run_batch(_two_step_recipe(), runs, servers=_neuro_servers())
+
+    assert spawns[0] == 1
+    assert [r.ok for r in results] == [True, True, True]
+
+
+@pytest.mark.asyncio
+async def test_run_batch_failed_item_does_not_stop_others(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One item's failure is isolated; the rest still run on the shared stacks."""
+    spawns = [0]
+
+    async def caller(server: str, tool: str, args: JsonDict) -> tuple[bool, JsonDict, str | None]:
+        if "scan1" in str(args.get("input_path", "")):
+            return False, {}, "boom"
+        return True, {"brain_path": "/b", "registered_path": "/r"}, None
+
+    monkeypatch.setattr(replay, "mcp_caller", _fake_mcp_caller(caller, spawns))
+
+    runs = [{"in_1": "/scan0.nii"}, {"in_1": "/scan1.nii"}, {"in_1": "/scan2.nii"}]
+    results = await replay.run_batch(_two_step_recipe(), runs, servers=_neuro_servers())
+
+    assert spawns[0] == 1  # still one shared spawn despite the mid-batch failure
+    assert [r.ok for r in results] == [True, False, True]
+    assert "boom" in (results[1].error or "")
+
+
+@pytest.mark.asyncio
+async def test_run_batch_isolates_validation_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An item missing its inputs fails validation without running; others run."""
+    spawns = [0]
+
+    async def caller(server: str, tool: str, args: JsonDict) -> tuple[bool, JsonDict, str | None]:
+        return True, {"brain_path": "/b", "registered_path": "/r"}, None
+
+    monkeypatch.setattr(replay, "mcp_caller", _fake_mcp_caller(caller, spawns))
+
+    runs = [{"in_1": "/a.nii"}, {}, {"in_1": "/c.nii"}]
+    results = await replay.run_batch(_two_step_recipe(), runs, servers=_neuro_servers())
+
+    assert [r.ok for r in results] == [True, False, True]
+    assert "missing" in (results[1].error or "")
+    assert results[1].steps == []  # never ran a step
+
+
+@pytest.mark.asyncio
+async def test_run_batch_streams_item_indexed_callbacks(monkeypatch: pytest.MonkeyPatch) -> None:
+    """on_step / on_item fire tagged with the item's index in runs."""
+    spawns = [0]
+
+    async def caller(server: str, tool: str, args: JsonDict) -> tuple[bool, JsonDict, str | None]:
+        return True, {"brain_path": "/b", "registered_path": "/r"}, None
+
+    monkeypatch.setattr(replay, "mcp_caller", _fake_mcp_caller(caller, spawns))
+
+    steps: list[tuple[int, int]] = []
+    items: list[int] = []
+
+    async def on_step(item: int, sr: replay.StepResult) -> None:
+        steps.append((item, sr.index))
+
+    async def on_item(item: int, res: replay.ReplayResult) -> None:
+        items.append(item)
+
+    runs = [{"in_1": "/a.nii"}, {"in_1": "/b.nii"}]
+    await replay.run_batch(
+        _two_step_recipe(), runs, servers=_neuro_servers(), on_step=on_step, on_item=on_item
+    )
+
+    assert steps == [(0, 1), (0, 2), (1, 1), (1, 2)]
+    assert items == [0, 1]


### PR DESCRIPTION
Bundles the replay batch-reuse work with a round of workspace UI performance fixes (the latter built on top of the former).

## Replay — batch
- Reuse one set of MCP servers across a whole batch instead of respawning them per item; respawn only a *crashed* stack mid-batch rather than poisoning the rest of the run.
- Batch results are now first-class in the UI: per-item retry, tally, outputs, and timing, plus polish on the live-run view from hands-on testing.

## Workspace UI — responsiveness
- **Chat:** stream the assistant message block-by-block so only the still-growing trailing block re-parses through react-markdown each flush (was re-parsing the whole, growing message — ~O(n²)); memoized `Chat` and a split-out composer so `fsVersion` bumps and keystrokes don't re-render/re-map the transcript.
- **Panels:** `React.memo` on `WorkflowPanel`, `FileExplorer`, and `Viewer` so a per-tool-call `fsVersion` bump (and separator drags) don't re-render them every time/frame.
- **Viewer resize (the main culprit):** Niivue leaks GPU resources every time its canvas resizes, which progressively degraded the viewer and lost the WebGL context (reproduced across Firefox/Chrome/Safari, worst on Intel iGPUs). Fix: never resize the live canvas — freeze it during the drag (flag held for the whole pointer drag, cleared on `pointerup`, not the library's mid-drag "settled" event) and rebuild the view fresh at the new size once the drag settles, with a single steady spinner covering the rebuild.
- **Viewer GPU/UX:** force 1× device-pixel-ratio and disable MSAA (large GPU savings, no loss of data resolution — slices are sampled from the volume regardless); dispose Niivue + release the GL context on unmount so contexts don't leak across opened files; loading spinner with a yielded frame so it paints before Niivue's synchronous parse/upload; black viewer background; neurological/radiological convention toggle.
- **Logo:** brand wordmark gradient matching the marketing site.

## Testing
- `npm run build` (tsc + vite) and `npm run lint` (eslint) pass.
- Viewer resize verified live: smooth and non-degrading with a volume loaded, across repeated resizes.