### PR TITLE
feat(catalog): register medmcp-monai stack

### DIFF
--- a/catalog.ghcr.json
+++ b/catalog.ghcr.json
@@ -24,6 +24,12 @@
       "image": "ghcr.io/medmcp/neuro-cancer:main",
       "description": "Brain-tumor (glioma / BraTS) segmentation (MONAI SegResNet).",
       "gpu": true
+    },
+    {
+      "name": "medmcp-monai",
+      "image": "ghcr.io/medmcp/monai:main",
+      "description": "Run pretrained MONAI Model-Zoo bundles (spleen / multi-organ / whole-body CT segmentation).",
+      "gpu": true
     }
   ]
 }

--- a/catalog.json
+++ b/catalog.json
@@ -24,6 +24,12 @@
       "image": "medmcp-neuro-cancer:dev",
       "description": "Brain-tumor (glioma / BraTS) segmentation (MONAI SegResNet).",
       "gpu": true
+    },
+    {
+      "name": "medmcp-monai",
+      "image": "medmcp-monai:dev",
+      "description": "Run pretrained MONAI Model-Zoo bundles (spleen / multi-organ / whole-body CT segmentation).",
+      "gpu": true
     }
   ]
 }


### PR DESCRIPTION
Adds the **medmcp-monai** stack (generic MONAI Model-Zoo bundle runner) to both catalogs so it appears in Settings → Stacks → Available.

- `catalog.ghcr.json`: `ghcr.io/medmcp/monai:main` (published by medmcp-monai-dev CI)
- `catalog.json`: `medmcp-monai:dev`

GPU stack; runs curated zoo bundles (spleen / multi-organ / whole-body CT). Validated end-to-end on 4 bundles in `medmcp/medmcp-monai-dev`.