### PR TITLE
feat(pool): persistent stack backend pool + pre-warm proxy (Layer 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -219,6 +219,9 @@ __marimo__/
 .vibe/provenance_enabled.json
 .vibe/explain_enabled.json
 .vibe/ui_sessions.json
+.vibe/gpu_selection.json
+.vibe/backends.json
+.vibe/backend.sock
 .vibe/provenance/
 .vibe/workflows/
 data/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
 [project.scripts]
 medmcp = "medmcp.provcli:main"
 medmcp-workspace = "medmcp.server:main"
+medmcp-mcp-proxy = "medmcp.proxy:main"
 
 [dependency-groups]
 test = [

--- a/src/medmcp/backend_broker.py
+++ b/src/medmcp/backend_broker.py
@@ -1,0 +1,164 @@
+"""Unix-socket broker fronting the :class:`~medmcp.backend_pool.BackendPool`.
+
+vibe-acp spawns ``medmcp-mcp-proxy <stack>`` per tool call (see ``proxy.py``); that
+shim connects to this broker over a unix domain socket and forwards ``list_tools``
+/ ``call_tool`` for its stack. The broker dispatches to the persistent pool —
+warming the backend if needed — and relays the result back, so the expensive
+spawn/import/CUDA cost is paid once in the pool instead of on every call.
+
+This is the server half of the broker protocol (Layer 1 of
+``docs/stack-prewarm-proxy.md``). Activation pre-warm / eviction are driven
+in-process by the workspace server holding the pool directly; the socket carries
+only the per-call forwarding ops.
+
+Wire protocol — newline-delimited JSON, one object per line.
+
+Request (proxy → broker)::
+
+    {"op": "list_tools", "stack": "medmcp-neuro", "id": 1}
+    {"op": "call_tool", "stack": "medmcp-neuro", "tool": "skull_strip",
+     "args": {...}, "id": 2}
+
+Response (broker → proxy)::
+
+    {"id": 1, "ok": true, "tools": [ <Tool.model_dump> ... ]}
+    {"id": 2, "ok": true, "result": <CallToolResult.model_dump>}
+    {"id": 2, "ok": false, "error": "stack 'x' is not installed"}
+
+Sampling relay is intentionally omitted in v1 (no stack uses MCP sampling).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+from pathlib import Path
+from typing import Any, cast
+
+from medmcp.backend_pool import BackendError, BackendPool
+
+log: logging.Logger = logging.getLogger(__name__)
+
+JsonDict = dict[str, Any]
+
+# Per-connection stream buffer cap. Tool results can be large (mirrors the 16 MB
+# vibe-acp stdout buffer); newline-delimited JSON otherwise overflows asyncio's
+# default 64 KB stream limit. Proxy clients MUST use the same cap on their reader.
+STREAM_LIMIT: int = 32 * 1024 * 1024
+
+
+class BrokerRequestError(Exception):
+    """Raised for a malformed broker request (reported back as ``ok: false``)."""
+
+
+class BackendBroker:
+    """Serves a :class:`BackendPool` to proxy shim processes over a unix socket."""
+
+    def __init__(self, pool: BackendPool, socket_path: Path) -> None:
+        """Create a broker; call :meth:`start` to begin listening.
+
+        Args:
+            pool: The persistent backend pool to dispatch to (owned elsewhere — the
+                broker does not close it).
+            socket_path: Path to the unix domain socket to bind.
+        """
+        self._pool = pool
+        self._socket_path = socket_path
+        self._server: asyncio.Server | None = None
+
+    async def start(self) -> None:
+        """Bind the unix socket and start accepting proxy connections."""
+        self._socket_path.parent.mkdir(parents=True, exist_ok=True)
+        with contextlib.suppress(FileNotFoundError):
+            self._socket_path.unlink()  # clear a stale socket from a prior crash
+        self._server = await asyncio.start_unix_server(
+            self._handle, path=str(self._socket_path), limit=STREAM_LIMIT
+        )
+        log.info("backend broker listening at %s", self._socket_path)
+
+    async def aclose(self) -> None:
+        """Stop listening and remove the socket file (does not close the pool)."""
+        server, self._server = self._server, None
+        if server is not None:
+            server.close()
+            with contextlib.suppress(Exception):
+                await server.wait_closed()
+        with contextlib.suppress(FileNotFoundError):
+            self._socket_path.unlink()
+
+    @property
+    def socket_path(self) -> Path:
+        """The unix socket path this broker binds."""
+        return self._socket_path
+
+    # ── connection handling ──────────────────────────────────────────────────
+
+    async def _handle(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        """Serve one proxy connection until it disconnects (EOF on stdin close)."""
+        try:
+            while True:
+                line = await reader.readline()
+                if not line:
+                    break  # proxy disconnected
+                await self._dispatch_line(line, writer)
+        except (ConnectionResetError, BrokenPipeError):
+            pass
+        except Exception as exc:  # a bad connection must not take down the broker
+            log.warning("broker connection error: %s", exc)
+        finally:
+            with contextlib.suppress(Exception):
+                writer.close()
+                await writer.wait_closed()
+
+    async def _dispatch_line(self, line: bytes, writer: asyncio.StreamWriter) -> None:
+        try:
+            parsed: object = json.loads(line)
+        except json.JSONDecodeError as exc:
+            await self._send(writer, {"id": None, "ok": False, "error": f"bad request: {exc}"})
+            return
+        if not isinstance(parsed, dict):
+            await self._send(
+                writer, {"id": None, "ok": False, "error": "request must be a JSON object"}
+            )
+            return
+
+        req = cast("JsonDict", parsed)
+        req_id = req.get("id")
+        op = req.get("op")
+        stack = req.get("stack")
+        try:
+            resp = await self._run_op(req_id, op, stack, req)
+        except (BackendError, BrokerRequestError) as exc:
+            resp = {"id": req_id, "ok": False, "error": str(exc)}
+        except Exception as exc:  # surface any failure rather than dropping the call
+            log.warning("broker dispatch failed (op=%s stack=%s): %s", op, stack, exc)
+            resp = {"id": req_id, "ok": False, "error": str(exc)}
+        await self._send(writer, resp)
+
+    async def _run_op(self, req_id: object, op: object, stack: object, req: JsonDict) -> JsonDict:
+        if not isinstance(stack, str) or not stack:
+            raise BrokerRequestError("missing 'stack'")
+
+        if op == "list_tools":
+            tools = await self._pool.list_tools(stack)
+            dumped = [t.model_dump(mode="json") for t in tools]
+            return {"id": req_id, "ok": True, "tools": dumped}
+
+        if op == "call_tool":
+            tool = req.get("tool")
+            if not isinstance(tool, str) or not tool:
+                raise BrokerRequestError("missing 'tool'")
+            raw_args: object = req.get("args") or {}
+            if not isinstance(raw_args, dict):
+                raise BrokerRequestError("'args' must be an object")
+            args: JsonDict = cast("JsonDict", raw_args)
+            result = await self._pool.call(stack, tool, args)
+            return {"id": req_id, "ok": True, "result": result.model_dump(mode="json")}
+
+        raise BrokerRequestError(f"unknown op {op!r}")
+
+    async def _send(self, writer: asyncio.StreamWriter, payload: JsonDict) -> None:
+        writer.write(json.dumps(payload).encode() + b"\n")
+        await writer.drain()

--- a/src/medmcp/backend_pool.py
+++ b/src/medmcp/backend_pool.py
@@ -1,0 +1,450 @@
+"""Persistent MCP backend pool — keeps stack servers warm across tool calls.
+
+Today every stack tool call spawns a fresh MCP stdio server (``docker run`` +
+import + CUDA init), runs one tool, and tears it down. This module holds each
+stack's server **persistent** so that cost is paid once (ideally pre-warmed at
+activation) instead of on every call. It is the UI/vibe-agnostic core of the
+stack pre-warm design (``docs/stack-prewarm-proxy.md``, Layer 1); the broker and
+proxy shim that connect vibe-acp to this pool live in separate modules.
+
+A :class:`Backend` wraps one long-lived ``stdio_client`` + ``ClientSession`` (the
+same primitives as :mod:`medmcp.replay`'s ``mcp_caller``) but does **not** tear
+the session down after a call. Because the MCP/anyio session must be entered and
+exited in the *same* task, each backend runs a dedicated *runner* task that owns
+the session for its whole lifetime: it opens the session, signals readiness, then
+waits for a close signal before unwinding. Calls from other tasks use the live
+``ClientSession`` object (safe — the SDK multiplexes requests by id); calls into a
+single backend are serialized so a stack keeps its one-call-at-a-time assumption.
+
+:class:`BackendPool` owns the set of warm backends and enforces two policies: an
+idle-TTL reaper evicts backends unused past their TTL, and a GPU LRU cap bounds
+how many VRAM-holding backends stay warm at once (they compete with the LLM).
+
+Sampling relay is intentionally **not** implemented in v1 (no current stack uses
+MCP sampling); a backend that issues a sampling request gets the SDK's default
+rejection. See the design doc's open decisions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Any
+
+import mcp.types as mcp_types
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+log: logging.Logger = logging.getLogger(__name__)
+
+JsonDict = dict[str, Any]
+
+# Name of the optional, best-effort tool a stack may expose so the pool can make
+# it load heavy resources (model weights, CUDA context) at pre-warm time rather
+# than on the first real call. Unmodified stacks simply don't expose it.
+WARMUP_TOOL: str = "warmup"
+
+# How often the idle reaper sweeps for TTL-expired / dead backends.
+_REAPER_INTERVAL_SEC: float = 15.0
+# Liveness ping bound — a pre-warmed backend may have died while idle (OOM, the
+# container daemon restarting); ``ensure`` probes before handing it back.
+_PING_TIMEOUT_SEC: float = 2.0
+# Grace period for a backend to unwind cleanly before it is cancelled.
+_TEARDOWN_TIMEOUT_SEC: float = 10.0
+
+
+class BackendError(Exception):
+    """Raised when a backend cannot be started or is not running."""
+
+
+@dataclass(frozen=True)
+class BackendSpec:
+    """Immutable launch recipe for one stack's persistent MCP server.
+
+    Produced by discovery (``settings.load_mcp_servers`` → ``.vibe/backends.json``)
+    and resolved by name through the pool's ``resolve_spec`` callback.
+
+    Attributes:
+        name: Stack name (e.g. ``"medmcp-neuro"``).
+        command: Executable to launch (``"docker"`` for container stacks, or the
+            absolute uv-tool binary host-native).
+        args: Arguments to *command*.
+        env: Extra environment variables, merged over ``os.environ``.
+        gpu: Whether this stack holds VRAM; counts against the GPU LRU cap.
+        idle_ttl_sec: Evict the backend after this many seconds idle.
+        startup_timeout_sec: Max time to reach the MCP ``initialize`` handshake.
+        tool_timeout_sec: Per-call read timeout for ``call_tool``.
+    """
+
+    name: str
+    command: str
+    args: list[str]
+    env: dict[str, str]
+    gpu: bool
+    idle_ttl_sec: float
+    startup_timeout_sec: float
+    tool_timeout_sec: float
+
+
+class Backend:
+    """One long-lived MCP stdio session to a stack server, reused across calls."""
+
+    def __init__(self, spec: BackendSpec, *, cwd: str | None = None) -> None:
+        """Create a backend for *spec*; call :meth:`start` to launch it.
+
+        Args:
+            spec: The launch recipe.
+            cwd: Working directory for the server process (the workspace root, so
+                a stack's tools resolve paths the same way the live chat does).
+        """
+        self.spec = spec
+        self._cwd = cwd
+        self._session: ClientSession | None = None
+        self._runner: asyncio.Task[None] | None = None
+        self._started: asyncio.Event = asyncio.Event()
+        self._closing: asyncio.Event = asyncio.Event()
+        self._start_error: BaseException | None = None
+        self._lock: asyncio.Lock = asyncio.Lock()  # serializes call_tool
+        self._tools: list[mcp_types.Tool] | None = None
+        self._last_used: float = time.monotonic()
+
+    # ── lifecycle ────────────────────────────────────────────────────────────
+
+    def _server_params(self) -> StdioServerParameters:
+        env = {**os.environ, **self.spec.env}
+        return StdioServerParameters(
+            command=self.spec.command,
+            args=list(self.spec.args),
+            env=env,
+            cwd=self._cwd,
+        )
+
+    async def _run(self) -> None:
+        """Own the session for its whole lifetime (enter + exit in one task).
+
+        Opens the stdio session, runs ``initialize``, publishes the live session,
+        then blocks until :meth:`aclose` signals close — so the session's context
+        managers unwind in the same task that entered them. A failure before the
+        ready signal is stored for :meth:`start` to raise; a failure *after* (the
+        process dying) just ends the task, so :attr:`alive` flips to ``False``.
+        """
+        init_timeout = timedelta(seconds=self.spec.startup_timeout_sec)
+        try:
+            async with (
+                stdio_client(self._server_params()) as (read, write),
+                ClientSession(read, write, read_timeout_seconds=init_timeout) as session,
+            ):
+                await session.initialize()
+                self._session = session
+                self._started.set()
+                await self._closing.wait()
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            if not self._started.is_set():
+                self._start_error = exc
+                self._started.set()  # unblock start()
+            else:
+                log.warning("backend %s ended unexpectedly: %s", self.spec.name, exc)
+        finally:
+            self._session = None
+
+    async def start(self) -> None:
+        """Launch the server and wait until it is initialized.
+
+        Raises:
+            BackendError: the server failed to start or did not initialize within
+                its startup timeout.
+        """
+        if self._runner is not None:
+            return
+        self._runner = asyncio.create_task(self._run(), name=f"backend:{self.spec.name}")
+        try:
+            await asyncio.wait_for(
+                self._started.wait(), timeout=self.spec.startup_timeout_sec + 5.0
+            )
+        except TimeoutError as exc:
+            await self.aclose()
+            raise BackendError(
+                f"stack {self.spec.name!r} did not start within "
+                f"{self.spec.startup_timeout_sec:.0f}s"
+            ) from exc
+        if self._start_error is not None or self._session is None:
+            err = self._start_error
+            await self.aclose()
+            raise BackendError(f"stack {self.spec.name!r} failed to start: {err}") from err
+
+    async def aclose(self) -> None:
+        """Stop the server; idempotent and safe to call mid-call (cancels it)."""
+        self._closing.set()
+        runner, self._runner = self._runner, None
+        if runner is None:
+            self._session = None
+            return
+        try:
+            await asyncio.wait_for(runner, timeout=_TEARDOWN_TIMEOUT_SEC)
+        except TimeoutError:
+            log.warning("backend %s did not stop in time; cancelled", self.spec.name)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            log.debug("backend %s teardown error: %s", self.spec.name, exc)
+        finally:
+            self._session = None
+
+    # ── use ──────────────────────────────────────────────────────────────────
+
+    async def call(self, tool: str, args: JsonDict) -> mcp_types.CallToolResult:
+        """Call *tool* on this backend (serialized with other calls to it).
+
+        A transport-level failure (the process having died) propagates so the pool
+        can evict and respawn; a tool that merely *reports* failure returns a
+        normal :class:`~mcp.types.CallToolResult` with ``isError`` set.
+        """
+        session = self._session
+        if session is None or not self.alive:
+            raise BackendError(f"backend {self.spec.name!r} is not running")
+        timeout = timedelta(seconds=self.spec.tool_timeout_sec)
+        async with self._lock:
+            self._last_used = time.monotonic()
+            try:
+                return await session.call_tool(tool, args, read_timeout_seconds=timeout)
+            finally:
+                self._last_used = time.monotonic()
+
+    async def list_tools(self) -> list[mcp_types.Tool]:
+        """Return the backend's tools (cached after the first call)."""
+        if self._tools is not None:
+            return self._tools
+        session = self._session
+        if session is None or not self.alive:
+            raise BackendError(f"backend {self.spec.name!r} is not running")
+        resp = await session.list_tools()
+        self._tools = list(resp.tools)
+        self._last_used = time.monotonic()
+        return self._tools
+
+    async def healthy(self) -> bool:
+        """Return whether the backend answers a bounded ping (does not touch idle)."""
+        session = self._session
+        if session is None or not self.alive:
+            return False
+        try:
+            await asyncio.wait_for(session.send_ping(), timeout=_PING_TIMEOUT_SEC)
+        except Exception:
+            return False
+        return True
+
+    # ── introspection ────────────────────────────────────────────────────────
+
+    @property
+    def alive(self) -> bool:
+        """Whether the runner is still running and the session is live."""
+        return (
+            self._runner is not None
+            and not self._runner.done()
+            and self._session is not None
+            and not self._closing.is_set()
+        )
+
+    @property
+    def busy(self) -> bool:
+        """Whether a call is currently in flight (its lock is held)."""
+        return self._lock.locked()
+
+    @property
+    def last_used(self) -> float:
+        """Monotonic timestamp of the last call (drives idle-TTL and LRU)."""
+        return self._last_used
+
+    def idle_seconds(self, now: float | None = None) -> float:
+        """Seconds since the backend was last used."""
+        return (now if now is not None else time.monotonic()) - self._last_used
+
+
+class BackendPool:
+    """Owns warm backends; enforces idle-TTL eviction and a GPU LRU cap."""
+
+    def __init__(
+        self,
+        *,
+        resolve_spec: Callable[[str], BackendSpec | None],
+        max_warm_gpu: int = 1,
+        cwd: str | None = None,
+        reaper_interval_sec: float = _REAPER_INTERVAL_SEC,
+    ) -> None:
+        """Create an empty pool.
+
+        Args:
+            resolve_spec: Maps a stack name to its :class:`BackendSpec`, or ``None``
+                if the stack is not installed.
+            max_warm_gpu: Max number of GPU (VRAM-holding) backends kept warm at
+                once; starting another evicts the least-recently-used GPU backend.
+                Clamped to at least 1.
+            cwd: Working directory passed to every backend (the workspace root).
+            reaper_interval_sec: How often the idle reaper sweeps.
+        """
+        self._resolve = resolve_spec
+        self._max_warm_gpu = max(1, max_warm_gpu)
+        self._cwd = cwd
+        self._reaper_interval = reaper_interval_sec
+        self._backends: dict[str, Backend] = {}
+        self._name_locks: dict[str, asyncio.Lock] = {}
+        self._reaper: asyncio.Task[None] | None = None
+        self._closed = False
+
+    # ── public API ───────────────────────────────────────────────────────────
+
+    async def ensure(self, name: str) -> Backend:
+        """Return a live backend for *name*, starting (or restarting) it if needed.
+
+        A pre-existing backend is probed with a bounded ping first, so a stack that
+        died while idle is transparently replaced. Concurrent ``ensure`` calls for
+        the same name are serialized so the server is started only once.
+        """
+        existing = self._backends.get(name)
+        if existing is not None and existing.alive and await existing.healthy():
+            return existing
+
+        async with self._name_lock(name):
+            existing = self._backends.get(name)
+            if existing is not None and existing.alive:
+                return existing
+            if existing is not None:
+                await self._drop(name)  # dead — make way for a fresh one
+
+            spec = self._resolve(name)
+            if spec is None:
+                raise BackendError(f"stack {name!r} is not installed")
+            if spec.gpu:
+                await self._enforce_gpu_cap(exclude=name)
+
+            backend = Backend(spec, cwd=self._cwd)
+            await backend.start()
+            self._backends[name] = backend
+            self._ensure_reaper()
+            log.info("backend %s warm (gpu=%s)", name, spec.gpu)
+            return backend
+
+    async def call(self, name: str, tool: str, args: JsonDict) -> mcp_types.CallToolResult:
+        """Call *tool* on stack *name*, warming the backend if needed.
+
+        On a transport failure the backend is evicted so the next call respawns it;
+        the error is **not** retried here (re-running a side-effecting medical tool
+        is worse than surfacing the failure).
+        """
+        backend = await self.ensure(name)
+        try:
+            return await backend.call(tool, args)
+        except BackendError:
+            raise
+        except Exception:
+            await self._drop(name)
+            raise
+
+    async def list_tools(self, name: str) -> list[mcp_types.Tool]:
+        """Return the tools advertised by stack *name*, warming it if needed."""
+        backend = await self.ensure(name)
+        return await backend.list_tools()
+
+    async def prewarm(self, names: Iterable[str]) -> dict[str, str | None]:
+        """Warm each named stack now (activation hook); never raises.
+
+        Calls each stack's optional ``warmup`` tool so heavy init happens here
+        rather than on the first real call. Returns a per-stack result mapping with
+        ``None`` on success or an error string on failure.
+        """
+        results: dict[str, str | None] = {}
+        for name in names:
+            try:
+                backend = await self.ensure(name)
+                await self._maybe_warmup(backend)
+                results[name] = None
+            except Exception as exc:
+                log.warning("pre-warm of %s failed: %s", name, exc)
+                results[name] = str(exc)
+        return results
+
+    async def evict(self, name: str) -> None:
+        """Tear down a backend now (deactivation), freeing its RAM/VRAM."""
+        await self._drop(name)
+
+    def warm_names(self) -> list[str]:
+        """Names of currently-live backends."""
+        return [n for n, b in self._backends.items() if b.alive]
+
+    async def aclose(self) -> None:
+        """Stop the reaper and tear down every backend."""
+        self._closed = True
+        reaper, self._reaper = self._reaper, None
+        if reaper is not None:
+            reaper.cancel()
+            await asyncio.gather(reaper, return_exceptions=True)
+        for name in list(self._backends):
+            await self._drop(name)
+
+    # ── internals ────────────────────────────────────────────────────────────
+
+    def _name_lock(self, name: str) -> asyncio.Lock:
+        lock = self._name_locks.get(name)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._name_locks[name] = lock
+        return lock
+
+    async def _drop(self, name: str) -> None:
+        backend = self._backends.pop(name, None)
+        if backend is not None:
+            await backend.aclose()
+            log.info("backend %s evicted", name)
+
+    async def _enforce_gpu_cap(self, *, exclude: str) -> None:
+        """Evict least-recently-used non-busy GPU backends to make room for one more."""
+
+        def warm_gpu() -> list[Backend]:
+            return [b for n, b in self._backends.items() if b.spec.gpu and b.alive and n != exclude]
+
+        while len(warm_gpu()) >= self._max_warm_gpu:
+            evictable = [b for b in warm_gpu() if not b.busy]
+            if not evictable:
+                log.warning(
+                    "GPU warm cap (%d) reached but all backends busy; "
+                    "temporarily exceeding it for %s",
+                    self._max_warm_gpu,
+                    exclude,
+                )
+                return
+            lru = min(evictable, key=lambda b: b.last_used)
+            await self._drop(lru.spec.name)
+
+    async def _maybe_warmup(self, backend: Backend) -> None:
+        try:
+            tools = await backend.list_tools()
+        except Exception as exc:
+            log.debug("warmup tool-list for %s failed: %s", backend.spec.name, exc)
+            return
+        if any(t.name == WARMUP_TOOL for t in tools):
+            try:
+                await backend.call(WARMUP_TOOL, {})
+            except Exception as exc:
+                log.debug("warmup call for %s failed: %s", backend.spec.name, exc)
+
+    def _ensure_reaper(self) -> None:
+        if self._reaper is None and not self._closed:
+            self._reaper = asyncio.create_task(self._reap_loop(), name="backend-pool-reaper")
+
+    async def _reap_loop(self) -> None:
+        while not self._closed:
+            await asyncio.sleep(self._reaper_interval)
+            now = time.monotonic()
+            for name, backend in list(self._backends.items()):
+                if not backend.alive:
+                    await self._drop(name)
+                elif not backend.busy and backend.idle_seconds(now) >= backend.spec.idle_ttl_sec:
+                    log.info("backend %s idle %.0fs; reaping", name, backend.idle_seconds(now))
+                    await self._drop(name)

--- a/src/medmcp/proxy.py
+++ b/src/medmcp/proxy.py
@@ -1,0 +1,224 @@
+"""``medmcp-mcp-proxy`` — the thin per-call MCP shim vibe-acp spawns.
+
+vibe-acp spawns one ``medmcp-mcp-proxy <stack>`` process per tool call. Instead of
+launching the real (heavy) stack server, this shim presents as an MCP stdio server
+to vibe and forwards ``list_tools`` / ``call_tool`` to the persistent backend pool
+via the broker socket (``MEDMCP_BROKER_SOCK``). The expensive spawn/import/CUDA
+cost is paid once in the pool, not on every call. The shim itself imports almost
+nothing, so vibe's per-call spawn stays cheap.
+
+If the broker socket is unreachable (the pool isn't running), the shim falls back
+to spawning the real stack directly from the backend registry
+(``MEDMCP_BACKENDS_FILE`` / ``.vibe/backends.json``) — degraded to a per-call cold
+start, but a chat never breaks. See ``docs/stack-prewarm-proxy.md`` (Layer 1).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import os
+import sys
+from datetime import timedelta
+from pathlib import Path
+from typing import Any, cast
+
+import mcp.types as mcp_types
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+from mcp.server.lowlevel import Server
+from mcp.server.stdio import stdio_server
+
+from medmcp.acp import VIBE_HOME
+from medmcp.backend_broker import STREAM_LIMIT
+
+log: logging.Logger = logging.getLogger(__name__)
+
+JsonDict = dict[str, Any]
+
+_DEFAULT_STARTUP_TIMEOUT_SEC: float = 60.0
+_DEFAULT_TOOL_TIMEOUT_SEC: float = 900.0
+
+
+class ProxyError(Exception):
+    """A broker- or registry-level error to surface to the caller as a tool error."""
+
+
+class _BrokerUnavailableError(Exception):
+    """The broker socket could not be reached; triggers the direct-spawn fallback."""
+
+
+def _backends_path() -> Path:
+    """Path to the backend registry (env override, else ``.vibe/backends.json``)."""
+    override = os.environ.get("MEDMCP_BACKENDS_FILE", "").strip()
+    return Path(override) if override else VIBE_HOME / "backends.json"
+
+
+class _Forwarder:
+    """Forwards a stack's tool calls to the broker, with a direct-spawn fallback."""
+
+    def __init__(self, stack: str) -> None:
+        self._stack = stack
+        self._sock_path = os.environ.get("MEDMCP_BROKER_SOCK", "").strip()
+        self._reader: asyncio.StreamReader | None = None
+        self._writer: asyncio.StreamWriter | None = None
+        self._req_id = 0
+        # No socket configured ⇒ go straight to direct-spawn mode.
+        self._direct = not self._sock_path
+        self._spec_cache: JsonDict | None = None
+
+    async def list_tools(self) -> list[mcp_types.Tool]:
+        if not self._direct:
+            try:
+                resp = await self._request({"op": "list_tools", "stack": self._stack})
+                raw = cast("list[Any]", resp.get("tools", []))
+                return [mcp_types.Tool.model_validate(t) for t in raw]
+            except _BrokerUnavailableError as exc:
+                log.warning("broker unavailable (%s); direct-spawning %s", exc, self._stack)
+                self._direct = True
+        return await self._direct_list_tools()
+
+    async def call_tool(self, name: str, args: JsonDict) -> mcp_types.CallToolResult:
+        if not self._direct:
+            try:
+                resp = await self._request(
+                    {"op": "call_tool", "stack": self._stack, "tool": name, "args": args}
+                )
+                return mcp_types.CallToolResult.model_validate(resp["result"])
+            except _BrokerUnavailableError as exc:
+                log.warning("broker unavailable (%s); direct-spawning %s", exc, self._stack)
+                self._direct = True
+        return await self._direct_call(name, args)
+
+    async def aclose(self) -> None:
+        writer, self._writer = self._writer, None
+        self._reader = None
+        if writer is not None:
+            writer.close()
+            with contextlib.suppress(Exception):
+                await writer.wait_closed()
+
+    # ── broker transport ─────────────────────────────────────────────────────
+
+    async def _request(self, payload: JsonDict) -> JsonDict:
+        if self._writer is None or self._reader is None:
+            try:
+                self._reader, self._writer = await asyncio.open_unix_connection(
+                    self._sock_path, limit=STREAM_LIMIT
+                )
+            except OSError as exc:
+                raise _BrokerUnavailableError(str(exc)) from exc
+        self._req_id += 1
+        payload["id"] = self._req_id
+        try:
+            self._writer.write(json.dumps(payload).encode() + b"\n")
+            await self._writer.drain()
+            line = await self._reader.readline()
+        except OSError as exc:
+            raise _BrokerUnavailableError(str(exc)) from exc
+        if not line:
+            raise _BrokerUnavailableError("broker closed the connection")
+        resp = cast("JsonDict", json.loads(line))
+        if not resp.get("ok"):
+            raise ProxyError(str(resp.get("error", "broker error")))
+        return resp
+
+    # ── direct-spawn fallback ────────────────────────────────────────────────
+
+    def _spec(self) -> JsonDict:
+        if self._spec_cache is not None:
+            return self._spec_cache
+        try:
+            data = cast("JsonDict", json.loads(_backends_path().read_text(encoding="utf-8")))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ProxyError(f"cannot read backend registry: {exc}") from exc
+        entry = data.get(self._stack)
+        if not isinstance(entry, dict):
+            raise ProxyError(f"stack {self._stack!r} is not configured")
+        self._spec_cache = cast("JsonDict", entry)
+        return self._spec_cache
+
+    def _server_params(self) -> StdioServerParameters:
+        spec = self._spec()
+        env: dict[str, str] = {**os.environ}
+        extra = spec.get("env")
+        if isinstance(extra, dict):
+            env.update({str(k): str(v) for k, v in cast("JsonDict", extra).items()})
+        cwd = spec.get("cwd") or os.environ.get("MEDMCP_WORKSPACE")
+        return StdioServerParameters(
+            command=str(spec["command"]),
+            args=[str(a) for a in cast("list[Any]", spec.get("args", []))],
+            env=env,
+            cwd=str(cwd) if cwd else None,
+        )
+
+    def _startup_timeout(self) -> timedelta:
+        secs = self._spec().get("startup_timeout_sec") or _DEFAULT_STARTUP_TIMEOUT_SEC
+        return timedelta(seconds=float(secs))
+
+    def _tool_timeout(self) -> timedelta:
+        secs = self._spec().get("tool_timeout_sec") or _DEFAULT_TOOL_TIMEOUT_SEC
+        return timedelta(seconds=float(secs))
+
+    async def _direct_list_tools(self) -> list[mcp_types.Tool]:
+        async with (
+            stdio_client(self._server_params()) as (read, write),
+            ClientSession(read, write, read_timeout_seconds=self._startup_timeout()) as session,
+        ):
+            await session.initialize()
+            resp = await session.list_tools()
+            return list(resp.tools)
+
+    async def _direct_call(self, name: str, args: JsonDict) -> mcp_types.CallToolResult:
+        async with (
+            stdio_client(self._server_params()) as (read, write),
+            ClientSession(read, write, read_timeout_seconds=self._startup_timeout()) as session,
+        ):
+            await session.initialize()
+            return await session.call_tool(name, args, read_timeout_seconds=self._tool_timeout())
+
+
+async def _serve(stack: str) -> None:
+    """Run the proxy MCP server for *stack* over stdio until vibe disconnects."""
+    server: Server[object, object] = Server(f"medmcp-proxy-{stack}")
+    forwarder = _Forwarder(stack)
+
+    # Registered via decorator side effect; pyright can't see the access.
+    @server.list_tools()
+    async def _list_tools() -> list[mcp_types.Tool]:  # pyright: ignore[reportUnusedFunction]
+        return await forwarder.list_tools()
+
+    @server.call_tool(validate_input=False)
+    async def _call_tool(  # pyright: ignore[reportUnusedFunction]
+        name: str, arguments: JsonDict
+    ) -> mcp_types.CallToolResult:
+        try:
+            return await forwarder.call_tool(name, arguments)
+        except ProxyError as exc:
+            # Surface a broker/registry error as a tool failure, not a crash.
+            return mcp_types.CallToolResult(
+                content=[mcp_types.TextContent(type="text", text=str(exc))],
+                isError=True,
+            )
+
+    try:
+        async with stdio_server() as (read, write):
+            await server.run(read, write, server.create_initialization_options())
+    finally:
+        await forwarder.aclose()
+
+
+def main() -> None:
+    """Console-script entry point: ``medmcp-mcp-proxy <stack-name>``."""
+    logging.basicConfig(level=logging.WARNING, stream=sys.stderr)
+    args = sys.argv[1:]
+    if len(args) != 1 or not args[0].strip():
+        sys.stderr.write("usage: medmcp-mcp-proxy <stack-name>\n")
+        raise SystemExit(2)
+    asyncio.run(_serve(args[0].strip()))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/medmcp/proxy.py
+++ b/src/medmcp/proxy.py
@@ -41,6 +41,14 @@ JsonDict = dict[str, Any]
 _DEFAULT_STARTUP_TIMEOUT_SEC: float = 60.0
 _DEFAULT_TOOL_TIMEOUT_SEC: float = 900.0
 
+# Tools that exist for the backend pool's machinery, not for the model to call, so
+# the shim hides them from the vibe/LLM-facing tool list. Kept in sync by hand with
+# ``medmcp.backend_pool.WARMUP_TOOL`` rather than imported — importing that module
+# would pull the whole pool implementation into this deliberately lightweight per-call
+# shim. The pool discovers ``warmup`` by listing tools directly on the backend (not
+# through this proxy), so hiding it here leaves pre-warm untouched.
+_HIDDEN_TOOLS: frozenset[str] = frozenset({"warmup"})
+
 
 class ProxyError(Exception):
     """A broker- or registry-level error to surface to the caller as a tool error."""
@@ -188,7 +196,10 @@ async def _serve(stack: str) -> None:
     # Registered via decorator side effect; pyright can't see the access.
     @server.list_tools()
     async def _list_tools() -> list[mcp_types.Tool]:  # pyright: ignore[reportUnusedFunction]
-        return await forwarder.list_tools()
+        # Hide pool-machinery tools (e.g. ``warmup``) from the model; the pool still
+        # discovers them by listing tools directly on the backend.
+        tools = await forwarder.list_tools()
+        return [t for t in tools if t.name not in _HIDDEN_TOOLS]
 
     @server.call_tool(validate_input=False)
     async def _call_tool(  # pyright: ignore[reportUnusedFunction]

--- a/src/medmcp/server.py
+++ b/src/medmcp/server.py
@@ -39,6 +39,7 @@ import os
 import re
 import shutil
 import time
+from collections.abc import AsyncGenerator
 from pathlib import Path
 from typing import Any, cast
 
@@ -50,8 +51,11 @@ from pydantic import BaseModel
 
 from medmcp import distill, explain, provenance, replay, sessions, settings
 from medmcp.acp import PROJECT_ROOT, VIBE_HOME, JsonDict, VibeAcpClient
+from medmcp.backend_broker import BackendBroker
+from medmcp.backend_pool import BackendPool, BackendSpec
 
 _audit: logging.Logger = logging.getLogger("medmcp.audit")
+log: logging.Logger = logging.getLogger(__name__)
 
 # Directory shown in the file explorer AND the agent's working directory (its
 # tools run here, so it sees the same files as the explorer/viewer). Defaults
@@ -78,7 +82,59 @@ _SKIP_DIRS: frozenset[str] = frozenset(
 _TREE_MAX_DEPTH: int = 12
 _TREE_MAX_ENTRIES_PER_DIR: int = 500
 
-app = FastAPI(title="MedMCP Workspace")
+# ── Persistent stack pool + broker (Layer 1; MEDMCP_STACK_POOL) ───────────────
+# Created at startup only when the pool is enabled; None otherwise (the legacy
+# per-call spawn). The pool lives in THIS process, so warm backends survive the
+# vibe-acp restarts that stack/workflow changes trigger.
+_pool: BackendPool | None = None
+_broker: BackendBroker | None = None
+
+
+def _resolve_backend_spec(name: str) -> BackendSpec | None:
+    """Map an active stack name to its persistent-backend launch spec (pool callback)."""
+    entry = settings.build_backend_registry(settings.active_servers()).get(name)
+    if entry is None:
+        return None
+    return BackendSpec(
+        name=name,
+        command=str(entry["command"]),
+        args=[str(a) for a in cast("list[Any]", entry["args"])],
+        env={str(k): str(v) for k, v in cast("JsonDict", entry["env"]).items()},
+        gpu=bool(entry["gpu"]),
+        idle_ttl_sec=float(entry["idle_ttl_sec"]),
+        startup_timeout_sec=float(entry["startup_timeout_sec"]),
+        tool_timeout_sec=float(entry["tool_timeout_sec"]),
+    )
+
+
+@contextlib.asynccontextmanager
+async def _lifespan(_app: FastAPI) -> AsyncGenerator[None]:
+    """Start the stack pool + broker on boot (when enabled); tear them down on exit."""
+    global _pool, _broker
+    if settings.stack_pool_enabled():
+        # Proxy children read MEDMCP_WORKSPACE for their fallback cwd; export it.
+        os.environ.setdefault("MEDMCP_WORKSPACE", str(WORKSPACE_ROOT))
+        _pool = BackendPool(resolve_spec=_resolve_backend_spec, cwd=str(WORKSPACE_ROOT))
+        _broker = BackendBroker(_pool, settings.backend_socket_path())
+        try:
+            await _broker.start()
+            # Proxied config + backends.json exist from boot, before any tool call.
+            await asyncio.to_thread(settings.sync_servers_to_vibe_config, settings.active_servers())
+            log.info("stack pool enabled; broker at %s", settings.backend_socket_path())
+        except Exception:
+            log.exception("backend broker failed to start; proxy will direct-spawn")
+    try:
+        yield
+    finally:
+        if _broker is not None:
+            await _broker.aclose()
+        if _pool is not None:
+            await _pool.aclose()
+        _broker = None
+        _pool = None
+
+
+app = FastAPI(title="MedMCP Workspace", lifespan=_lifespan)
 
 # One vibe-acp subprocess shared by every websocket connection. The subprocess
 # cwd must stay PROJECT_ROOT — `uv run` resolves the project from it; the
@@ -286,7 +342,7 @@ async def put_settings(payload: SettingsPayload) -> JsonDict:
     sockets are closed; each client auto-reconnects into a new session.
     """
 
-    def _apply() -> bool:
+    def _apply() -> tuple[bool, set[str], set[str]]:
         old_stacks = settings.load_active_server_names()
         old_workflows = settings.load_active_workflow_names()
         old_wf_enabled = settings.load_workflows_enabled()
@@ -318,13 +374,29 @@ async def put_settings(payload: SettingsPayload) -> JsonDict:
         )
         if restart:
             settings.sync_servers_to_vibe_config(settings.active_servers())
-        return restart
+        return restart, new_stacks - old_stacks, old_stacks - new_stacks
 
-    restart_needed = await asyncio.to_thread(_apply)
+    restart_needed, newly_active, newly_inactive = await asyncio.to_thread(_apply)
     if restart_needed:
         _audit.info("settings changed; restarting vibe-acp")
         await _restart_vibe()
+    await _apply_pool_changes(newly_active, newly_inactive)
     return {"ok": True, "restarted": restart_needed}
+
+
+async def _apply_pool_changes(newly_active: set[str], newly_inactive: set[str]) -> None:
+    """Evict deactivated stacks and pre-warm newly-activated ones (pool enabled only)."""
+    if _pool is None:
+        return
+    for name in newly_inactive:
+        with contextlib.suppress(Exception):
+            await _pool.evict(name)
+    if newly_active:
+        # Pre-warm in the background so the settings response stays snappy; the
+        # heavy spawn/import/CUDA cost is then paid before the first real call.
+        task = asyncio.create_task(_pool.prewarm(newly_active))
+        _background_tasks.add(task)
+        task.add_done_callback(_background_tasks.discard)
 
 
 async def _restart_vibe() -> None:

--- a/src/medmcp/settings.py
+++ b/src/medmcp/settings.py
@@ -128,6 +128,99 @@ EXPLAIN_ENABLED_PATH: Path = VIBE_HOME / "explain_enabled.json"
 # against the environment at load time (e.g. ``${MEDMCP_WORKSPACE}`` for path parity).
 STACKS_D_PATH: Path = Path(PROJECT_ROOT) / "stacks.d"
 
+# ── Persistent stack pool / pre-warm proxy (Layer 1) ─────────────────────────
+# When MEDMCP_STACK_POOL is enabled, vibe's [[mcp_servers]] are rewritten to spawn
+# the lightweight `medmcp-mcp-proxy <stack>` shim, which forwards tool calls to a
+# persistent BackendPool over a broker socket (so the spawn/import/CUDA cost is
+# paid once, not per call). The real launch specs go to backends.json for the pool
+# and the proxy's direct-spawn fallback. Off by default — ships dark.
+PROXY_COMMAND: str = "medmcp-mcp-proxy"
+DEFAULT_IDLE_TTL_SEC: float = 120.0
+DEFAULT_STARTUP_TIMEOUT_SEC: float = 60.0
+DEFAULT_TOOL_TIMEOUT_SEC: float = 900.0
+# Env keys the proxy layer injects into a stack's [[mcp_servers]] entry — stripped
+# again when the pool is disabled so toggling off leaves no stale routing.
+_POOL_ENV_KEYS: tuple[str, ...] = ("MEDMCP_BROKER_SOCK", "MEDMCP_WORKSPACE")
+
+
+def stack_pool_enabled() -> bool:
+    """Whether the persistent stack pool / pre-warm proxy is enabled (default off)."""
+    return os.environ.get("MEDMCP_STACK_POOL", "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def backend_socket_path() -> Path:
+    """Unix socket the broker binds and the proxy connects to."""
+    return VIBE_HOME / "backend.sock"
+
+
+def backends_registry_path() -> Path:
+    """Registry of real stack launch specs (pool + proxy direct-spawn fallback)."""
+    return VIBE_HOME / "backends.json"
+
+
+def build_backend_registry(servers: list[JsonDict]) -> dict[str, JsonDict]:
+    """Build the name→launch-spec registry the pool and proxy fallback read.
+
+    Captures each stack's *real* command/args/env (the pool spawns these, not vibe)
+    plus the pool-policy fields. ``gpu`` is taken from an explicit flag or inferred
+    from a CDI ``--device nvidia.com/gpu=…`` arg (host-native stacks without the
+    flag are treated as non-GPU — a known gap for the LRU cap in local dev).
+    """
+    registry: dict[str, JsonDict] = {}
+    for srv in servers:
+        name = str(srv["name"])
+        args = [str(a) for a in cast("list[Any]", srv.get("args", []))]
+        raw_env = srv.get("env")
+        env = (
+            {str(k): str(v) for k, v in cast("JsonDict", raw_env).items()}
+            if isinstance(raw_env, dict)
+            else {}
+        )
+        registry[name] = {
+            "command": str(srv["command"]),
+            "args": args,
+            "env": env,
+            "gpu": bool(srv.get("gpu")) or any("nvidia.com/gpu" in a for a in args),
+            "idle_ttl_sec": float(srv.get("idle_ttl_sec") or DEFAULT_IDLE_TTL_SEC),
+            "startup_timeout_sec": float(
+                srv.get("startup_timeout_sec") or DEFAULT_STARTUP_TIMEOUT_SEC
+            ),
+            "tool_timeout_sec": float(srv.get("tool_timeout_sec") or DEFAULT_TOOL_TIMEOUT_SEC),
+        }
+    return registry
+
+
+def _write_backend_registry(servers: list[JsonDict]) -> None:
+    """Atomically write backends.json from the real (un-proxied) server specs."""
+    _atomic_write_json(backends_registry_path(), build_backend_registry(servers))
+
+
+def _proxied_entry(entry: JsonDict, ws_root: str | None) -> JsonDict:
+    """Rewrite a synced ``[[mcp_servers]]`` entry to launch through the proxy shim.
+
+    vibe spawns ``medmcp-mcp-proxy <stack>`` instead of the real server; discovery
+    fields (``skills_path``, ``tool_timeout_sec``, ``transport``, ``name``) are kept
+    so vibe still loads skills and waits long enough for a possibly-cold backend.
+    The stack's real ``env`` lives in backends.json, not here.
+    """
+    out = dict(entry)
+    out["command"] = shutil.which(PROXY_COMMAND) or PROXY_COMMAND
+    out["args"] = [str(entry["name"])]
+    proxied_env: dict[str, str] = {"MEDMCP_BROKER_SOCK": str(backend_socket_path())}
+    if ws_root:
+        proxied_env["MEDMCP_WORKSPACE"] = ws_root
+    out["env"] = proxied_env
+    return out
+
+
+def _strip_pool_env(entries: list[JsonDict]) -> None:
+    """Drop pool-injected env keys preserved from a prior proxied config."""
+    for entry in entries:
+        env = entry.get("env")
+        if isinstance(env, dict):
+            for key in _POOL_ENV_KEYS:
+                cast("JsonDict", env).pop(key, None)
+
 
 def get_uv_tool_dir() -> Path | None:
     """Return the uv tool installation directory, or ``None`` if unavailable."""
@@ -194,6 +287,8 @@ def _load_stack_manifests() -> list[JsonDict]:
             entry["skills_path"] = os.path.expandvars(str(raw["skills_path"]))
         if raw.get("tool_timeout_sec") is not None:
             entry["tool_timeout_sec"] = raw["tool_timeout_sec"]
+        if raw.get("idle_ttl_sec") is not None:
+            entry["idle_ttl_sec"] = raw["idle_ttl_sec"]
         manifests.append(entry)
     return manifests
 
@@ -283,7 +378,13 @@ def load_mcp_servers() -> list[JsonDict]:
                     "env": dict(cast("dict[str, str]", srv.get("env", {}))),
                     "version": version,
                 }
-                for key in ("skills_path", "tool_timeout_sec", "startup_timeout_sec"):
+                for key in (
+                    "skills_path",
+                    "tool_timeout_sec",
+                    "startup_timeout_sec",
+                    "idle_ttl_sec",
+                    "gpu",
+                ):
                     if srv.get(key) is not None:
                         entry[key] = srv[key]
                 servers[name] = entry
@@ -929,6 +1030,17 @@ def _sync_servers_to_vibe_config_locked(servers: list[JsonDict]) -> None:
             else:
                 entry.pop("args", None)
             new_entries.append(entry)
+
+    # Route every stack through the pre-warm proxy when the pool is enabled. vibe
+    # then spawns the cheap `medmcp-mcp-proxy <stack>` shim, which forwards to the
+    # persistent BackendPool; the real launch specs go to backends.json. Disabled
+    # is byte-for-byte the legacy behaviour, minus any stale proxy env keys.
+    if stack_pool_enabled():
+        _write_backend_registry(servers)
+        ws_root = os.environ.get("MEDMCP_WORKSPACE") or None
+        new_entries = [_proxied_entry(entry, ws_root) for entry in new_entries]
+    else:
+        _strip_pool_env(new_entries)
 
     cfg["mcp_servers"] = new_entries
 

--- a/tests/fake_stack_server.py
+++ b/tests/fake_stack_server.py
@@ -1,0 +1,47 @@
+"""Minimal FastMCP stdio server used by tests/test_backend_pool.py.
+
+Exposes a handful of tools that let the backend-pool tests observe lifecycle
+behaviour: ``echo`` (basic call), ``warmup`` + ``warmup_count`` (the pre-warm
+hook plus a counter that proves in-process state persists across calls of a
+warm backend), and ``crash`` (kills the process to exercise death/respawn).
+"""
+
+from __future__ import annotations
+
+import os
+
+from mcp.server.fastmcp import FastMCP
+
+mcp: FastMCP = FastMCP("fake-stack")
+
+_warmups: int = 0
+
+
+@mcp.tool()
+def echo(text: str) -> dict[str, str]:
+    """Return *text* unchanged."""
+    return {"text": text}
+
+
+@mcp.tool()
+def warmup() -> dict[str, bool]:
+    """Pre-warm hook; increments an in-process counter."""
+    global _warmups
+    _warmups += 1
+    return {"ok": True}
+
+
+@mcp.tool()
+def warmup_count() -> dict[str, int]:
+    """Return how many times ``warmup`` ran in this process."""
+    return {"count": _warmups}
+
+
+@mcp.tool()
+def crash() -> dict[str, str]:
+    """Terminate the process immediately (simulates a backend dying mid-call)."""
+    os._exit(0)
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/tests/test_backend_broker.py
+++ b/tests/test_backend_broker.py
@@ -1,0 +1,147 @@
+"""End-to-end tests for the backend broker (unix socket → pool → fake server)."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import sys
+from collections.abc import AsyncGenerator, Callable
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+
+import mcp.types as mcp_types
+import pytest
+
+from medmcp import replay
+from medmcp.backend_broker import STREAM_LIMIT, BackendBroker
+from medmcp.backend_pool import BackendPool, BackendSpec
+
+JsonDict = dict[str, Any]
+
+_FAKE_SERVER: Path = Path(__file__).parent / "fake_stack_server.py"
+
+
+def _spec(name: str) -> BackendSpec:
+    return BackendSpec(
+        name=name,
+        command=sys.executable,
+        args=[str(_FAKE_SERVER)],
+        env={},
+        gpu=False,
+        idle_ttl_sec=300.0,
+        startup_timeout_sec=30.0,
+        tool_timeout_sec=30.0,
+    )
+
+
+def _resolver(specs: dict[str, BackendSpec]) -> Callable[[str], BackendSpec | None]:
+    def resolve(name: str) -> BackendSpec | None:
+        return specs.get(name)
+
+    return resolve
+
+
+@asynccontextmanager
+async def _broker(tmp_path: Path) -> AsyncGenerator[Path]:
+    """Run a broker over a real socket against a pool with the fake stack."""
+    pool = BackendPool(resolve_spec=_resolver({"fake": _spec("fake")}))
+    broker = BackendBroker(pool, tmp_path / "broker.sock")
+    await broker.start()
+    try:
+        yield broker.socket_path
+    finally:
+        await broker.aclose()
+        await pool.aclose()
+
+
+async def _roundtrip(socket_path: Path, request: JsonDict) -> JsonDict:
+    """Send one request line and return the parsed response."""
+    reader, writer = await asyncio.open_unix_connection(str(socket_path), limit=STREAM_LIMIT)
+    try:
+        writer.write(json.dumps(request).encode() + b"\n")
+        await writer.drain()
+        line = await reader.readline()
+    finally:
+        writer.close()
+        with contextlib.suppress(Exception):
+            await writer.wait_closed()
+    return json.loads(line)
+
+
+@pytest.mark.asyncio
+async def test_list_tools_over_socket(tmp_path: Path) -> None:
+    """list_tools returns the stack's tools through the broker."""
+    async with _broker(tmp_path) as sock:
+        resp = await _roundtrip(sock, {"op": "list_tools", "stack": "fake", "id": 1})
+    assert resp["ok"] is True
+    assert resp["id"] == 1
+    names = {t["name"] for t in resp["tools"]}
+    assert {"echo", "warmup", "crash"} <= names
+
+
+@pytest.mark.asyncio
+async def test_call_tool_over_socket(tmp_path: Path) -> None:
+    """call_tool runs the tool and relays a reconstructable CallToolResult."""
+    async with _broker(tmp_path) as sock:
+        resp = await _roundtrip(
+            sock,
+            {"op": "call_tool", "stack": "fake", "tool": "echo", "args": {"text": "hi"}, "id": 2},
+        )
+    assert resp["ok"] is True
+    result = mcp_types.CallToolResult.model_validate(resp["result"])
+    assert replay.extract_structured(result) == {"text": "hi"}
+
+
+@pytest.mark.asyncio
+async def test_unknown_stack_returns_error(tmp_path: Path) -> None:
+    """A call for an uninstalled stack comes back as ok=false with a message."""
+    async with _broker(tmp_path) as sock:
+        resp = await _roundtrip(sock, {"op": "list_tools", "stack": "ghost", "id": 3})
+    assert resp["ok"] is False
+    assert "not installed" in resp["error"]
+
+
+@pytest.mark.asyncio
+async def test_bad_op_and_missing_fields(tmp_path: Path) -> None:
+    """Protocol errors are reported, not dropped, and the connection survives."""
+    async with _broker(tmp_path) as sock:
+        bad_op = await _roundtrip(sock, {"op": "nope", "stack": "fake", "id": 4})
+        assert bad_op["ok"] is False and "unknown op" in bad_op["error"]
+
+        no_stack = await _roundtrip(sock, {"op": "list_tools", "id": 5})
+        assert no_stack["ok"] is False and "stack" in no_stack["error"]
+
+        no_tool = await _roundtrip(sock, {"op": "call_tool", "stack": "fake", "id": 6})
+        assert no_tool["ok"] is False and "tool" in no_tool["error"]
+
+
+@pytest.mark.asyncio
+async def test_multiple_requests_on_one_connection(tmp_path: Path) -> None:
+    """A single connection can issue several requests in sequence."""
+    async with _broker(tmp_path) as sock:
+        reader, writer = await asyncio.open_unix_connection(str(sock), limit=STREAM_LIMIT)
+        try:
+            for i, text in enumerate(["a", "b", "c"]):
+                writer.write(
+                    json.dumps(
+                        {
+                            "op": "call_tool",
+                            "stack": "fake",
+                            "tool": "echo",
+                            "args": {"text": text},
+                            "id": i,
+                        }
+                    ).encode()
+                    + b"\n"
+                )
+                await writer.drain()
+                resp = json.loads(await reader.readline())
+                assert resp["id"] == i
+                result = mcp_types.CallToolResult.model_validate(resp["result"])
+                assert replay.extract_structured(result) == {"text": text}
+        finally:
+            writer.close()
+            with contextlib.suppress(Exception):
+                await writer.wait_closed()

--- a/tests/test_backend_pool.py
+++ b/tests/test_backend_pool.py
@@ -1,0 +1,151 @@
+"""Lifecycle tests for the persistent MCP backend pool.
+
+These spawn a real (tiny) FastMCP stdio server (``fake_stack_server.py``) so the
+subtle part — a session held open across calls in a dedicated runner task — is
+exercised for real, not mocked.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from medmcp import replay
+from medmcp.backend_pool import Backend, BackendError, BackendPool, BackendSpec
+
+_FAKE_SERVER: Path = Path(__file__).parent / "fake_stack_server.py"
+
+
+def _spec(name: str, *, gpu: bool = False, idle_ttl: float = 300.0) -> BackendSpec:
+    """Build a spec that launches the fake stack server."""
+    return BackendSpec(
+        name=name,
+        command=sys.executable,
+        args=[str(_FAKE_SERVER)],
+        env={},
+        gpu=gpu,
+        idle_ttl_sec=idle_ttl,
+        startup_timeout_sec=30.0,
+        tool_timeout_sec=30.0,
+    )
+
+
+def _resolver(specs: dict[str, BackendSpec]) -> Callable[[str], BackendSpec | None]:
+    """Return a resolve_spec callback backed by *specs*."""
+
+    def resolve(name: str) -> BackendSpec | None:
+        return specs.get(name)
+
+    return resolve
+
+
+@pytest.mark.asyncio
+async def test_backend_start_call_and_close() -> None:
+    """A backend starts, serves calls, lists tools, pings, then closes cleanly."""
+    backend = Backend(_spec("fake"))
+    await backend.start()
+    try:
+        assert backend.alive
+        names = {t.name for t in await backend.list_tools()}
+        assert {"echo", "warmup", "crash"} <= names
+        result = await backend.call("echo", {"text": "hi"})
+        assert replay.extract_structured(result) == {"text": "hi"}
+        assert await backend.healthy()
+    finally:
+        await backend.aclose()
+    assert not backend.alive
+
+
+@pytest.mark.asyncio
+async def test_pool_ensure_reuses_then_evicts() -> None:
+    """Ensure returns the same warm backend; evict tears it down."""
+    pool = BackendPool(resolve_spec=_resolver({"fake": _spec("fake")}))
+    try:
+        first = await pool.ensure("fake")
+        second = await pool.ensure("fake")
+        assert first is second
+        assert pool.warm_names() == ["fake"]
+        await pool.evict("fake")
+        assert pool.warm_names() == []
+        assert not first.alive
+    finally:
+        await pool.aclose()
+
+
+@pytest.mark.asyncio
+async def test_prewarm_invokes_warmup_and_state_persists() -> None:
+    """Prewarm calls the warmup hook once; the same process serves later calls."""
+    pool = BackendPool(resolve_spec=_resolver({"fake": _spec("fake")}))
+    try:
+        errors = await pool.prewarm(["fake"])
+        assert errors == {"fake": None}
+        # warmup ran exactly once at pre-warm, and the counter survives — proof
+        # the call below hit the same warm process, not a fresh one.
+        result = await pool.call("fake", "warmup_count", {})
+        assert replay.extract_structured(result) == {"count": 1}
+    finally:
+        await pool.aclose()
+
+
+@pytest.mark.asyncio
+async def test_gpu_lru_cap_evicts_least_recently_used() -> None:
+    """With max_warm_gpu=1, warming a second GPU stack evicts the first."""
+    specs = {"a": _spec("a", gpu=True), "b": _spec("b", gpu=True)}
+    pool = BackendPool(resolve_spec=_resolver(specs), max_warm_gpu=1)
+    try:
+        first = await pool.ensure("a")
+        second = await pool.ensure("b")
+        assert second.alive
+        assert not first.alive
+        assert pool.warm_names() == ["b"]
+    finally:
+        await pool.aclose()
+
+
+@pytest.mark.asyncio
+async def test_idle_backend_is_reaped() -> None:
+    """A backend idle past its TTL is evicted by the reaper."""
+    pool = BackendPool(
+        resolve_spec=_resolver({"fake": _spec("fake", idle_ttl=0.05)}),
+        reaper_interval_sec=0.05,
+    )
+    try:
+        await pool.ensure("fake")
+        deadline = time.monotonic() + 5.0
+        while pool.warm_names() and time.monotonic() < deadline:
+            await asyncio.sleep(0.05)
+        assert pool.warm_names() == []
+    finally:
+        await pool.aclose()
+
+
+@pytest.mark.asyncio
+async def test_call_failure_evicts_and_ensure_respawns() -> None:
+    """A backend that dies mid-call is dropped; ensure spawns a fresh one."""
+    pool = BackendPool(resolve_spec=_resolver({"fake": _spec("fake")}))
+    try:
+        first = await pool.ensure("fake")
+        with pytest.raises(Exception):  # noqa: B017 - transport death surfaces
+            await pool.call("fake", "crash", {})
+        assert pool.warm_names() == []
+        second = await pool.ensure("fake")
+        assert second is not first
+        assert second.alive
+    finally:
+        await pool.aclose()
+
+
+@pytest.mark.asyncio
+async def test_ensure_unknown_stack_raises() -> None:
+    """Ensure raises BackendError when the stack is not installed."""
+    pool = BackendPool(resolve_spec=_resolver({}))
+    try:
+        with pytest.raises(BackendError):
+            await pool.ensure("nope")
+    finally:
+        await pool.aclose()

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,0 +1,123 @@
+"""End-to-end tests for the medmcp-mcp-proxy shim.
+
+Each test spawns the proxy as a real MCP stdio server (``python -m medmcp.proxy
+<stack>``) and drives it as an MCP client, exercising both paths: forwarding to a
+live broker, and the direct-spawn fallback when no broker is reachable.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from collections.abc import AsyncGenerator, Callable
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import mcp.types as mcp_types
+import pytest
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+from medmcp import replay
+from medmcp.backend_broker import BackendBroker
+from medmcp.backend_pool import BackendPool, BackendSpec
+
+_FAKE_SERVER: Path = Path(__file__).parent / "fake_stack_server.py"
+
+
+def _spec(name: str) -> BackendSpec:
+    return BackendSpec(
+        name=name,
+        command=sys.executable,
+        args=[str(_FAKE_SERVER)],
+        env={},
+        gpu=False,
+        idle_ttl_sec=300.0,
+        startup_timeout_sec=30.0,
+        tool_timeout_sec=30.0,
+    )
+
+
+def _resolver(specs: dict[str, BackendSpec]) -> Callable[[str], BackendSpec | None]:
+    def resolve(name: str) -> BackendSpec | None:
+        return specs.get(name)
+
+    return resolve
+
+
+@asynccontextmanager
+async def _proxy_client(env: dict[str, str]) -> AsyncGenerator[ClientSession]:
+    """Spawn the proxy as an MCP server and yield a connected client session."""
+    params = StdioServerParameters(
+        command=sys.executable,
+        args=["-m", "medmcp.proxy", "fake"],
+        env={**os.environ, **env},
+    )
+    async with (
+        stdio_client(params) as (read, write),
+        ClientSession(read, write) as session,
+    ):
+        await session.initialize()
+        yield session
+
+
+@pytest.mark.asyncio
+async def test_proxy_forwards_to_broker(tmp_path: Path) -> None:
+    """With a live broker, the proxy forwards list_tools and call_tool."""
+    pool = BackendPool(resolve_spec=_resolver({"fake": _spec("fake")}))
+    broker = BackendBroker(pool, tmp_path / "broker.sock")
+    await broker.start()
+    try:
+        async with _proxy_client({"MEDMCP_BROKER_SOCK": str(broker.socket_path)}) as session:
+            names = {t.name for t in (await session.list_tools()).tools}
+            assert {"echo", "warmup", "crash"} <= names
+            result = await session.call_tool("echo", {"text": "hi"})
+            assert replay.extract_structured(result) == {"text": "hi"}
+            assert result.isError is False
+    finally:
+        await broker.aclose()
+        await pool.aclose()
+
+
+@pytest.mark.asyncio
+async def test_proxy_falls_back_to_direct_spawn(tmp_path: Path) -> None:
+    """With no reachable broker, the proxy spawns the stack from the registry."""
+    backends = tmp_path / "backends.json"
+    backends.write_text(
+        json.dumps(
+            {
+                "fake": {
+                    "command": sys.executable,
+                    "args": [str(_FAKE_SERVER)],
+                    "env": {},
+                    "startup_timeout_sec": 30.0,
+                    "tool_timeout_sec": 30.0,
+                }
+            }
+        )
+    )
+    env = {
+        "MEDMCP_BROKER_SOCK": str(tmp_path / "does-not-exist.sock"),
+        "MEDMCP_BACKENDS_FILE": str(backends),
+    }
+    async with _proxy_client(env) as session:
+        result = await session.call_tool("echo", {"text": "via-fallback"})
+        assert replay.extract_structured(result) == {"text": "via-fallback"}
+
+
+@pytest.mark.asyncio
+async def test_proxy_reports_broker_error_as_tool_error(tmp_path: Path) -> None:
+    """An uninstalled stack comes back as an error result, not a crash."""
+    pool = BackendPool(resolve_spec=_resolver({}))  # nothing installed
+    broker = BackendBroker(pool, tmp_path / "broker.sock")
+    await broker.start()
+    try:
+        async with _proxy_client({"MEDMCP_BROKER_SOCK": str(broker.socket_path)}) as session:
+            result = await session.call_tool("echo", {"text": "x"})
+            assert result.isError is True
+            text = "".join(b.text for b in result.content if isinstance(b, mcp_types.TextContent))
+            assert "not installed" in text
+    finally:
+        await broker.aclose()
+        await pool.aclose()

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -62,6 +62,18 @@ async def _proxy_client(env: dict[str, str]) -> AsyncGenerator[ClientSession]:
         yield session
 
 
+def test_hidden_tools_cover_warmup_convention() -> None:
+    """The proxy's hidden-tool set is hand-synced with the pool's warmup convention.
+
+    ``proxy`` deliberately doesn't import ``backend_pool`` (keeps the per-call shim
+    light), so this guards against the two constants drifting apart.
+    """
+    from medmcp.backend_pool import WARMUP_TOOL
+    from medmcp.proxy import _HIDDEN_TOOLS
+
+    assert WARMUP_TOOL in _HIDDEN_TOOLS
+
+
 @pytest.mark.asyncio
 async def test_proxy_forwards_to_broker(tmp_path: Path) -> None:
     """With a live broker, the proxy forwards list_tools and call_tool."""
@@ -71,10 +83,15 @@ async def test_proxy_forwards_to_broker(tmp_path: Path) -> None:
     try:
         async with _proxy_client({"MEDMCP_BROKER_SOCK": str(broker.socket_path)}) as session:
             names = {t.name for t in (await session.list_tools()).tools}
-            assert {"echo", "warmup", "crash"} <= names
+            assert {"echo", "crash"} <= names
+            # ``warmup`` is pool machinery, not a model-facing tool: hidden from the
+            # list, but still callable (the pool invokes it on activation).
+            assert "warmup" not in names
             result = await session.call_tool("echo", {"text": "hi"})
             assert replay.extract_structured(result) == {"text": "hi"}
             assert result.isError is False
+            warmup = await session.call_tool("warmup", {})
+            assert warmup.isError is False
     finally:
         await broker.aclose()
         await pool.aclose()
@@ -102,6 +119,11 @@ async def test_proxy_falls_back_to_direct_spawn(tmp_path: Path) -> None:
         "MEDMCP_BACKENDS_FILE": str(backends),
     }
     async with _proxy_client(env) as session:
+        # The hidden-tool filter applies on the direct-spawn path too, not just the
+        # broker path: ``warmup`` is absent while real tools remain.
+        names = {t.name for t in (await session.list_tools()).tools}
+        assert "echo" in names
+        assert "warmup" not in names
         result = await session.call_tool("echo", {"text": "via-fallback"})
         assert replay.extract_structured(result) == {"text": "via-fallback"}
 

--- a/tests/test_server_pool.py
+++ b/tests/test_server_pool.py
@@ -1,0 +1,116 @@
+"""Tests for the stack-pool wiring in the workspace server (no vibe-acp)."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from medmcp import server, settings
+from medmcp.backend_pool import BackendPool, BackendSpec
+
+# pyright: reportPrivateUsage=false
+
+JsonDict = dict[str, Any]
+
+_FAKE_SERVER: Path = Path(__file__).parent / "fake_stack_server.py"
+
+
+def _spec(name: str) -> BackendSpec:
+    return BackendSpec(
+        name=name,
+        command=sys.executable,
+        args=[str(_FAKE_SERVER)],
+        env={},
+        gpu=False,
+        idle_ttl_sec=300.0,
+        startup_timeout_sec=30.0,
+        tool_timeout_sec=30.0,
+    )
+
+
+def _resolver(specs: dict[str, BackendSpec]) -> Callable[[str], BackendSpec | None]:
+    def resolve(name: str) -> BackendSpec | None:
+        return specs.get(name)
+
+    return resolve
+
+
+def test_resolve_backend_spec_maps_active_registry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The pool callback turns an active stack into a BackendSpec, None if unknown."""
+    neuro: JsonDict = {
+        "name": "medmcp-neuro",
+        "command": "docker",
+        "args": ["run", "--device", "nvidia.com/gpu=all", "neuro:dev"],
+        "env": {},
+        "tool_timeout_sec": 7200.0,
+    }
+    monkeypatch.setattr(settings, "active_servers", lambda: [neuro])
+
+    spec = server._resolve_backend_spec("medmcp-neuro")
+    assert spec is not None
+    assert spec.command == "docker"
+    assert spec.gpu is True
+    assert spec.tool_timeout_sec == 7200.0
+    assert server._resolve_backend_spec("ghost") is None
+
+
+@pytest.mark.asyncio
+async def test_lifespan_disabled_creates_no_pool(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With the flag off, the lifespan leaves the pool/broker unset."""
+    monkeypatch.delenv("MEDMCP_STACK_POOL", raising=False)
+    monkeypatch.setattr(server, "_pool", None)
+    monkeypatch.setattr(server, "_broker", None)
+    async with server._lifespan(server.app):
+        assert server._pool is None
+        assert server._broker is None
+
+
+@pytest.mark.asyncio
+async def test_lifespan_enabled_starts_and_stops_broker(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """With the flag on, the broker socket is bound on entry and removed on exit."""
+    monkeypatch.setenv("MEDMCP_STACK_POOL", "1")
+    monkeypatch.setenv("MEDMCP_WORKSPACE", str(tmp_path))
+    monkeypatch.setattr(settings, "VIBE_HOME", tmp_path)
+    monkeypatch.setattr(settings, "WORKFLOWS_ENABLED_PATH", tmp_path / "workflows_enabled.json")
+    monkeypatch.setattr(settings, "ACTIVE_WORKFLOWS_PATH", tmp_path / "active_workflows.json")
+    monkeypatch.setattr(settings, "get_uv_tool_dir", lambda: None)
+    settings.load_mcp_servers.cache_clear()
+    monkeypatch.setattr(server, "_pool", None)
+    monkeypatch.setattr(server, "_broker", None)
+
+    sock = tmp_path / "backend.sock"
+    async with server._lifespan(server.app):
+        assert server._pool is not None
+        assert server._broker is not None
+        assert sock.exists()
+        # the startup sync wrote the (empty) registry + proxied config
+        assert (tmp_path / "backends.json").exists()
+    assert server._pool is None
+    assert server._broker is None
+    assert not sock.exists()
+    settings.load_mcp_servers.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_apply_pool_changes_prewarms_and_evicts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Activation pre-warms newly-active stacks and evicts deactivated ones."""
+    pool = BackendPool(resolve_spec=_resolver({"fake": _spec("fake")}))
+    monkeypatch.setattr(server, "_pool", pool)
+    try:
+        before = set(server._background_tasks)
+        await server._apply_pool_changes({"fake"}, set())
+        # pre-warm is fire-and-forget; await the task it scheduled
+        await asyncio.gather(*(set(server._background_tasks) - before))
+        assert "fake" in pool.warm_names()
+
+        await server._apply_pool_changes(set(), {"fake"})
+        assert "fake" not in pool.warm_names()
+    finally:
+        await pool.aclose()

--- a/tests/test_stack_pool_sync.py
+++ b/tests/test_stack_pool_sync.py
@@ -1,0 +1,142 @@
+"""Tests for the pre-warm proxy interception in settings (Layer 1 wiring)."""
+
+from __future__ import annotations
+
+import json
+import tomllib
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from medmcp import settings
+from medmcp.settings import sync_servers_to_vibe_config
+
+JsonDict = dict[str, Any]
+
+_NEURO: JsonDict = {
+    "name": "medmcp-neuro",
+    "command": "docker",
+    "args": ["run", "--rm", "-i", "--device", "nvidia.com/gpu=all", "-v", "/ws:/ws", "neuro:dev"],
+    "env": {},
+    "skills_path": "/skills/neuro",
+    "tool_timeout_sec": 7200.0,
+}
+_DICOM: JsonDict = {
+    "name": "medmcp-dicom",
+    "command": "/abs/bin/medmcp-dicom",
+    "args": [],
+    "env": {"FOO": "bar"},
+}
+
+
+def _isolate(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, *, pool: bool) -> None:
+    monkeypatch.setattr(settings, "VIBE_HOME", tmp_path)
+    monkeypatch.setattr(settings, "WORKFLOWS_ENABLED_PATH", tmp_path / "workflows_enabled.json")
+    monkeypatch.setattr(settings, "ACTIVE_WORKFLOWS_PATH", tmp_path / "active_workflows.json")
+    if pool:
+        monkeypatch.setenv("MEDMCP_STACK_POOL", "1")
+    else:
+        monkeypatch.delenv("MEDMCP_STACK_POOL", raising=False)
+
+
+def _entries_by_name(tmp_path: Path) -> dict[str, JsonDict]:
+    with (tmp_path / "config.toml").open("rb") as fh:
+        cfg = tomllib.load(fh)
+    entries = cast("list[JsonDict]", cfg["mcp_servers"])
+    return {str(e["name"]): e for e in entries}
+
+
+# ── feature flag ──────────────────────────────────────────────────────────────
+
+
+def test_stack_pool_enabled_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The flag is off by default and reads common truthy spellings."""
+    monkeypatch.delenv("MEDMCP_STACK_POOL", raising=False)
+    assert settings.stack_pool_enabled() is False
+    for truthy in ("1", "true", "YES", "on"):
+        monkeypatch.setenv("MEDMCP_STACK_POOL", truthy)
+        assert settings.stack_pool_enabled() is True
+    monkeypatch.setenv("MEDMCP_STACK_POOL", "0")
+    assert settings.stack_pool_enabled() is False
+
+
+# ── backend registry ────────────────────────────────────────────────────────
+
+
+def test_build_backend_registry_captures_specs_and_infers_gpu() -> None:
+    """Registry captures real command/env and infers gpu from the CDI arg."""
+    reg = settings.build_backend_registry([_NEURO, _DICOM])
+    neuro = reg["medmcp-neuro"]
+    assert neuro["command"] == "docker"
+    assert neuro["gpu"] is True  # inferred from the CDI --device arg
+    assert neuro["tool_timeout_sec"] == 7200.0
+    assert neuro["idle_ttl_sec"] == settings.DEFAULT_IDLE_TTL_SEC
+    dicom = reg["medmcp-dicom"]
+    assert dicom["gpu"] is False
+    assert dicom["env"] == {"FOO": "bar"}
+    assert dicom["tool_timeout_sec"] == settings.DEFAULT_TOOL_TIMEOUT_SEC
+
+
+def test_build_backend_registry_honors_explicit_gpu_and_ttl() -> None:
+    """An explicit gpu flag and idle_ttl_sec override the defaults."""
+    srv: JsonDict = {
+        "name": "x",
+        "command": "/bin/x",
+        "args": [],
+        "gpu": True,
+        "idle_ttl_sec": 30.0,
+    }
+    reg = settings.build_backend_registry([srv])
+    assert reg["x"]["gpu"] is True
+    assert reg["x"]["idle_ttl_sec"] == 30.0
+
+
+# ── sync interception ────────────────────────────────────────────────────────
+
+
+def test_sync_disabled_writes_real_commands(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """With the pool off, sync writes the real commands and no registry."""
+    _isolate(monkeypatch, tmp_path, pool=False)
+    sync_servers_to_vibe_config([_NEURO, _DICOM])
+    by = _entries_by_name(tmp_path)
+    assert by["medmcp-neuro"]["command"] == "docker"
+    assert by["medmcp-dicom"]["command"] == "/abs/bin/medmcp-dicom"
+    assert not (tmp_path / "backends.json").exists()
+
+
+def test_sync_enabled_routes_through_proxy(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """With the pool on, entries point at the proxy and backends.json holds the real specs."""
+    _isolate(monkeypatch, tmp_path, pool=True)
+    sync_servers_to_vibe_config([_NEURO, _DICOM])
+
+    neuro = _entries_by_name(tmp_path)["medmcp-neuro"]
+    assert Path(str(neuro["command"])).name == "medmcp-mcp-proxy"
+    assert neuro["args"] == ["medmcp-neuro"]
+    assert neuro["env"]["MEDMCP_BROKER_SOCK"] == str(tmp_path / "backend.sock")
+    # discovery-owned fields are preserved so vibe still loads skills / waits long enough
+    assert neuro["skills_path"] == "/skills/neuro"
+    assert neuro["tool_timeout_sec"] == 7200.0
+
+    reg = cast("JsonDict", json.loads((tmp_path / "backends.json").read_text()))
+    assert reg["medmcp-neuro"]["command"] == "docker"  # the REAL spec
+    assert reg["medmcp-neuro"]["gpu"] is True
+    assert reg["medmcp-dicom"]["command"] == "/abs/bin/medmcp-dicom"
+
+
+def test_toggle_off_restores_real_command_and_strips_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Toggling the pool off restores real commands and removes proxy env keys."""
+    _isolate(monkeypatch, tmp_path, pool=True)
+    sync_servers_to_vibe_config([_NEURO])
+    # The first sync proxied the config; now disable and re-sync.
+    monkeypatch.delenv("MEDMCP_STACK_POOL", raising=False)
+    sync_servers_to_vibe_config([_NEURO])
+
+    neuro = _entries_by_name(tmp_path)["medmcp-neuro"]
+    assert neuro["command"] == "docker"  # real command restored
+    assert neuro["args"][0] == "run"
+    assert "MEDMCP_BROKER_SOCK" not in cast("JsonDict", neuro.get("env", {}))


### PR DESCRIPTION
## Summary
Adds Layer 1 of the stack pre-warm design: a persistent MCP backend pool that keeps stack servers warm across tool calls, a broker socket, and a thin per-call proxy shim so vibe pays the heavy spawn/import/CUDA cost once at pre-warm rather than on every call. Stacks may expose an optional `warmup` tool the pool invokes at activation; the proxy hides that pool-machinery tool from the model.

## Test plan
- [x] `uv run pytest` — full suite green (248 passed)
- [x] Pool/broker lifecycle: pre-warm invokes `warmup` once and in-process state persists across calls; dead backends respawn; idle-TTL reaper and GPU LRU cap enforced
- [x] Proxy forwards `list_tools`/`call_tool` to a live broker, and falls back to direct-spawn when the broker socket is unreachable
- [x] `warmup` is hidden from the model on both the broker and direct-spawn list paths, yet remains callable, while the pool still discovers it directly on the backend (pre-warm unaffected)
- [x] `_HIDDEN_TOOLS` stays in sync with `backend_pool.WARMUP_TOOL` (pinned by test)
- [x] ruff check + format clean (pre-commit)

## Security & data handling
- **New tool surface:** the optional `warmup` hook is now hidden from the model-facing tool list (the proxy filters `_HIDDEN_TOOLS` from `list_tools`), so it doesn't expand what the agent can choose to call. The pool still invokes it internally at activation only.
- **New IPC:** a Unix-domain broker socket (`MEDMCP_BROKER_SOCK`) carries `list_tools`/`call_tool` between the proxy and the pool. No new outbound network calls; no new patient-data paths.

## Notes
- The proxy deliberately does not import `backend_pool` (keeps the per-call shim lightweight), so `_HIDDEN_TOOLS` is hand-synced with `backend_pool.WARMUP_TOOL`; a test pins them together to catch drift.
- Sampling relay is intentionally out of scope for v1 (no current stack uses MCP sampling).
