### PR TITLE
feat(deploy): plumb MEDMCP_STACK_POOL toggle into compose

### DIFF
--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -96,6 +96,10 @@ services:
       # that mount no plaintext auths. Leave empty to use the mounted config.
       GHCR_USER: "${GHCR_USER:-}"
       GHCR_TOKEN: "${GHCR_TOKEN:-}"
+      # Persistent stack pool + pre-warm proxy (Layer 1): keeps stack backends
+      # warm across calls and hides pool-machinery tools (warmup) from the model.
+      # 1/true to enable; empty = off (legacy per-call spawn).
+      MEDMCP_STACK_POOL: "${MEDMCP_STACK_POOL:-}"
     healthcheck:
       test:
         - CMD

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,10 @@ services:
       # that mount no plaintext auths. Leave empty to use the mounted config.
       GHCR_USER: "${GHCR_USER:-}"
       GHCR_TOKEN: "${GHCR_TOKEN:-}"
+      # Persistent stack pool + pre-warm proxy (Layer 1): keeps stack backends
+      # warm across calls and hides pool-machinery tools (warmup) from the model.
+      # 1/true to enable; empty = off (legacy per-call spawn).
+      MEDMCP_STACK_POOL: "${MEDMCP_STACK_POOL:-}"
     healthcheck:
       test:
         - CMD


### PR DESCRIPTION
## Summary
Expose the persistent stack pool / pre-warm proxy (Layer 1) as a first-class `MEDMCP_STACK_POOL` env var on the `medmcp` core service in both `docker-compose.ghcr.yml` (GHCR/OCI deploy) and `docker-compose.yml` (build). The pool is gated on this var but the deploy compose never plumbed it through, so enabling it on a deployed stack previously required a local override file.

## Test plan
- [x] `docker compose config` resolves `MEDMCP_STACK_POOL=1` → `"1"` and unset → `""` (off) in the core service
- [x] Both files pass `docker compose config -q`
- [x] Cut a live stack over from the override file to the env-var path with **no recreate** (identical resolved config); confirmed `MEDMCP_STACK_POOL=1` in the running core and `medmcp-neuro` routed via `medmcp-mcp-proxy`
- [x] Verified `warmup` is hidden from the model's tool list when enabled (proxy `list_tools` omits it; the real neuro server still exposes it)

## Security & data handling
Reduces the model-visible tool surface (hides the pool-machinery `warmup` tool); does not add network calls, file-write paths, or any auto-approval path — the permission flow is unchanged. Defaults to off (empty), so existing deployments are byte-for-byte unchanged.

## Notes
Follow-up to the Layer 1 pool (#55) and warmup-hiding (#59). The published OCI compose artifact (`oci://ghcr.io/medmcp/compose:main`) only picks up this toggle after merge + CI republish; until then, deploy from the local `docker-compose.ghcr.yml`.
