### PR TITLE
feat(ui): viewer settings panel + chat, explorer & replay fixes

### DIFF
--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -531,7 +531,11 @@ export const Chat = memo(function Chat({
             </button>
           )}
           {onSelectSession && (
-            <ChatsMenu currentSessionId={currentSessionId ?? null} onSelectSession={onSelectSession} />
+            <ChatsMenu
+              currentSessionId={currentSessionId ?? null}
+              onSelectSession={onSelectSession}
+              onCurrentDeleted={onNewChat ?? (() => undefined)}
+            />
           )}
         </span>
         <span className="panel-actions chat-meta">

--- a/frontend/src/components/ChatsMenu.tsx
+++ b/frontend/src/components/ChatsMenu.tsx
@@ -8,6 +8,8 @@ interface ChatsMenuProps {
   currentSessionId: string | null
   /** Open an existing session in the chat panel. */
   onSelectSession: (id: string) => void
+  /** Called when the currently-open session is deleted, so a fresh chat opens. */
+  onCurrentDeleted: () => void
 }
 
 /** Coarse day bucket for the list headers, from an ISO timestamp. */
@@ -37,7 +39,7 @@ function timeLabel(iso: string | null): string {
  * archive, or delete from per-row actions; reveal archived ones to restore or
  * delete. Sessions load each time the menu opens.
  */
-export function ChatsMenu({ currentSessionId, onSelectSession }: ChatsMenuProps) {
+export function ChatsMenu({ currentSessionId, onSelectSession, onCurrentDeleted }: ChatsMenuProps) {
   const [open, setOpen] = useState(false)
   const [list, setList] = useState<SessionInfo[] | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -79,8 +81,16 @@ export function ChatsMenu({ currentSessionId, onSelectSession }: ChatsMenuProps)
   }
 
   const confirmDelete = (id: string) => {
-    if (confirm('Delete this chat for good? Its transcript and provenance are removed too.'))
-      act(deleteSession(id))
+    if (!confirm('Delete this chat for good? Its transcript and provenance are removed too.')) return
+    deleteSession(id)
+      .then(() => {
+        // Deleting the open chat would otherwise leave its (now-gone) transcript
+        // on screen — start a fresh chat instead. That remounts Chat (and this
+        // menu with it), so reloading the list here is unnecessary.
+        if (id === currentSessionId) onCurrentDeleted()
+        else load()
+      })
+      .catch((e: unknown) => setError(String(e)))
   }
 
   const select = (id: string) => {

--- a/frontend/src/components/FileExplorer.tsx
+++ b/frontend/src/components/FileExplorer.tsx
@@ -1,4 +1,5 @@
 import { memo, useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import type { MouseEvent as ReactMouseEvent } from 'react'
 import { Tree } from 'react-arborist'
 import type { NodeApi, NodeRendererProps } from 'react-arborist'
@@ -122,6 +123,7 @@ export const FileExplorer = memo(function FileExplorer({
   const [size, setSize] = useState({ width: 280, height: 400 })
   const [menu, setMenu] = useState<{ x: number; y: number; node: NodeApi<TreeNode> } | null>(null)
   const containerRef = useRef<HTMLDivElement>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
   // Read inside the mount-once observer effect without re-subscribing.
   const isResizingRef = useRef(isResizing)
@@ -211,11 +213,18 @@ export const FileExplorer = memo(function FileExplorer({
     })
   }
 
-  // Any click/Escape outside the menu dismisses it; the menu itself stops
-  // mousedown propagation so its buttons still receive their click.
+  // Any click/Escape outside the menu dismisses it. The menu is portaled to
+  // <body> (so it can't be clipped by a panel), which means it's outside the
+  // React root's event delegation — stopPropagation on its mousedown wouldn't
+  // reliably stop this window listener. Instead, skip dismissal when the event
+  // originates inside the menu (a contains-check, position-independent); its
+  // buttons close it explicitly via menuAction.
   useEffect(() => {
     if (!menu) return
-    const close = () => setMenu(null)
+    const close = (e: Event) => {
+      if (menuRef.current?.contains(e.target as Node)) return
+      setMenu(null)
+    }
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') setMenu(null)
     }
@@ -312,16 +321,17 @@ export const FileExplorer = memo(function FileExplorer({
         >
           {(props) => <NodeRow {...props} onMenu={openMenu} />}
         </Tree>
-        {menu && (
-          <div
-            className="ctx-menu"
-            style={{
-              left: Math.min(menu.x, window.innerWidth - 170),
-              top: Math.min(menu.y, window.innerHeight - 150),
-            }}
-            onMouseDown={(e) => e.stopPropagation()}
-            onContextMenu={(e) => e.preventDefault()}
-          >
+        {menu &&
+          createPortal(
+            <div
+              ref={menuRef}
+              className="ctx-menu"
+              style={{
+                left: Math.min(menu.x, window.innerWidth - 170),
+                top: Math.min(menu.y, window.innerHeight - 150),
+              }}
+              onContextMenu={(e) => e.preventDefault()}
+            >
             {menu.node.isLeaf ? (
               <button onClick={menuAction(() => onOpenFile(menu.node.data.id))}>Open</button>
             ) : (
@@ -353,8 +363,9 @@ export const FileExplorer = memo(function FileExplorer({
                 </button>
               )
             })()}
-          </div>
-        )}
+            </div>,
+            document.body,
+          )}
       </div>
     </div>
   )

--- a/frontend/src/components/Viewer.tsx
+++ b/frontend/src/components/Viewer.tsx
@@ -1,9 +1,10 @@
-import { memo, useEffect, useRef, useState } from 'react'
+import { memo, useCallback, useEffect, useRef, useState } from 'react'
 import { Niivue, SHOW_RENDER, SLICE_TYPE } from '@niivue/niivue'
 import { fetchTree, rawUrl } from '../api'
 import { getDraggedFilePath } from '../dragState'
 import { DRAG_PATH_MIME, type TreeNode } from '../types'
-import { DownloadIcon, XIcon } from './icons'
+import { DownloadIcon, GearIcon, XIcon } from './icons'
+import { ViewerSettingsPanel } from './ViewerSettings'
 
 const VOLUME_EXT = /\.(nii|nii\.gz|mgz|mgh|nrrd|nhdr|mha|mhd|hdr|img|v16|dcm)$/
 const IMAGE_EXT = /\.(png|jpe?g|gif|svg|webp|bmp)$/
@@ -57,9 +58,81 @@ const LABEL_COLORMAP = labelColorMap()
 // use its numeric value.
 const COLORMAP_TYPE_TRANSPARENT_BELOW_MIN = 1
 
-// Persist the display convention across volumes/sessions. Default false =
-// neurological (Niivue's default: image-left is patient-left).
+// Legacy standalone convention key — still read once to migrate the preference
+// into the consolidated viewer settings below.
 const RADIOLOGICAL_KEY = 'medmcp.radiologicalView'
+
+export type SlicePlane = 'multiplanar' | 'axial' | 'coronal' | 'sagittal'
+
+/** User-tunable viewer display options (the gear popover); persisted per browser. */
+export type RenderScale = 'native' | '2x' | '4x'
+
+export interface ViewerSettings {
+  /** Slice sampling: nearest (faithful voxels, sharp label edges) or linear (smoothed). */
+  interpolation: 'nearest' | 'linear'
+  /** true = radiological (image-left is patient-right), false = neurological. */
+  radiological: boolean
+  /** Multiplanar (3 orthogonal + optional 3D) or a single plane. */
+  slicePlane: SlicePlane
+  /** Show the 3D volume render alongside the slices (multiplanar only). */
+  showRender: boolean
+  /** Draw the crosshair lines. */
+  crosshair: boolean
+  /** WebGL MSAA edge anti-aliasing (browser picks the sample count). */
+  antialias: boolean
+  /** Supersampling factor via forceDevicePixelRatio: 'native' matches the
+   *  display, '2x'/'3x' render larger then downsample (smoother edges, more
+   *  GPU), '1x' is the cheapest. Both antialias and renderScale are set at
+   *  canvas-attach time, so a change remounts the view rather than applying live. */
+  renderScale: RenderScale
+}
+
+/** Map a RenderScale to Niivue's forceDevicePixelRatio (0 = window.devicePixelRatio). */
+const RENDER_SCALE_DPR: Record<RenderScale, number> = { native: 0, '2x': 2, '4x': 4 }
+
+const VIEWER_SETTINGS_KEY = 'medmcp.viewerSettings'
+
+const DEFAULT_VIEWER_SETTINGS: ViewerSettings = {
+  interpolation: 'nearest',
+  radiological: false,
+  slicePlane: 'multiplanar',
+  showRender: true,
+  crosshair: true,
+  antialias: true,
+  renderScale: 'native',
+}
+
+const SLICE_TYPE_BY_PLANE: Record<SlicePlane, SLICE_TYPE> = {
+  multiplanar: SLICE_TYPE.MULTIPLANAR,
+  axial: SLICE_TYPE.AXIAL,
+  coronal: SLICE_TYPE.CORONAL,
+  sagittal: SLICE_TYPE.SAGITTAL,
+}
+
+function loadViewerSettings(): ViewerSettings {
+  try {
+    const raw = localStorage.getItem(VIEWER_SETTINGS_KEY)
+    if (raw) {
+      const merged = { ...DEFAULT_VIEWER_SETTINGS, ...(JSON.parse(raw) as Partial<ViewerSettings>) }
+      // Drop a renderScale persisted under an older option set (e.g. '1x'/'3x').
+      if (!(merged.renderScale in RENDER_SCALE_DPR)) merged.renderScale = 'native'
+      return merged
+    }
+  } catch {
+    // malformed storage — fall back to defaults (+ legacy migration below)
+  }
+  return { ...DEFAULT_VIEWER_SETTINGS, radiological: localStorage.getItem(RADIOLOGICAL_KEY) === 'true' }
+}
+
+/** Apply the full settings set to a live Niivue instance (idempotent). */
+function applyViewerSettings(nv: Niivue, s: ViewerSettings): void {
+  nv.setInterpolation(s.interpolation === 'nearest')
+  nv.setRadiologicalConvention(s.radiological)
+  nv.setSliceType(SLICE_TYPE_BY_PLANE[s.slicePlane])
+  nv.setCrosshairWidth(s.crosshair ? 1 : 0)
+  nv.opts.multiplanarShowRender = s.showRender ? SHOW_RENDER.ALWAYS : SHOW_RENDER.NEVER
+  nv.drawScene()
+}
 
 type FileKind = 'volume' | 'pdf' | 'image' | 'text' | 'other'
 
@@ -93,10 +166,12 @@ function collectVolumePaths(nodes: TreeNode[], out: string[] = []): string[] {
  */
 function VolumeView({
   path,
+  settings,
   refreshSignal,
   isResizing,
 }: {
   path: string
+  settings: ViewerSettings
   refreshSignal?: number
   isResizing?: boolean
 }) {
@@ -111,15 +186,13 @@ function VolumeView({
   const [overlayPath, setOverlayPath] = useState<string>('')
   const [overlayOpacity, setOverlayOpacity] = useState(0.5)
   const [dragOver, setDragOver] = useState(false)
-  const [radiological, setRadiological] = useState(
-    () => localStorage.getItem(RADIOLOGICAL_KEY) === 'true',
-  )
-  // Read inside the url-keyed load effect without making it a dependency (a
-  // toggle must not tear down and reload the volume).
-  const radiologicalRef = useRef(radiological)
+  // Read inside the url-keyed load effect (constructor seeding + post-load) and
+  // the live-settings effect without making settings a dependency of the load
+  // effect — a setting change must not tear down and reload the volume.
+  const settingsRef = useRef(settings)
   useEffect(() => {
-    radiologicalRef.current = radiological
-  }, [radiological])
+    settingsRef.current = settings
+  }, [settings])
   // Read inside the mount-once observer effect without re-subscribing.
   const isResizingRef = useRef(isResizing)
   useEffect(() => {
@@ -168,14 +241,16 @@ function VolumeView({
   useEffect(() => {
     const canvas = canvasRef.current
     if (!canvas) return
+    const s0 = settingsRef.current
     const nv = new Niivue({
-      multiplanarShowRender: SHOW_RENDER.ALWAYS,
-      // Render at 1× pixel ratio instead of the display's HiDPI/Retina ratio.
-      // On a 2× display that's 4× fewer pixels per frame — the single biggest
-      // GPU saving, and it costs no data fidelity: slices are sampled from the
-      // volume, so screen pixels beyond the data resolution are wasted work.
-      // (-1 = block high DPI; that oversampling was the dominant GPU cost.)
-      forceDevicePixelRatio: -1,
+      // Seed the creation-time opts from the current viewer settings (the rest
+      // are applied after load / live). Nearest interpolation keeps a
+      // segmentation overlay's integer labels crisp instead of blending IDs at
+      // boundaries; native DPR renders crisp slices; the 3D render is part of
+      // the multiplanar layout. All are user-toggleable in the viewer settings.
+      isNearestInterpolation: s0.interpolation === 'nearest',
+      forceDevicePixelRatio: RENDER_SCALE_DPR[s0.renderScale],
+      multiplanarShowRender: s0.showRender ? SHOW_RENDER.ALWAYS : SHOW_RENDER.NEVER,
       backColor: [0, 0, 0, 1],
       // Suppress Niivue's own canvas "loading ..." text — our spinner overlay
       // is the single loading affordance.
@@ -191,10 +266,12 @@ function VolumeView({
       setLoading(true)
       setLoadError(null)
       try {
-        // Disable MSAA: it multiplies the framebuffer's GPU memory, which is the
-        // likely trigger for WebGL context loss on memory-constrained GPUs. AA
-        // only smooths edges — it doesn't affect slice/data resolution.
-        await nv.attachToCanvas(canvas, false)
+        // MSAA (anti-aliasing) follows the antialias setting. AA smooths edges
+        // (3D render, crosshair, slice boundaries) but multiplies the
+        // framebuffer's GPU memory — the trigger for WebGL context loss on
+        // memory-constrained GPUs — so it's toggleable. Independent of the
+        // render scale (supersampling), which is set via forceDevicePixelRatio.
+        await nv.attachToCanvas(canvas, s0.antialias)
         nv.setSliceType(SLICE_TYPE.MULTIPLANAR)
         // Niivue streams the download/inflate, but parsing the volume and the
         // initial WebGL upload + 3D render run synchronously on the main thread
@@ -204,7 +281,7 @@ function VolumeView({
         await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))
         if (cancelled) return
         await nv.loadVolumes([{ url }])
-        nv.setRadiologicalConvention(radiologicalRef.current)
+        applyViewerSettings(nv, settingsRef.current)
       } catch (e) {
         if (!cancelled) setLoadError(String(e))
       } finally {
@@ -243,6 +320,15 @@ function VolumeView({
     }, 300)
     return () => window.clearTimeout(timer)
   }, [path, refreshSignal])
+
+  // Apply live setting changes to the open volume. `antialias` and
+  // `renderScale` are excluded here — both are creation-time, so changing them
+  // remounts this view via its key (see Viewer). The guard skips the initial
+  // mount before the volume has loaded; the load effect applies settings then.
+  useEffect(() => {
+    const nv = nvRef.current
+    if (nv && nv.volumes.length > 0) applyViewerSettings(nv, settings)
+  }, [settings])
 
   // Overlay operations are serialized on a promise chain, seeded with the
   // base-volume load: a switch while the previous add was still in flight
@@ -295,12 +381,6 @@ function VolumeView({
     if (nv && nv.volumes.length > 1) {
       nv.setOpacity(1, value)
     }
-  }
-
-  const setConvention = (value: boolean) => {
-    setRadiological(value)
-    localStorage.setItem(RADIOLOGICAL_KEY, String(value))
-    nvRef.current?.setRadiologicalConvention(value)
   }
 
   // A path is a valid overlay if it's a volume other than the base image.
@@ -367,17 +447,6 @@ function VolumeView({
             </button>
           </>
         )}
-        <button
-          className="btn-plain conv-toggle"
-          title={
-            radiological
-              ? 'Radiological convention (image-left = patient-right) — click for neurological'
-              : 'Neurological convention (image-left = patient-left) — click for radiological'
-          }
-          onClick={() => setConvention(!radiological)}
-        >
-          {radiological ? 'Radiological' : 'Neurological'}
-        </button>
       </div>
       {loadError && <div className="panel-error">{loadError}</div>}
       <div className="niivue-sizer" ref={sizerRef}>
@@ -447,6 +516,19 @@ export const Viewer = memo(function Viewer({
   // letting the old image flash at the wrong size during the debounce window.
   const [rebuilding, setRebuilding] = useState(false)
   const didResizeRef = useRef(false)
+  const [settings, setSettings] = useState<ViewerSettings>(loadViewerSettings)
+  const [settingsOpen, setSettingsOpen] = useState(false)
+  const updateSettings = useCallback((patch: Partial<ViewerSettings>) => {
+    setSettings((prev) => {
+      const next = { ...prev, ...patch }
+      try {
+        localStorage.setItem(VIEWER_SETTINGS_KEY, JSON.stringify(next))
+      } catch {
+        // ignore storage failure — settings still apply for this session
+      }
+      return next
+    })
+  }, [])
   useEffect(() => {
     if (isResizing) {
       didResizeRef.current = true
@@ -483,6 +565,24 @@ export const Viewer = memo(function Viewer({
           {path}
         </span>
         <span className="panel-actions">
+          {kind === 'volume' && (
+            <span className="viewer-settings-anchor">
+              <button
+                className={settingsOpen ? 'btn-icon active' : 'btn-icon'}
+                title="Viewer settings"
+                onClick={() => setSettingsOpen((v) => !v)}
+              >
+                <GearIcon />
+              </button>
+              {settingsOpen && (
+                <ViewerSettingsPanel
+                  settings={settings}
+                  onChange={updateSettings}
+                  onClose={() => setSettingsOpen(false)}
+                />
+              )}
+            </span>
+          )}
           <a href={url} download title="Download">
             <DownloadIcon />
           </a>
@@ -492,8 +592,9 @@ export const Viewer = memo(function Viewer({
         {kind === 'volume' && (
           <div className={`volume-slot${rebuilding ? ' rebuilding' : ''}`}>
             <VolumeView
-              key={`${path}#${resizeGen}`}
+              key={`${path}#${resizeGen}#${settings.antialias ? 'aa' : 'noaa'}#${settings.renderScale}`}
               path={path}
+              settings={settings}
               refreshSignal={refreshSignal}
               isResizing={isResizing}
             />

--- a/frontend/src/components/ViewerSettings.tsx
+++ b/frontend/src/components/ViewerSettings.tsx
@@ -1,0 +1,161 @@
+import { useEffect, useState } from 'react'
+import type { RenderScale, SlicePlane, ViewerSettings } from './Viewer'
+import { ChevronRightIcon } from './icons'
+
+interface Props {
+  settings: ViewerSettings
+  onChange: (patch: Partial<ViewerSettings>) => void
+  onClose: () => void
+}
+
+/** A small two-option segmented toggle. */
+function Segmented<T extends string>({
+  value,
+  options,
+  onChange,
+}: {
+  value: T
+  options: { value: T; label: string }[]
+  onChange: (v: T) => void
+}) {
+  return (
+    <div className="vs-segmented">
+      {options.map((o) => (
+        <button
+          key={o.value}
+          type="button"
+          className={o.value === value ? 'vs-seg active' : 'vs-seg'}
+          onClick={() => onChange(o.value)}
+        >
+          {o.label}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+/** Viewer display settings popover (opened from the gear in the panel header). */
+export function ViewerSettingsPanel({ settings, onChange, onClose }: Props) {
+  // Advanced (rendering-fidelity) settings are set-once and technical, so they
+  // start collapsed; the everyday display controls are always visible.
+  const [advanced, setAdvanced] = useState(false)
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  return (
+    <>
+      <div className="vs-backdrop" onClick={onClose} />
+      <div className="vs-popover" role="dialog" aria-label="Viewer settings">
+        <div className="vs-row">
+          <span className="vs-label" title="Image-left = patient-left (neuro) or patient-right (rad)">
+            Orientation
+          </span>
+          <Segmented
+            value={settings.radiological ? 'rad' : 'neuro'}
+            options={[
+              { value: 'neuro', label: 'Neuro' },
+              { value: 'rad', label: 'Radiological' },
+            ]}
+            onChange={(v) => onChange({ radiological: v === 'rad' })}
+          />
+        </div>
+
+        <div className="vs-row">
+          <span className="vs-label">Layout</span>
+          <select
+            className="vs-select"
+            value={settings.slicePlane}
+            onChange={(e) => onChange({ slicePlane: e.target.value as SlicePlane })}
+          >
+            <option value="multiplanar">Multiplanar</option>
+            <option value="axial">Axial</option>
+            <option value="coronal">Coronal</option>
+            <option value="sagittal">Sagittal</option>
+          </select>
+        </div>
+
+        <label className="vs-row vs-check">
+          <span className="vs-label" title="Show the 3D render alongside the slices (multiplanar only)">
+            3D render
+          </span>
+          <input
+            type="checkbox"
+            checked={settings.showRender}
+            disabled={settings.slicePlane !== 'multiplanar'}
+            onChange={(e) => onChange({ showRender: e.target.checked })}
+          />
+        </label>
+
+        <label className="vs-row vs-check">
+          <span className="vs-label">Crosshair</span>
+          <input
+            type="checkbox"
+            checked={settings.crosshair}
+            onChange={(e) => onChange({ crosshair: e.target.checked })}
+          />
+        </label>
+
+        <button
+          type="button"
+          className="vs-advanced-toggle"
+          onClick={() => setAdvanced((v) => !v)}
+        >
+          <ChevronRightIcon size={12} className={advanced ? 'vs-chevron open' : 'vs-chevron'} />
+          Advanced
+        </button>
+
+        {advanced && (
+          <>
+            <div className="vs-row">
+              <span className="vs-label" title="Nearest = exact voxels & crisp labels; linear = smoothed">
+                Interpolation
+              </span>
+              <Segmented
+                value={settings.interpolation}
+                options={[
+                  { value: 'nearest', label: 'Nearest' },
+                  { value: 'linear', label: 'Linear' },
+                ]}
+                onChange={(v) => onChange({ interpolation: v })}
+              />
+            </div>
+
+            <div className="vs-row">
+              <span className="vs-label" title="MSAA edge smoothing; uses more GPU memory">
+                Anti-aliasing
+              </span>
+              <Segmented
+                value={settings.antialias ? 'on' : 'off'}
+                options={[
+                  { value: 'off', label: 'Off' },
+                  { value: 'on', label: 'On' },
+                ]}
+                onChange={(v) => onChange({ antialias: v === 'on' })}
+              />
+            </div>
+
+            <div className="vs-row">
+              <span className="vs-label" title="Supersample N× then downsample; Native matches your display">
+                Render scale
+              </span>
+              <select
+                className="vs-select"
+                value={settings.renderScale}
+                onChange={(e) => onChange({ renderScale: e.target.value as RenderScale })}
+              >
+                <option value="native">Native</option>
+                <option value="2x">2×</option>
+                <option value="4x">4×</option>
+              </select>
+            </div>
+          </>
+        )}
+      </div>
+    </>
+  )
+}

--- a/frontend/src/components/WorkflowPanel.tsx
+++ b/frontend/src/components/WorkflowPanel.tsx
@@ -105,6 +105,17 @@ function basename(p: string): string {
   return i >= 0 ? p.slice(i + 1) : p
 }
 
+type Input = { name: string; example: string; description: string }
+
+/** Dropdown label for an input: its name plus whatever hints what it is —
+ *  the human description and/or the example filename (e.g. "...T1w.nii.gz"). */
+function inputOptionLabel(i: Input): string {
+  const bits: string[] = []
+  if (i.description) bits.push(i.description)
+  if (i.example) bits.push(`e.g. ${basename(i.example)}`)
+  return bits.length > 0 ? `${i.name} — ${bits.join(' · ')}` : i.name
+}
+
 /** Short label for batch item *i* — its batched input's filename, else "Item N". */
 function itemLabel(runs: Record<string, string>[], batchInput: string | null, i: number): string {
   const v = batchInput ? runs[i]?.[batchInput] : undefined
@@ -163,7 +174,8 @@ function OutputLinks({
   )
 }
 
-/** One replay input field; accepts a file drag from the explorer. */
+/** One replay input field; accepts a file drag from the explorer (and is
+ *  auto-filled from the explorer selection by the parent form). */
 function InputField({
   name,
   example,
@@ -359,6 +371,36 @@ export const WorkflowPanel = memo(function WorkflowPanel({
     const id = setInterval(() => setNow(Date.now()), 1000)
     return () => clearInterval(id)
   }, [mode.kind])
+
+  // Auto-fill the single-run inputs form from the explorer selection — no extra
+  // click, mirroring how the batch flow binds the selection. Done by adjusting
+  // state during render on a selection change (tracked via prevSel) rather than
+  // in an effect — the React-recommended pattern for "adjust state when a prop
+  // changes" (https://react.dev/learn/you-might-not-need-an-effect). One input:
+  // take the latest selected file (re-selecting updates it). Several inputs:
+  // fill the still-empty ones in order. Skipped while batching (the selection is
+  // reserved for the batch input then) and when nothing is selected; the no-op
+  // guard avoids a render loop. Typing/dragging still overrides.
+  const [prevSel, setPrevSel] = useState<string[]>(selectedPaths)
+  if (selectedPaths !== prevSel) {
+    setPrevSel(selectedPaths)
+    if (mode.kind === 'inputs' && mode.batchInput === null && selectedPaths.length > 0) {
+      setMode((m) => {
+        if (m.kind !== 'inputs' || m.batchInput !== null) return m
+        const fields = Object.keys(m.values)
+        const values = { ...m.values }
+        if (fields.length === 1) {
+          values[fields[0]] = selectedPaths[selectedPaths.length - 1]
+        } else {
+          const empty = fields.filter((n) => !(values[n] ?? '').trim())
+          empty.forEach((n, idx) => {
+            if (selectedPaths[idx]) values[n] = selectedPaths[idx]
+          })
+        }
+        return fields.some((n) => values[n] !== m.values[n]) ? { ...m, values } : m
+      })
+    }
+  }
 
   // The workflow whose detail the panel currently wants. Guards against a
   // slow response for a previously clicked row overwriting the current one —
@@ -831,7 +873,8 @@ export const WorkflowPanel = memo(function WorkflowPanel({
           }}
         >
           <div className="wf-hint">
-            Provide a value for each input — type it or drag a file in from the explorer.
+            Provide a value for each input — select a file in the explorer to fill it, or type /
+            drag a path.
           </div>
           {d.inputs.map((i) =>
             i.name === mode.batchInput ? null : (
@@ -859,12 +902,23 @@ export const WorkflowPanel = memo(function WorkflowPanel({
             >
               <option value="">— single run —</option>
               {d.inputs.map((i) => (
-                <option key={i.name} value={i.name}>
-                  {i.name}
+                <option key={i.name} value={i.name} title={i.example || undefined}>
+                  {inputOptionLabel(i)}
                 </option>
               ))}
             </select>
           </label>
+          {mode.batchInput &&
+            (() => {
+              const bi = d.inputs.find((i) => i.name === mode.batchInput)
+              return bi && (bi.description || bi.example) ? (
+                <div className="wf-hint">
+                  Batching <code>{bi.name}</code>
+                  {bi.description ? ` — ${bi.description}` : ''}
+                  {bi.example ? ` (e.g. ${basename(bi.example)})` : ''}
+                </div>
+              ) : null
+            })()}
           {mode.batchInput && <BatchSelection paths={selectedPaths} />}
           <div className="wf-actions">
             <button

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -465,23 +465,142 @@ button:hover {
   border-color: rgba(127, 168, 245, 0.4);
 }
 
-/* Display-convention toggle, pushed to the right edge of the overlay bar. */
-.conv-toggle {
-  margin-left: auto;
-  flex-shrink: 0;
+/* Viewer settings: gear in the panel header opens a popover. Positioned within
+   the header (no overflow:hidden there); .panel is the clip box and is tall, so
+   the downward popover isn't clipped. */
+.viewer-settings-anchor {
+  position: relative;
+  display: inline-flex;
+}
+
+.btn-icon.active {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.vs-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+}
+
+.vs-popover {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 41;
+  /* Fixed width (not min-width) so the popover doesn't grow when the Advanced
+     section — with its description lines — expands. */
+  width: 264px;
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  padding: 12px;
   background: var(--card);
   border: 1px solid var(--border2);
-  border-radius: 6px;
-  padding: 3px 10px;
-  font-family: var(--mono);
-  font-size: 11.5px;
+  border-radius: 10px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
+  /* The popover lives inside .panel-header, which sets uppercase/bold/spaced
+     text — reset all three so its controls use the normal UI type. */
+  text-transform: none;
+  letter-spacing: normal;
+  font-weight: 400;
+}
+
+.vs-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.vs-label {
+  font-size: 12px;
   font-weight: 500;
   color: var(--muted2);
 }
 
-.conv-toggle:hover {
-  border-color: var(--blue-l);
+.vs-check {
+  cursor: pointer;
+}
+
+.vs-check input {
+  accent-color: var(--blue-l);
+  width: 15px;
+  height: 15px;
+}
+
+.vs-select {
+  background: var(--dark2);
   color: var(--text);
+  border: 1px solid var(--border2);
+  border-radius: 6px;
+  padding: 3px 8px;
+  font-size: 12px;
+}
+
+.vs-segmented {
+  display: inline-flex;
+  border: 1px solid var(--border2);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.vs-seg {
+  background: var(--dark2);
+  color: var(--muted);
+  border: none;
+  padding: 3px 10px;
+  font-size: 11.5px;
+  cursor: pointer;
+}
+
+.vs-seg:not(:last-child) {
+  border-right: 1px solid var(--border2);
+}
+
+.vs-seg.active {
+  background: var(--blue);
+  color: #fff;
+}
+
+.vs-seg:hover:not(.active) {
+  color: var(--text);
+}
+
+.vs-advanced-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 3px;
+  padding: 8px 0 2px;
+  background: none;
+  border: none;
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.vs-advanced-toggle:hover {
+  /* Neutralize the global button:hover (faint bg fade + brightened border) — on
+     this full-width, border-top-only row it read as a shimmer. Only the text and
+     chevron colour shift, and colour isn't in the global transition, so it's
+     instant (no fade). */
+  background: none;
+  border-color: var(--border);
+  color: var(--text);
+}
+
+.vs-chevron {
+  /* Inherit the toggle's colour (muted at rest, brighter on hover) instead of
+     pinning it, so the chevron tracks the hover with the label. */
+  transition: transform 0.12s ease;
+}
+
+.vs-chevron.open {
+  transform: rotate(90deg);
 }
 
 .overlay-opacity-label {


### PR DESCRIPTION
## Summary
A batch of workspace-UI improvements: a viewer settings panel, plus fixes to chat deletion, the explorer context menu, and the replay input flow.

- **Viewer settings** — a gear popover in the viewer header. Everyday controls (Orientation neuro/radiological, Layout, 3D render, Crosshair) up top; an **Advanced** disclosure holds Interpolation (nearest/linear), Anti-aliasing, and Render scale (Native/2×/4×). Persisted in `localStorage`; defaults to **nearest** interpolation (crisp segmentation-label edges) and **native** HiDPI. The neuro/radiological toggle moved here out of the overlay bar.
- **Chat** — deleting the currently-open chat now opens a fresh chat instead of leaving the deleted transcript on screen.
- **File explorer** — the right-click context menu renders through a portal, so it's no longer clipped by the panel (it could vanish under the viewer/workflows/chat panels).
- **Workflows** — replay inputs auto-fill from the explorer selection (no extra click); the batch "over" dropdown shows informative labels (description + example filename) instead of a bare `in_1`.

## Test plan
- [x] `npm run lint` and `npm run build` clean
- [x] Viewer settings verified via headless render captures: nearest vs linear interpolation (crisp vs blended segmentation-label boundaries), the popover layout, the Advanced disclosure, and fixed-width (no jump on expand)
- [x] Confirmed Niivue applies each setting (interpolation/convention/sliceType/crosshair live; DPR + AA via remount) against the Niivue 0.69 API
- [x] Delete-current-chat, context-menu portal, and replay auto-fill exercised live on the deployed workspace (:8100)

## Screenshots
UI change — verified with headless captures during development (viewer interpolation A/B, settings popover collapsed/expanded). Captures available on request.

## Security & data handling
No new network calls, agent tool surface, or file-write paths. Viewer settings are client-side only (`localStorage`, `medmcp.viewerSettings`). The context menu now portals to `document.body` but renders the same trusted, local actions.

## Notes
- Niivue interpolation is global per instance and limited to nearest/linear (WebGL texture-filter hardware limit); the 3D render stays linear regardless. Render scale uses `forceDevicePixelRatio` as supersampling.
- A separate PR covers the backend distillation note-leak fix (`distill.py`), kept out of this UI PR.
