### PR TITLE
fix(distill): strip the workspace-context note from distilled workflows

### DIFF
--- a/src/medmcp/distill.py
+++ b/src/medmcp/distill.py
@@ -98,13 +98,25 @@ def parse_messages_file(path: Path) -> list[JsonDict]:
     return messages
 
 
+# The workspace server appends a "[workspace context: …]" note to the prompt
+# text so the agent can resolve "this image" (server.py:_workspace_note). That
+# note is live-turn metadata, not part of the user's request — strip it here or
+# it leaks into the distilled workflow's name and description. Keep this in sync
+# with server.py's _WORKSPACE_NOTE_RE.
+_WORKSPACE_NOTE_RE = re.compile(r"\n\n\[workspace context:.*$", re.DOTALL)
+
+
 def _first_user_message(messages: list[JsonDict]) -> str:
-    """Return the first non-injected user message, for context/naming."""
+    """Return the first non-injected user message, for context/naming.
+
+    The appended workspace-context note is stripped — it would otherwise pollute
+    the distilled workflow's name and description.
+    """
     for msg in messages:
         if msg.get("role") == "user" and not msg.get("injected"):
             content = msg.get("content")
             if isinstance(content, str) and content.strip():
-                return content.strip()
+                return _WORKSPACE_NOTE_RE.sub("", content).strip()
     return ""
 
 

--- a/src/medmcp/server.py
+++ b/src/medmcp/server.py
@@ -847,7 +847,9 @@ def _extract_text(content: object) -> str:
 # showing either to the user. The note is always appended last, so we cut from
 # its marker to the end — this also handles a title truncated mid-note (no
 # closing ``]``). The ``\n\n`` anchor avoids touching a bracketed phrase a user
-# happened to type inline.
+# happened to type inline. distill.py keeps a copy of this pattern (it strips the
+# note from the request that seeds a distilled workflow's name/description) —
+# keep the two in sync.
 _WORKSPACE_NOTE_RE = re.compile(r"\n\n\[workspace context:.*$", re.DOTALL)
 
 

--- a/tests/test_distill.py
+++ b/tests/test_distill.py
@@ -198,6 +198,36 @@ def test_slugify() -> None:
     assert distill._slugify("") == "workflow"
 
 
+class TestFirstUserMessage:
+    """_first_user_message yields a clean seed request for naming/description."""
+
+    def test_strips_workspace_note(self) -> None:
+        """The appended [workspace context: …] note is stripped from the seed request."""
+        messages = [
+            {
+                "role": "user",
+                "content": (
+                    "Skull strip this scan\n\n"
+                    '[workspace context: the file "/data/sub-01_T1w.nii.gz" is '
+                    "currently open in the viewer]"
+                ),
+            }
+        ]
+        assert distill._first_user_message(messages) == "Skull strip this scan"
+
+    def test_skips_injected_message(self) -> None:
+        """An injected message is not treated as the user's request."""
+        messages: list[dict[str, Any]] = [
+            {"role": "user", "content": "injected context", "injected": True},
+            {"role": "user", "content": "the real request"},
+        ]
+        assert distill._first_user_message(messages) == "the real request"
+
+    def test_plain_message_trimmed(self) -> None:
+        """A message with no note is returned, trimmed."""
+        assert distill._first_user_message([{"role": "user", "content": "  do it  "}]) == "do it"
+
+
 class TestRenderSkillMd:
     """render_skill_md produces a valid SKILL.md with or without prose."""
 


### PR DESCRIPTION
## Summary
The workspace server appends a `[workspace context: …]` note to a prompt so the agent can resolve phrases like "this image". That note is live-turn metadata, but it's stored in the transcript and was leaking into distilled workflows — `_first_user_message` (which seeds the workflow name, the mechanical description, and the LLM prose pass) returned it verbatim. This strips it.

## Test plan
- [x] `ruff check`, `ruff format`, and `pyright` clean on the changed files
- [x] `pytest tests/test_distill.py` — 37 passed, including the new `TestFirstUserMessage` (strips the note, skips injected messages, trims a plain message)

## Security & data handling
N/A — no new surface; the audit trail and permission flow are untouched.

## Notes
- Fixed at the single chokepoint (`_first_user_message`) with a regex mirroring `server.py`'s `_WORKSPACE_NOTE_RE`; both carry a cross-reference comment so they stay in sync.
- Recipe steps come from structured tool-call arguments, not message text, so the note can't leak there.
