### PR TITLE
fix(deploy): persist personal workflows, provenance, and chat history

### DIFF
--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -115,6 +115,14 @@ services:
       - "${MEDMCP_WORKSPACE}:${MEDMCP_WORKSPACE}"
       # Persist installed stack manifests + extracted skills across recreates.
       - "stacks-d:/app/stacks.d"
+      # Persist user state across recreates: personal workflows, provenance, and
+      # chat transcripts. Without these, .vibe lives in the ephemeral container
+      # layer and every recreate (compose down/up, image update) wipes them.
+      # Subdirs only — the baked prompts/ and the startup-written config.toml
+      # stay image-fresh.
+      - "vibe-workflows:/app/.vibe/workflows"
+      - "vibe-provenance:/app/.vibe/provenance"
+      - "vibe-logs:/app/.vibe/logs"
       # Host registry creds, read-only at a staging path — the entrypoint copies
       # only `auths` to /root/.docker/config.json, dropping the host's
       # `currentContext` (which would break every in-container stack pull/run).
@@ -124,3 +132,6 @@ services:
 volumes:
   ollama-models:
   stacks-d:
+  vibe-workflows:
+  vibe-provenance:
+  vibe-logs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,6 +106,14 @@ services:
       - "${MEDMCP_WORKSPACE}:${MEDMCP_WORKSPACE}"
       # Container-stack manifests (read-write so UI install/uninstall can persist).
       - "./stacks.d:/app/stacks.d"
+      # Persist user state across recreates: personal workflows, provenance, and
+      # chat transcripts. Without these, .vibe lives in the ephemeral container
+      # layer and every recreate (compose down/up, image update) wipes them.
+      # Subdirs only — the baked prompts/ and the startup-written config.toml
+      # stay image-fresh.
+      - "vibe-workflows:/app/.vibe/workflows"
+      - "vibe-provenance:/app/.vibe/provenance"
+      - "vibe-logs:/app/.vibe/logs"
       # Host registry creds, read-only at a staging path — the entrypoint copies
       # only `auths` to /root/.docker/config.json, dropping the host's
       # `currentContext` (which would break every in-container stack pull/run).
@@ -116,3 +124,6 @@ services:
 
 volumes:
   ollama-models:
+  vibe-workflows:
+  vibe-provenance:
+  vibe-logs:


### PR DESCRIPTION
## Summary
Personal workflows, provenance records, and chat transcripts were stored under `/app/.vibe/`, which had no volume backing — it lived in the container's ephemeral writable layer. Any container recreate (`compose down/up`, an image update, or a GPU re-pin) silently wiped all of them. This mounts named volumes for the three stateful subdirs so they survive recreates.

## Test plan
- [x] `docker compose -f docker-compose.ghcr.yml config` and `-f docker-compose.yml config` both parse; the three `vibe-*` mounts resolve to `/app/.vibe/{workflows,provenance,logs}`
- [x] Applied the same mounts to the running stack (via a local override): create a workflow → `docker compose ... up -d` (recreate) → workflow still present
- [ ] Reviewer: confirm a new image build still boots (baked `prompts/` + startup `config.toml` are *not* shadowed — only the three data subdirs are volumes)

## Security & data handling
- No new network surface or agent capability. Named volumes only; the workspace bind, docker socket, and host registry-cred mount are unchanged.
- Persists chat transcripts and provenance to a local docker volume on the host — same trust boundary as the existing workspace bind.

## Notes
- Subdir mounts, not the whole `.vibe`: mounting a volume over `/app/.vibe` would shadow the image's `prompts/` and freeze `config.toml`, so new images couldn't update either. Persisting only `workflows/`, `provenance/`, and `logs/` keeps prompts + config image-fresh.
- Applies to both `docker-compose.ghcr.yml` (the published `compose:main` OCI artifact) and `docker-compose.yml` (local build). After merge, CI republishes the compose artifact; deployments adopt it on the next `up -d`.
- Existing deployments that recreate before this lands will keep losing `.vibe` state — that's the bug this fixes.
