### PR TITLE
fix(proxy): hide pool-machinery tools (warmup) from the model

### DIFF
--- a/src/medmcp/proxy.py
+++ b/src/medmcp/proxy.py
@@ -41,6 +41,14 @@ JsonDict = dict[str, Any]
 _DEFAULT_STARTUP_TIMEOUT_SEC: float = 60.0
 _DEFAULT_TOOL_TIMEOUT_SEC: float = 900.0
 
+# Tools that exist for the backend pool's machinery, not for the model to call, so
+# the shim hides them from the vibe/LLM-facing tool list. Kept in sync by hand with
+# ``medmcp.backend_pool.WARMUP_TOOL`` rather than imported — importing that module
+# would pull the whole pool implementation into this deliberately lightweight per-call
+# shim. The pool discovers ``warmup`` by listing tools directly on the backend (not
+# through this proxy), so hiding it here leaves pre-warm untouched.
+_HIDDEN_TOOLS: frozenset[str] = frozenset({"warmup"})
+
 
 class ProxyError(Exception):
     """A broker- or registry-level error to surface to the caller as a tool error."""
@@ -188,7 +196,10 @@ async def _serve(stack: str) -> None:
     # Registered via decorator side effect; pyright can't see the access.
     @server.list_tools()
     async def _list_tools() -> list[mcp_types.Tool]:  # pyright: ignore[reportUnusedFunction]
-        return await forwarder.list_tools()
+        # Hide pool-machinery tools (e.g. ``warmup``) from the model; the pool still
+        # discovers them by listing tools directly on the backend.
+        tools = await forwarder.list_tools()
+        return [t for t in tools if t.name not in _HIDDEN_TOOLS]
 
     @server.call_tool(validate_input=False)
     async def _call_tool(  # pyright: ignore[reportUnusedFunction]

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -23,6 +23,8 @@ from medmcp import replay
 from medmcp.backend_broker import BackendBroker
 from medmcp.backend_pool import BackendPool, BackendSpec
 
+# pyright: reportPrivateUsage=false
+
 _FAKE_SERVER: Path = Path(__file__).parent / "fake_stack_server.py"
 
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -62,6 +62,18 @@ async def _proxy_client(env: dict[str, str]) -> AsyncGenerator[ClientSession]:
         yield session
 
 
+def test_hidden_tools_cover_warmup_convention() -> None:
+    """The proxy's hidden-tool set is hand-synced with the pool's warmup convention.
+
+    ``proxy`` deliberately doesn't import ``backend_pool`` (keeps the per-call shim
+    light), so this guards against the two constants drifting apart.
+    """
+    from medmcp.backend_pool import WARMUP_TOOL
+    from medmcp.proxy import _HIDDEN_TOOLS
+
+    assert WARMUP_TOOL in _HIDDEN_TOOLS
+
+
 @pytest.mark.asyncio
 async def test_proxy_forwards_to_broker(tmp_path: Path) -> None:
     """With a live broker, the proxy forwards list_tools and call_tool."""
@@ -71,10 +83,15 @@ async def test_proxy_forwards_to_broker(tmp_path: Path) -> None:
     try:
         async with _proxy_client({"MEDMCP_BROKER_SOCK": str(broker.socket_path)}) as session:
             names = {t.name for t in (await session.list_tools()).tools}
-            assert {"echo", "warmup", "crash"} <= names
+            assert {"echo", "crash"} <= names
+            # ``warmup`` is pool machinery, not a model-facing tool: hidden from the
+            # list, but still callable (the pool invokes it on activation).
+            assert "warmup" not in names
             result = await session.call_tool("echo", {"text": "hi"})
             assert replay.extract_structured(result) == {"text": "hi"}
             assert result.isError is False
+            warmup = await session.call_tool("warmup", {})
+            assert warmup.isError is False
     finally:
         await broker.aclose()
         await pool.aclose()
@@ -102,6 +119,11 @@ async def test_proxy_falls_back_to_direct_spawn(tmp_path: Path) -> None:
         "MEDMCP_BACKENDS_FILE": str(backends),
     }
     async with _proxy_client(env) as session:
+        # The hidden-tool filter applies on the direct-spawn path too, not just the
+        # broker path: ``warmup`` is absent while real tools remain.
+        names = {t.name for t in (await session.list_tools()).tools}
+        assert "echo" in names
+        assert "warmup" not in names
         result = await session.call_tool("echo", {"text": "via-fallback"})
         assert replay.extract_structured(result) == {"text": "via-fallback"}
 


### PR DESCRIPTION
## Summary
The pre-warm proxy forwarded every backend tool to vibe unfiltered, so the pool's `warmup` hook surfaced as a model-callable tool (attributed to whichever stack exposes it). This filters a `_HIDDEN_TOOLS` set out of the `list_tools` response at the vibe-facing boundary, so pool machinery stays invisible to the model. Follow-up to #55.

## Test plan
- [x] `uv run pytest tests/test_proxy.py` — 4 passed
- [x] `warmup` is hidden from the model on both the broker and direct-spawn list paths, yet remains callable
- [x] The pool still discovers `warmup` by listing tools directly on the backend, so pre-warm is unaffected
- [x] `_HIDDEN_TOOLS` stays in sync with `backend_pool.WARMUP_TOOL` (pinned by test)
- [x] ruff check + format clean (pre-commit)

## Security & data handling
- **Tool surface (narrowing):** the optional `warmup` hook is now hidden from the model-facing tool list, so it no longer expands what the agent can choose to call. The pool still invokes it internally at activation only. No new network calls or patient-data paths.

## Notes
- The proxy deliberately does not import `backend_pool` (keeps the per-call shim lightweight), so `_HIDDEN_TOOLS` is hand-synced with `backend_pool.WARMUP_TOOL`; a test pins them together to catch drift.
- Supersedes #58, which was opened off a pre-#55 base and conflicted with the now-merged feature; this branch carries only the fix on top of current `main`.
