### PR TITLE
feat(workflows): shareable workflows + replay robustness

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -196,6 +196,26 @@ export async function deleteWorkflow(name: string): Promise<void> {
   await check(await fetch(`/api/workflows/${encodeURIComponent(name)}`, { method: 'DELETE' }))
 }
 
+/** Download a workflow as a shareable <name>.workflow.yaml via the browser. */
+export async function exportWorkflow(name: string): Promise<void> {
+  const res = await check(await fetch(`/api/workflows/${encodeURIComponent(name)}/export`))
+  const blob = await res.blob()
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = `${name}.workflow.yaml`
+  document.body.appendChild(a)
+  a.click()
+  a.remove()
+  URL.revokeObjectURL(url)
+}
+
+/** Import a shared workflow file (its YAML text); returns the new draft's detail. */
+export async function importWorkflow(content: string): Promise<WorkflowDetail> {
+  const res = await postJson('/api/workflows/import', { content })
+  return (await res.json()) as WorkflowDetail
+}
+
 export async function replayPreview(
   name: string,
   inputs: Record<string, string>,

--- a/frontend/src/components/WorkflowPanel.tsx
+++ b/frontend/src/components/WorkflowPanel.tsx
@@ -864,7 +864,7 @@ export const WorkflowPanel = memo(function WorkflowPanel({
               title="Export as a shareable .workflow.yaml file"
               onClick={() => void exportFile(d.name)}
             >
-              <DownloadIcon size={12} /> Export
+              <UploadIcon size={12} /> Export
             </button>
             <button className="btn-plain wf-delete" onClick={() => remove(d.name)}>
               Delete
@@ -1086,7 +1086,7 @@ export const WorkflowPanel = memo(function WorkflowPanel({
             disabled={busy !== null}
             onClick={() => fileInputRef.current?.click()}
           >
-            <UploadIcon />
+            <DownloadIcon />
           </button>
           <button className="btn-icon" title="Refresh" onClick={() => void reload()}>
             <RefreshIcon />

--- a/frontend/src/components/WorkflowPanel.tsx
+++ b/frontend/src/components/WorkflowPanel.tsx
@@ -3,8 +3,10 @@ import type { ReactNode } from 'react'
 import {
   deleteWorkflow,
   distillSession,
+  exportWorkflow,
   fetchWorkflowDetail,
   fetchWorkflows,
+  importWorkflow,
   promoteWorkflow,
   refineWorkflow,
   renameWorkflow,
@@ -15,6 +17,7 @@ import { getDraggedFilePath } from '../dragState'
 import type {
   ReplayFrame,
   ReplayPreviewStep,
+  StackRequirement,
   WorkflowDetail,
   WorkflowListEntry,
 } from '../types'
@@ -22,9 +25,11 @@ import { DRAG_PATH_MIME } from '../types'
 import {
   BookmarkPlusIcon,
   ChevronRightIcon,
+  DownloadIcon,
   PlayIcon,
   RefreshIcon,
   StopSquareIcon,
+  UploadIcon,
 } from './icons'
 
 type ReplayStepFrame = Extract<ReplayFrame, { type: 'step' }>
@@ -221,6 +226,31 @@ function InputField({
   )
 }
 
+/** The stacks a workflow needs, pinned by image(+digest) or version. */
+function Requirements({ requires }: { requires: StackRequirement[] }) {
+  if (requires.length === 0) return null
+  return (
+    <div className="wf-requires">
+      <div className="wf-requires-title">Requires</div>
+      <ul className="wf-requires-list">
+        {requires.map((r) => {
+          const pin = r.image
+            ? `${r.image}${r.digest ? ` @ ${r.digest.slice(0, 19)}…` : ''}`
+            : r.version
+              ? `v${r.version}`
+              : ''
+          return (
+            <li key={r.stack}>
+              <code>{r.stack}</code>
+              {pin && <span className="wf-req-pin">{pin}</span>}
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}
+
 function StepList({ steps }: { steps: { server: string; tool: string }[] }) {
   return (
     <ol className="wf-steps">
@@ -347,6 +377,7 @@ export const WorkflowPanel = memo(function WorkflowPanel({
   const [error, setError] = useState<string | null>(null)
   const [now, setNow] = useState(0)
   const runWs = useRef<WebSocket | null>(null)
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
 
   const reload = useCallback(
     () =>
@@ -463,6 +494,18 @@ export const WorkflowPanel = memo(function WorkflowPanel({
       await promoteWorkflow(name)
       await reload()
       setDetail(await fetchWorkflowDetail(name))
+    })
+
+  const exportFile = (name: string) => withBusy('Exporting…', () => exportWorkflow(name))
+
+  const importFile = (file: File) =>
+    withBusy('Importing workflow…', async () => {
+      const draft = await importWorkflow(await file.text())
+      await reload()
+      detailForRef.current = draft.name
+      setExpanded(draft.name)
+      setDetail(draft)
+      setMode({ kind: 'view' })
     })
 
   const unpromote = (name: string) =>
@@ -758,6 +801,19 @@ export const WorkflowPanel = memo(function WorkflowPanel({
           {!d.replayable && d.replay_error && d.steps.length > 0 && (
             <div className="wf-notice">Can't replay: {d.replay_error}</div>
           )}
+          <Requirements requires={d.requires} />
+          {d.manual_steps.length > 0 && (
+            <div className="wf-notice">
+              Includes manual step(s) replay can't run — do these by hand:
+              <ul className="wf-manual-list">
+                {d.manual_steps.map((m, i) => (
+                  <li key={i}>
+                    <code>{m}</code>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
           <div className="wf-actions">
             <button
               className="btn-primary wf-run-btn"
@@ -803,6 +859,13 @@ export const WorkflowPanel = memo(function WorkflowPanel({
                 Edit
               </button>
             )}
+            <button
+              className="btn-plain"
+              title="Export as a shareable .workflow.yaml file"
+              onClick={() => void exportFile(d.name)}
+            >
+              <DownloadIcon size={12} /> Export
+            </button>
             <button className="btn-plain wf-delete" onClick={() => remove(d.name)}>
               Delete
             </button>
@@ -1017,9 +1080,28 @@ export const WorkflowPanel = memo(function WorkflowPanel({
           >
             <BookmarkPlusIcon />
           </button>
+          <button
+            className="btn-icon"
+            title="Import a shared workflow (.workflow.yaml)"
+            disabled={busy !== null}
+            onClick={() => fileInputRef.current?.click()}
+          >
+            <UploadIcon />
+          </button>
           <button className="btn-icon" title="Refresh" onClick={() => void reload()}>
             <RefreshIcon />
           </button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".yaml,.yml"
+            style={{ display: 'none' }}
+            onChange={(e) => {
+              const file = e.target.files?.[0]
+              e.target.value = '' // allow re-importing the same file
+              if (file) void importFile(file)
+            }}
+          />
         </span>
       </div>
       <div className="panel-body wf-body">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1833,6 +1833,37 @@ textarea.wf-input {
   line-height: 1.45;
 }
 
+.wf-requires {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  font-size: 12px;
+}
+
+.wf-requires-title {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+}
+
+.wf-requires-list,
+.wf-manual-list {
+  margin: 2px 0 0;
+  padding-left: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.wf-req-pin {
+  margin-left: 6px;
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 11px;
+}
+
 .wf-runlog {
   display: flex;
   flex-direction: column;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -109,6 +109,14 @@ export interface WorkflowListEntry {
   kind: 'active' | 'draft'
 }
 
+/** A stack the workflow needs, pinned for reproducibility. */
+export interface StackRequirement {
+  stack: string
+  version?: string
+  image?: string
+  digest?: string
+}
+
 /** Full recipe detail from GET /api/workflows/{name}. */
 export interface WorkflowDetail {
   name: string
@@ -116,6 +124,8 @@ export interface WorkflowDetail {
   description: string
   inputs: { name: string; example: string; description: string }[]
   steps: { server: string; tool: string; arguments: Record<string, unknown> }[]
+  requires: StackRequirement[]
+  manual_steps: string[]
   replayable: boolean
   replay_error: string | null
 }

--- a/justfile
+++ b/justfile
@@ -146,6 +146,16 @@ workflows:
 delete-workflow NAME:
     uv run medmcp delete {{NAME}}
 
+# Export a workflow to a shareable <name>.workflow.yaml (add --out PATH to override)
+# Usage: just export-workflow <workflow-name>
+export-workflow NAME *ARGS:
+    uv run medmcp export {{NAME}} {{ARGS}}
+
+# Import a shared workflow file as a reviewable draft
+# Usage: just import-workflow <file.workflow.yaml>
+import-workflow FILE:
+    uv run medmcp import {{FILE}}
+
 # Launch the workspace UI (explorer + viewer + chat) at http://localhost:8100
 workspace:
     uv run medmcp-workspace

--- a/src/medmcp/distill.py
+++ b/src/medmcp/distill.py
@@ -33,7 +33,7 @@ import httpx
 import yaml
 
 from medmcp import provenance
-from medmcp.workflow import Recipe, RecipeStep, WorkflowInput
+from medmcp.workflow import Recipe, RecipeStep, StackRequirement, WorkflowInput
 
 JsonDict = dict[str, Any]
 
@@ -46,6 +46,13 @@ PROSE_TIMEOUT: float = 60.0
 EXPLORATORY_TOOLS: frozenset[str] = frozenset(
     {"read_file", "grep", "todo", "skill", "task", "ls", "web_fetch", "web_search"}
 )
+
+# Pool-machinery / internal tools that the model isn't meant to call and that
+# carry no workflow meaning (the persistent backend pool calls ``warmup`` itself).
+# Kept in sync with ``proxy._HIDDEN_TOOLS`` (which hides them from the model) via
+# ``tests/test_distill.py`` — distill must drop any tool the proxy hides, or a
+# session recorded before the proxy existed would bake ``warmup`` into a recipe.
+INTERNAL_TOOLS: frozenset[str] = frozenset({"warmup"})
 
 # Shell tools whose command is inspected so read-only invocations can be dropped.
 _SHELL_TOOLS: frozenset[str] = frozenset({"bash", "shell", "sh"})
@@ -224,6 +231,19 @@ def _iter_tool_calls(messages: list[JsonDict]) -> list[tuple[str, JsonDict, str]
 # ── Deterministic recipe extraction ──────────────────────────────────────────
 
 
+def _manual_step_label(tool: str, arguments: JsonDict) -> str:
+    """Describe a dropped built-in step for the workflow's manual-steps note.
+
+    For shell tools the command is included (it's the actual action); other
+    built-ins are labelled by tool name alone.
+    """
+    if tool in _SHELL_TOOLS:
+        command = arguments.get("command")
+        if isinstance(command, str) and command.strip():
+            return f"builtin:{tool} `{command.strip()}`"
+    return f"builtin:{tool}"
+
+
 def build_recipe(
     messages: list[JsonDict],
     *,
@@ -240,6 +260,7 @@ def build_recipe(
     recipe = Recipe(name=name, description=description)
     produced: dict[str, str] = {}  # concrete path → placeholder reference
     inputs: dict[str, WorkflowInput] = {}  # concrete path → input definition
+    manual_steps: list[str] = []  # dropped built-in steps, kept as documentation
 
     step_no = 0
     for tool_name, args, result_text in _iter_tool_calls(messages):
@@ -249,8 +270,19 @@ def build_recipe(
             or _is_rejected_result(result_text)
         ):
             continue
-        step_no += 1
         server, tool = provenance.split_tool_name(tool_name, server_names)
+
+        # Internal pool-machinery tools (warmup) carry no workflow meaning — drop
+        # them silently so they never become a replayable step.
+        if tool in INTERNAL_TOOLS:
+            continue
+        # Built-in (non-MCP) tools can't be replayed deterministically. Drop them
+        # from the recipe so the workflow stays replayable, but record them as
+        # manual steps so the real work isn't silently lost (see render_skill_md).
+        if server == "builtin":
+            manual_steps.append(_manual_step_label(tool, args))
+            continue
+        step_no += 1
 
         # Parameterize input paths against earlier outputs / declared inputs.
         new_args: JsonDict = {}
@@ -285,13 +317,54 @@ def build_recipe(
         )
 
     recipe.inputs = list(inputs.values())
+    recipe.manual_steps = manual_steps
     return recipe
 
 
-def _slugify(text: str) -> str:
+def slugify(text: str) -> str:
     """Turn arbitrary text into a filesystem/skill-safe slug."""
     slug = re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
     return slug[:48] or "workflow"
+
+
+def resolve_digest(image: str) -> str:
+    """Resolve *image*'s digest best-effort; never raise (distillation must not fail)."""
+    try:
+        from medmcp import settings
+
+        return settings.resolve_image_digest(image) or ""
+    except Exception:
+        return ""
+
+
+def build_requirements(recipe: Recipe, manifest: JsonDict | None) -> list[StackRequirement]:
+    """Build reproducibility requirements for *recipe* from the session *manifest*.
+
+    Filtered to the stacks the recipe actually uses (built-in steps need none).
+    Container stacks pin by image (+ best-effort digest); uv-tool stacks by version.
+    A used stack absent from the manifest is still listed by name so an importer
+    knows it is required.
+    """
+    used = sorted({s.server for s in recipe.steps if s.server != "builtin"})
+    by_name = {
+        str(s.get("name")): s for s in cast("list[JsonDict]", (manifest or {}).get("stacks") or [])
+    }
+    requires: list[StackRequirement] = []
+    for server in used:
+        entry = by_name.get(server)
+        if entry is None:
+            requires.append(StackRequirement(stack=server))
+            continue
+        image = str(entry.get("image") or "")
+        requires.append(
+            StackRequirement(
+                stack=server,
+                version=str(entry.get("version") or ""),
+                image=image,
+                digest=resolve_digest(image) if image else "",
+            )
+        )
+    return requires
 
 
 # ── Hybrid prose pass ────────────────────────────────────────────────────────
@@ -303,6 +376,13 @@ def _prose_prompt(recipe: Recipe, context: str) -> str:
         f"{i}. {s.server}:{s.tool} arguments={json.dumps(s.arguments)}"
         for i, s in enumerate(recipe.steps, start=1)
     )
+    manual_note = ""
+    if recipe.manual_steps:
+        manual_note = (
+            "\n\nManual steps (built-in tools that were used but CANNOT be replayed "
+            "automatically) — call these out in gotchas_markdown so the reader performs "
+            "them by hand:\n" + "\n".join(f"- {m}" for m in recipe.manual_steps)
+        )
     return (
         "You are documenting a medical-imaging workflow so a colleague can reuse it "
         "on their own data. Below is the original user request and the exact sequence "
@@ -329,6 +409,7 @@ def _prose_prompt(recipe: Recipe, context: str) -> str:
         '"gotchas_markdown": "<markdown bullet list of caveats, or empty string>"}\n\n'
         f"Original request:\n{context}\n\n"
         f"Executed steps (tool names are authoritative — reuse them verbatim):\n{steps_desc}\n"
+        f"{manual_note}"
     )
 
 
@@ -402,6 +483,37 @@ def _required_tools(recipe: Recipe) -> list[tuple[str, str]]:
     return seen
 
 
+def _manual_steps_markdown(recipe: Recipe) -> str:
+    """Render the note about manual (built-in) steps replay can't run, or ``""``."""
+    if not recipe.manual_steps:
+        return ""
+    lines = [
+        "This workflow originally included manual steps using built-in tools that "
+        "the replay engine cannot run automatically. Perform them by hand where the "
+        "pipeline needs them:",
+    ]
+    lines += [f"- `{m}`" for m in recipe.manual_steps]
+    return "\n".join(lines)
+
+
+def _requirements_markdown(recipe: Recipe) -> str:
+    """Render the stacks the workflow needs, pinned for reproducibility.
+
+    Derived from the recipe's ``requires`` (captured at distillation): container
+    stacks show their image (+ digest when resolved), uv-tool stacks their version.
+    """
+    lines: list[str] = []
+    for req in recipe.requires:
+        if req.image:
+            pin = f"image `{req.image}`" + (f" (`{req.digest}`)" if req.digest else "")
+        elif req.version:
+            pin = f"version `{req.version}`"
+        else:
+            pin = ""
+        lines.append(f"- `{req.stack}`" + (f" — {pin}" if pin else ""))
+    return "\n".join(lines)
+
+
 def _tools_markdown(recipe: Recipe) -> str:
     """Render the explicit list of tools/skills the workflow requires.
 
@@ -427,6 +539,10 @@ def render_skill_md(recipe: Recipe, prose: JsonDict | None) -> str:
         steps_md = str(prose.get("steps_markdown") or steps_md)
         gotchas_md = str(prose.get("gotchas_markdown") or "")
 
+    # Always surface dropped manual steps (deterministic), ahead of any LLM gotchas.
+    manual_md = _manual_steps_markdown(recipe)
+    gotchas_md = "\n\n".join(part for part in (manual_md, gotchas_md.strip()) if part)
+
     title = recipe.name.replace("-", " ").strip().capitalize()
     parts: list[str] = [
         "---",
@@ -439,6 +555,9 @@ def render_skill_md(recipe: Recipe, prose: JsonDict | None) -> str:
     tools_md = _tools_markdown(recipe)
     if tools_md:
         parts += ["", "## Tools", "", tools_md]
+    reqs_md = _requirements_markdown(recipe)
+    if reqs_md:
+        parts += ["", "## Requirements", "", reqs_md]
     parts += ["", "## Steps", "", steps_md]
     if gotchas_md.strip():
         parts += ["", "## Gotchas", "", gotchas_md.strip()]
@@ -510,11 +629,23 @@ def load_recipe(draft_dir: Path) -> Recipe:
         )
         for s in cast("list[JsonDict]", data.get("steps", []))
     ]
+    requires = [
+        StackRequirement(
+            stack=str(r.get("stack", "")),
+            version=str(r.get("version", "")),
+            image=str(r.get("image", "")),
+            digest=str(r.get("digest", "")),
+        )
+        for r in cast("list[JsonDict]", data.get("requires", []))
+    ]
+    manual_steps = [str(m) for m in cast("list[Any]", data.get("manual_steps", []))]
     return Recipe(
         name=str(data.get("name", "")),
         description=str(data.get("description", "")),
         inputs=inputs,
         steps=steps,
+        requires=requires,
+        manual_steps=manual_steps,
     )
 
 
@@ -551,7 +682,7 @@ def distill_session(
     )
 
     context = _first_user_message(messages)
-    fallback_name = _slugify(context) if context else f"workflow-{session_id[:8]}"
+    fallback_name = slugify(context) if context else f"workflow-{session_id[:8]}"
     recipe = build_recipe(
         messages,
         server_names=server_names,
@@ -559,9 +690,11 @@ def distill_session(
         description=context[:120] if context else "Distilled MedMCP workflow",
     )
 
+    recipe.requires = build_requirements(recipe, manifest)
+
     prose = generate_prose(recipe, context) if use_llm else None
     if prose is not None and isinstance(prose.get("name"), str):
-        recipe.name = _slugify(str(prose["name"]))
+        recipe.name = slugify(str(prose["name"]))
         recipe.description = str(prose.get("description") or recipe.description)
 
     draft_dir = _draft_dir(recipe.name, workflows_root)
@@ -632,7 +765,7 @@ def rename_draft(name: str, new_name: str, *, workflows_root: Path | None = None
     src = _draft_dir(name, workflows_root)
     if not (src / "SKILL.md").exists():
         raise FileNotFoundError(f"no draft workflow named {name!r} (looked in {src})")
-    new_slug = _slugify(new_name)
+    new_slug = slugify(new_name)
     recipe = load_recipe(src)
     recipe.name = new_slug
     prose = _read_prose(src)

--- a/src/medmcp/provcli.py
+++ b/src/medmcp/provcli.py
@@ -9,14 +9,17 @@ Exposed as the ``medmcp`` console script::
     medmcp promote <name>       # move a reviewed draft into active/ (reusable)
     medmcp workflows            # list personal workflows (draft + promoted)
     medmcp delete   <name>      # delete a personal workflow (draft or active)
+    medmcp export   <name>      # write a shareable <name>.workflow.yaml
+    medmcp import   <file>      # import a shared workflow file as a draft
 """
 
 from __future__ import annotations
 
 import argparse
 import sys
+from pathlib import Path
 
-from medmcp import distill, provenance
+from medmcp import distill, provenance, share
 
 
 def _list_sessions() -> int:
@@ -99,6 +102,36 @@ def _delete(name: str) -> int:
     return 0
 
 
+def _export(name: str, out: str | None) -> int:
+    """Serialize a workflow into a single shareable ``<name>.workflow.yaml`` file."""
+    try:
+        text = share.export_workflow(name)
+    except FileNotFoundError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    out_path = Path(out) if out else Path(f"{name}{share.EXPORT_SUFFIX}")
+    out_path.write_text(text, encoding="utf-8")
+    print(f"Exported workflow to: {out_path}")
+    return 0
+
+
+def _import(path: str) -> int:
+    """Import a shared workflow file as a reviewable draft."""
+    try:
+        text = Path(path).read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"error: cannot read {path}: {exc}", file=sys.stderr)
+        return 1
+    try:
+        draft = share.import_workflow(text)
+    except share.WorkflowShareError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    print(f"Imported workflow as draft: {draft}")
+    print("Review it, then promote it to reuse.")
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     """Entry point for the ``medmcp`` console script."""
     parser = argparse.ArgumentParser(prog="medmcp", description=__doc__)
@@ -126,6 +159,13 @@ def main(argv: list[str] | None = None) -> int:
     delete_p = sub.add_parser("delete", help="delete a personal workflow by name")
     delete_p.add_argument("name")
 
+    export_p = sub.add_parser("export", help="write a shareable <name>.workflow.yaml")
+    export_p.add_argument("name")
+    export_p.add_argument("--out", help="output path (default <name>.workflow.yaml)")
+
+    import_p = sub.add_parser("import", help="import a shared workflow file as a draft")
+    import_p.add_argument("file")
+
     args = parser.parse_args(argv)
     if args.command == "list":
         return _list_sessions()
@@ -139,6 +179,10 @@ def main(argv: list[str] | None = None) -> int:
         return _list_workflows()
     if args.command == "delete":
         return _delete(args.name)
+    if args.command == "export":
+        return _export(args.name, args.out)
+    if args.command == "import":
+        return _import(args.file)
     parser.error(f"unknown command {args.command!r}")
 
 

--- a/src/medmcp/provenance.py
+++ b/src/medmcp/provenance.py
@@ -99,6 +99,35 @@ def _read_model_config(model_name: str) -> JsonDict:
     return {}
 
 
+def _docker_image_ref(server: JsonDict) -> str | None:
+    """Return the container image ref for a ``docker``-launched stack, else ``None``.
+
+    MedMCP container stacks launch via ``docker run … <image>`` with no trailing
+    command, so the image is the last non-flag argument (e.g.
+    ``ghcr.io/medmcp/neuro:main``). Cheap and offline — no docker call.
+    """
+    if str(server.get("command", "")) != "docker":
+        return None
+    args = [str(a) for a in cast("list[Any]", server.get("args", []))]
+    for arg in reversed(args):
+        if not arg.startswith("-"):
+            return None if arg == "run" else arg
+    return None
+
+
+def _stack_manifest_entry(server: JsonDict) -> JsonDict:
+    """Build one stack entry for the manifest (name/version/command + image)."""
+    entry: JsonDict = {
+        "name": server.get("name"),
+        "version": server.get("version"),
+        "command": server.get("command"),
+    }
+    image = _docker_image_ref(server)
+    if image:
+        entry["image"] = image
+    return entry
+
+
 def build_manifest(session_id: str, *, servers: list[JsonDict], model_name: str) -> JsonDict:
     """Assemble (but do not write) the environment manifest for a session."""
     return {
@@ -108,14 +137,7 @@ def build_manifest(session_id: str, *, servers: list[JsonDict], model_name: str)
             "git_commit": _git(["rev-parse", "HEAD"]),
             "git_branch": _git(["rev-parse", "--abbrev-ref", "HEAD"]),
         },
-        "stacks": [
-            {
-                "name": s.get("name"),
-                "version": s.get("version"),
-                "command": s.get("command"),
-            }
-            for s in servers
-        ],
+        "stacks": [_stack_manifest_entry(s) for s in servers],
         "model": {"name": model_name, **_read_model_config(model_name)},
         "platform": {
             "python": sys.version.split()[0],

--- a/src/medmcp/server.py
+++ b/src/medmcp/server.py
@@ -45,11 +45,11 @@ from typing import Any, cast
 
 import uvicorn
 from fastapi import FastAPI, HTTPException, UploadFile, WebSocket, WebSocketDisconnect
-from fastapi.responses import FileResponse, JSONResponse
+from fastapi.responses import FileResponse, JSONResponse, Response
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
-from medmcp import distill, explain, provenance, replay, sessions, settings
+from medmcp import distill, explain, provenance, replay, sessions, settings, share
 from medmcp.acp import PROJECT_ROOT, VIBE_HOME, JsonDict, VibeAcpClient
 from medmcp.backend_broker import BackendBroker
 from medmcp.backend_pool import BackendPool, BackendSpec
@@ -570,6 +570,8 @@ def _workflow_detail(name: str) -> JsonDict:
         "steps": [
             {"server": s.server, "tool": s.tool, "arguments": s.arguments} for s in recipe.steps
         ],
+        "requires": [r.to_dict() for r in recipe.requires],
+        "manual_steps": list(recipe.manual_steps),
         "replayable": replay_error is None,
         "replay_error": replay_error,
     }
@@ -682,6 +684,38 @@ async def delete_workflow(name: str) -> JsonDict:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     _audit.info("workflow deleted: %s", name)
     return {"ok": True}
+
+
+@app.get("/api/workflows/{name}/export")
+async def get_workflow_export(name: str) -> Response:
+    """Export a workflow as a single self-contained ``.workflow.yaml`` download."""
+    try:
+        text = await asyncio.to_thread(share.export_workflow, name)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    filename = f"{name}{share.EXPORT_SUFFIX}"
+    return Response(
+        content=text,
+        media_type="application/x-yaml",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+class WorkflowImportPayload(BaseModel):
+    """Request body for importing a shared workflow file (its YAML text)."""
+
+    content: str
+
+
+@app.post("/api/workflows/import")
+async def post_import_workflow(payload: WorkflowImportPayload) -> JsonDict:
+    """Import a shared workflow envelope as a reviewable draft; return its detail."""
+    try:
+        draft_dir = await asyncio.to_thread(share.import_workflow, payload.content)
+    except share.WorkflowShareError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    _audit.info("workflow imported: %s", draft_dir.name)
+    return await asyncio.to_thread(_workflow_detail, draft_dir.name)
 
 
 def _resolve_input_path(value: str) -> str:

--- a/src/medmcp/settings.py
+++ b/src/medmcp/settings.py
@@ -543,6 +543,38 @@ def read_stack_label(image: str) -> JsonDict:
     return cast("JsonDict", meta)
 
 
+def resolve_image_digest(image: str) -> str | None:
+    """Return the local image's ``sha256:…`` digest, or ``None`` if unresolved.
+
+    Best-effort and offline: reads the ``RepoDigests`` of an **already-present**
+    image and never pulls — digest resolution (for a workflow's requirements pin)
+    must not block on a registry or drag in a multi-GB image. Prefers the digest
+    whose repository matches *image*, falling back to the first available.
+    """
+    image = image.strip()
+    if not image or any(c.isspace() for c in image) or not _image_present(image):
+        return None
+    try:
+        raw = _run_docker(["inspect", "--format", "{{json .RepoDigests}}", image], timeout=30)
+    except RuntimeError:
+        return None
+    try:
+        repo_digests = json.loads(raw.stdout.strip())
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(repo_digests, list):
+        return None
+    repo = image.split("@", 1)[0].rsplit(":", 1)[0]
+    digests = [
+        rd for rd in cast("list[Any]", repo_digests) if isinstance(rd, str) and "@sha256:" in rd
+    ]
+    for rd in digests:
+        rd_repo, _, digest = rd.partition("@")
+        if rd_repo == repo:
+            return digest
+    return digests[0].partition("@")[2] if digests else None
+
+
 def _extract_image_skills(image: str, in_image_path: str, into_dir: Path) -> None:
     """Copy ``<image>:<in_image_path>`` into *into_dir* via a throwaway container.
 

--- a/src/medmcp/share.py
+++ b/src/medmcp/share.py
@@ -1,0 +1,238 @@
+"""Export / import a distilled workflow as a single self-contained YAML file.
+
+A workflow normally lives as a directory under
+``.vibe/workflows/{draft,active}/<name>/`` (``recipe.yaml`` + ``SKILL.md`` +
+``prose.json``). To share one with a colleague we serialize it into a single
+inline ``<name>.workflow.yaml`` envelope that carries everything needed to
+reproduce and document it:
+
+- the replayable ``steps`` and ``inputs`` (the recipe),
+- the ``requires`` block (stacks pinned by version or image+digest),
+- a human-readable ``documentation`` block (what the workflow does), and
+- the cached ``prose`` so the narrative can still be refined after import.
+
+Import always lands the workflow as a **draft** for review before promotion, and
+never overwrites an existing one (names collide → a unique suffix is added).
+
+This module has no UI/vibe-acp dependency (like the rest of the distill cluster)
+so it can be driven from the server or the ``medmcp`` CLI alike.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+
+from medmcp import distill, provenance
+from medmcp.workflow import Recipe, RecipeStep, StackRequirement, WorkflowInput
+
+JsonDict = dict[str, Any]
+
+# Envelope format version. Bump only on a breaking schema change; import accepts
+# any version it understands (currently exactly this one).
+FORMAT_VERSION: int = 1
+FORMAT_KEY: str = "medmcp_workflow"
+
+# Suggested filename extension for an exported workflow.
+EXPORT_SUFFIX: str = ".workflow.yaml"
+
+
+class WorkflowShareError(Exception):
+    """Raised when an import payload is malformed or an unknown format version."""
+
+
+def _workflows_root(workflows_root: Path | None) -> Path:
+    """Resolve the workflows root, defaulting to ``.vibe/workflows``."""
+    return workflows_root if workflows_root is not None else provenance.VIBE_HOME / "workflows"
+
+
+def _find_workflow_dir(name: str, workflows_root: Path | None) -> Path:
+    """Return the dir for workflow *name* (active preferred, then draft).
+
+    Raises ``FileNotFoundError`` if neither location has it.
+    """
+    root = _workflows_root(workflows_root)
+    for kind in ("active", "draft"):
+        candidate = root / kind / name
+        if (candidate / "recipe.yaml").exists():
+            return candidate
+    raise FileNotFoundError(f"no workflow named {name!r} in {root}")
+
+
+def _skill_body(skill_md: str) -> str:
+    """Strip the leading YAML frontmatter from a ``SKILL.md``, returning the body."""
+    if skill_md.startswith("---"):
+        end = skill_md.find("\n---", 3)
+        if end != -1:
+            newline = skill_md.find("\n", end + 1)
+            if newline != -1:
+                return skill_md[newline + 1 :].lstrip("\n")
+    return skill_md
+
+
+def _read_prose(workflow_dir: Path) -> JsonDict | None:
+    """Read a workflow's cached ``prose.json`` (``None`` if absent/mechanical)."""
+    path = workflow_dir / "prose.json"
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+    return cast("JsonDict", data) if isinstance(data, dict) else None
+
+
+# ── Export ────────────────────────────────────────────────────────────────────
+
+
+def export_workflow(name: str, *, workflows_root: Path | None = None) -> str:
+    """Serialize workflow *name* into a single inline-YAML envelope (returns text).
+
+    Pulls the recipe, the human-readable documentation (the rendered ``SKILL.md``
+    body), and the cached prose. Any required image without a digest is resolved
+    best-effort at export time so the shared file pins as tightly as possible.
+
+    Raises ``FileNotFoundError`` if no draft/active workflow has that name.
+    """
+    workflow_dir = _find_workflow_dir(name, workflows_root)
+    recipe = distill.load_recipe(workflow_dir)
+
+    # Tighten the pin: fill any missing digests now (the image may not have been
+    # present when the workflow was distilled). Best-effort — never fails export.
+    for req in recipe.requires:
+        if req.image and not req.digest:
+            req.digest = distill.resolve_digest(req.image)
+
+    skill_path = workflow_dir / "SKILL.md"
+    documentation = (
+        _skill_body(skill_path.read_text(encoding="utf-8")) if skill_path.exists() else ""
+    )
+
+    envelope: JsonDict = {
+        FORMAT_KEY: FORMAT_VERSION,
+        "name": recipe.name,
+        "description": recipe.description,
+    }
+    if recipe.requires:
+        envelope["requires"] = [r.to_dict() for r in recipe.requires]
+    envelope["inputs"] = [i.to_dict() for i in recipe.inputs]
+    envelope["steps"] = [s.to_dict() for s in recipe.steps]
+    if recipe.manual_steps:
+        envelope["manual_steps"] = list(recipe.manual_steps)
+    if documentation:
+        envelope["documentation"] = documentation
+    prose = _read_prose(workflow_dir)
+    if prose is not None:
+        envelope["prose"] = prose
+
+    return yaml.safe_dump(envelope, sort_keys=False, allow_unicode=True)
+
+
+# ── Import ────────────────────────────────────────────────────────────────────
+
+
+def _recipe_from_envelope(env: JsonDict) -> Recipe:
+    """Reconstruct a :class:`Recipe` from a validated envelope dict."""
+    inputs = [
+        WorkflowInput(
+            name=str(i.get("name", "")),
+            example=str(i.get("example", "")),
+            description=str(i.get("description", "")),
+        )
+        for i in cast("list[JsonDict]", env.get("inputs", []))
+    ]
+    steps = [
+        RecipeStep(
+            server=str(s.get("server", "")),
+            tool=str(s.get("tool", "")),
+            arguments=cast("JsonDict", s.get("arguments", {})),
+            produces=cast("dict[str, str]", s.get("produces", {})),
+        )
+        for s in cast("list[JsonDict]", env.get("steps", []))
+    ]
+    requires = [
+        StackRequirement(
+            stack=str(r.get("stack", "")),
+            version=str(r.get("version", "")),
+            image=str(r.get("image", "")),
+            digest=str(r.get("digest", "")),
+        )
+        for r in cast("list[JsonDict]", env.get("requires", []))
+    ]
+    manual_steps = [str(m) for m in cast("list[Any]", env.get("manual_steps", []))]
+    return Recipe(
+        name=distill.slugify(str(env.get("name", ""))),
+        description=str(env.get("description", "")),
+        inputs=inputs,
+        steps=steps,
+        requires=requires,
+        manual_steps=manual_steps,
+    )
+
+
+def _unique_draft_name(base: str, workflows_root: Path | None) -> str:
+    """Return a draft name not already used by a draft or active workflow."""
+    root = _workflows_root(workflows_root)
+
+    def taken(candidate: str) -> bool:
+        return any((root / kind / candidate).exists() for kind in ("draft", "active"))
+
+    if not taken(base):
+        return base
+    suffixed = f"{base}-imported"
+    if not taken(suffixed):
+        return suffixed
+    n = 2
+    while taken(f"{suffixed}-{n}"):
+        n += 1
+    return f"{suffixed}-{n}"
+
+
+def import_workflow(yaml_text: str, *, workflows_root: Path | None = None) -> Path:
+    """Import a shared workflow envelope as a new **draft**; return its directory.
+
+    Validates the envelope (format version + a non-empty step list), reconstructs
+    the recipe, and writes ``recipe.yaml`` + ``SKILL.md`` + ``prose.json`` into a
+    fresh ``draft/<name>/``. A name already in use gets a unique suffix so an
+    import never clobbers an existing workflow.
+
+    Raises ``WorkflowShareError`` on a malformed payload or unknown version.
+    """
+    try:
+        loaded = yaml.safe_load(yaml_text)
+    except yaml.YAMLError as exc:
+        raise WorkflowShareError(f"not a valid workflow file: {exc}") from exc
+    if not isinstance(loaded, dict):
+        raise WorkflowShareError("not a valid workflow file (expected a YAML mapping)")
+    env = cast("JsonDict", loaded)
+
+    version = env.get(FORMAT_KEY)
+    if version != FORMAT_VERSION:
+        raise WorkflowShareError(
+            f"unsupported workflow format {version!r} (this build understands {FORMAT_VERSION})"
+        )
+    if not str(env.get("name", "")).strip():
+        raise WorkflowShareError("workflow file is missing a name")
+    if not isinstance(env.get("steps"), list) or not env["steps"]:
+        raise WorkflowShareError("workflow file has no steps")
+
+    recipe = _recipe_from_envelope(env)
+    recipe.name = _unique_draft_name(recipe.name, workflows_root)
+
+    draft_dir = _workflows_root(workflows_root) / "draft" / recipe.name
+    draft_dir.mkdir(parents=True, exist_ok=True)
+    prose = env.get("prose") if isinstance(env.get("prose"), dict) else None
+    prose_dict = cast("JsonDict | None", prose)
+
+    recipe_yaml = yaml.safe_dump(recipe.to_dict(), sort_keys=False, allow_unicode=True)
+    (draft_dir / "recipe.yaml").write_text(recipe_yaml, encoding="utf-8")
+    (draft_dir / "SKILL.md").write_text(
+        distill.render_skill_md(recipe, prose_dict), encoding="utf-8"
+    )
+    (draft_dir / "prose.json").write_text(
+        json.dumps(prose_dict) if prose_dict is not None else "null", encoding="utf-8"
+    )
+    return draft_dir

--- a/src/medmcp/workflow.py
+++ b/src/medmcp/workflow.py
@@ -40,6 +40,34 @@ class WorkflowInput:
 
 
 @dataclass
+class StackRequirement:
+    """A stack the workflow needs, pinned for reproducibility.
+
+    Captured at distillation from the session's provenance manifest and filtered
+    to the stacks the recipe actually uses. ``version`` applies to uv-tool stacks;
+    ``image`` (+ best-effort ``digest``) applies to container stacks.
+    """
+
+    stack: str
+    """The MCP server/stack name (e.g. ``medmcp-neuro``)."""
+    version: str = ""
+    """Package version for a uv-tool stack (e.g. ``0.1.0``); empty if unknown."""
+    image: str = ""
+    """Container image ref for a container stack (e.g. ``ghcr.io/medmcp/neuro:main``)."""
+    digest: str = ""
+    """Resolved image digest (``sha256:…``) for exact pinning; empty if unresolved."""
+
+    def to_dict(self) -> JsonDict:
+        """Return a plain-dict form suitable for YAML/JSON serialization."""
+        out: JsonDict = {"stack": self.stack}
+        for key in ("version", "image", "digest"):
+            value = getattr(self, key)
+            if value:
+                out[key] = value
+        return out
+
+
+@dataclass
 class RecipeStep:
     """A single tool invocation in a distilled workflow."""
 
@@ -72,12 +100,25 @@ class Recipe:
     description: str
     inputs: list[WorkflowInput] = field(default_factory=list[WorkflowInput])
     steps: list[RecipeStep] = field(default_factory=list[RecipeStep])
+    requires: list[StackRequirement] = field(default_factory=list[StackRequirement])
+    manual_steps: list[str] = field(default_factory=list[str])
+    """Built-in (non-MCP) steps dropped from the replayable recipe, kept as docs.
+
+    These are real actions from the session (e.g. ``builtin:edit``) that the replay
+    engine can't run deterministically; recording them here lets the workflow note
+    the manual work instead of silently losing it.
+    """
 
     def to_dict(self) -> JsonDict:
         """Return a plain-dict form suitable for YAML/JSON serialization."""
-        return {
+        out: JsonDict = {
             "name": self.name,
             "description": self.description,
             "inputs": [i.to_dict() for i in self.inputs],
             "steps": [s.to_dict() for s in self.steps],
         }
+        if self.requires:
+            out["requires"] = [r.to_dict() for r in self.requires]
+        if self.manual_steps:
+            out["manual_steps"] = list(self.manual_steps)
+        return out

--- a/tests/test_distill.py
+++ b/tests/test_distill.py
@@ -7,11 +7,12 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
+import pytest
 import yaml
 
 # pyright: reportPrivateUsage=false
 from medmcp import distill, provcli, provenance
-from medmcp.workflow import Recipe
+from medmcp.workflow import Recipe, RecipeStep, StackRequirement
 
 JsonDict = dict[str, Any]
 
@@ -134,8 +135,8 @@ class TestBuildRecipe:
         )
         assert [s.tool for s in recipe.steps] == ["skull_strip", "register_to_template"]
 
-    def test_keeps_shell_call_that_writes(self) -> None:
-        """A bash command with output redirection writes, so it is kept."""
+    def test_writing_shell_call_becomes_manual_step(self) -> None:
+        """A writing bash command is dropped from steps and recorded as a manual step."""
         messages: list[JsonDict] = [
             _assistant_call("w0", "bash", {"command": "cat a.txt > b.txt"}),
             _tool_result("w0", "ok: True"),
@@ -143,7 +144,28 @@ class TestBuildRecipe:
         recipe = distill.build_recipe(
             messages, server_names=["medmcp-neuro"], name="t", description="d"
         )
-        assert [s.tool for s in recipe.steps] == ["bash"]
+        assert recipe.steps == []
+        assert recipe.manual_steps == ["builtin:bash `cat a.txt > b.txt`"]
+
+    def test_drops_internal_warmup_tool(self) -> None:
+        """Pool-machinery tools (warmup) are dropped entirely — not a step nor manual."""
+        messages: list[JsonDict] = [
+            _assistant_call("w0", "medmcp-neuro_warmup", {}),
+            _tool_result("w0", "ok: True"),
+            _assistant_call("s0", "medmcp-neuro_skull_strip", {"input_path": "/data/a.nii.gz"}),
+            _tool_result("s0", "ok: True"),
+        ]
+        recipe = distill.build_recipe(
+            messages, server_names=["medmcp-neuro"], name="t", description="d"
+        )
+        assert [(s.server, s.tool) for s in recipe.steps] == [("medmcp-neuro", "skull_strip")]
+        assert recipe.manual_steps == []
+
+    def test_internal_tools_cover_proxy_hidden(self) -> None:
+        """distill.INTERNAL_TOOLS must cover every tool the proxy hides (keep in sync)."""
+        from medmcp.proxy import _HIDDEN_TOOLS
+
+        assert _HIDDEN_TOOLS <= distill.INTERNAL_TOOLS
 
     def test_drops_tool_error_rendered_as_ok_true(self) -> None:
         """A wrapped tool exception (vibe renders ``ok: True``) is dropped as failed.
@@ -194,8 +216,8 @@ class TestProseParsing:
 
 def test_slugify() -> None:
     """Slugs are lowercased, hyphenated, and bounded."""
-    assert distill._slugify("Skull Strip & Register!") == "skull-strip-register"
-    assert distill._slugify("") == "workflow"
+    assert distill.slugify("Skull Strip & Register!") == "skull-strip-register"
+    assert distill.slugify("") == "workflow"
 
 
 class TestFirstUserMessage:
@@ -267,18 +289,78 @@ class TestRenderSkillMd:
         assert "`medmcp-neuro:skull_strip` — from the `medmcp-neuro` stack" in md
         assert "`medmcp-neuro:register_to_template`" in md
 
-    def test_required_tools_dedup_and_builtin(self) -> None:
-        """Distinct tools are listed once; builtin tools are labelled built-in."""
+    def test_required_tools_dedup(self) -> None:
+        """Distinct MCP tools are listed once, in first-seen order."""
+        recipe = Recipe(name="f", description="d")
+        recipe.steps = [
+            RecipeStep(server="medmcp-neuro", tool="skull_strip", arguments={}),
+            RecipeStep(server="medmcp-neuro", tool="skull_strip", arguments={}),
+            RecipeStep(server="medmcp-neuro", tool="coregister", arguments={}),
+        ]
+        assert distill._required_tools(recipe) == [
+            ("medmcp-neuro", "skull_strip"),
+            ("medmcp-neuro", "coregister"),
+        ]
+
+    def test_builtin_calls_recorded_as_manual_steps(self) -> None:
+        """Built-in (non-MCP) calls are dropped but surfaced as manual steps in Gotchas."""
         messages: list[JsonDict] = [
             _assistant_call("b0", "bash", {"command": "convert a b"}),
             _tool_result("b0", "ok: True"),
-            _assistant_call("b1", "bash", {"command": "convert c d"}),
-            _tool_result("b1", "ok: True"),
         ]
         recipe = distill.build_recipe(messages, server_names=[], name="f", description="d")
-        tools = distill._required_tools(recipe)
-        assert tools == [("builtin", "bash")]
-        assert "`bash` — built-in tool" in distill.render_skill_md(recipe, None)
+        assert distill._required_tools(recipe) == []
+        assert recipe.manual_steps == ["builtin:bash `convert a b`"]
+        md = distill.render_skill_md(recipe, None)
+        assert "## Gotchas" in md
+        assert "builtin:bash `convert a b`" in md
+
+
+class TestRequirements:
+    """build_requirements + the ## Requirements rendering."""
+
+    def test_filters_to_used_stacks_and_pins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Only stacks the recipe uses are required; container→image+digest, uv→version."""
+        recipe = Recipe(name="w", description="d")
+        recipe.steps = [
+            RecipeStep(server="medmcp-neuro", tool="skull_strip", arguments={}),
+            RecipeStep(server="builtin", tool="bash", arguments={}),  # needs no stack
+        ]
+        manifest: JsonDict = {
+            "stacks": [
+                {"name": "medmcp-neuro", "image": "ghcr.io/medmcp/neuro:main"},
+                {"name": "medmcp-dicom", "version": "0.1.0"},  # not used → excluded
+            ]
+        }
+
+        def _fake_digest(_image: str) -> str:
+            return "sha256:abc"
+
+        monkeypatch.setattr(distill, "resolve_digest", _fake_digest)
+        reqs = distill.build_requirements(recipe, manifest)
+        assert [r.stack for r in reqs] == ["medmcp-neuro"]
+        assert reqs[0].image == "ghcr.io/medmcp/neuro:main"
+        assert reqs[0].digest == "sha256:abc"
+
+    def test_used_stack_absent_from_manifest_listed_by_name(self) -> None:
+        """A used stack with no manifest entry is still listed (importer needs it)."""
+        recipe = Recipe(name="w", description="d")
+        recipe.steps = [RecipeStep(server="medmcp-x", tool="t", arguments={})]
+        assert distill.build_requirements(recipe, None) == [StackRequirement(stack="medmcp-x")]
+
+    def test_requirements_rendered_in_skill_md(self) -> None:
+        """## Requirements pins each stack by image(+digest) or version."""
+        recipe = Recipe(name="w", description="d")
+        recipe.requires = [
+            StackRequirement(
+                stack="medmcp-neuro", image="ghcr.io/medmcp/neuro:main", digest="sha256:abc"
+            ),
+            StackRequirement(stack="medmcp-dicom", version="0.1.0"),
+        ]
+        md = distill.render_skill_md(recipe, None)
+        assert "## Requirements" in md
+        assert "image `ghcr.io/medmcp/neuro:main` (`sha256:abc`)" in md
+        assert "version `0.1.0`" in md
 
 
 def _write_fake_session(root: Path) -> None:

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -85,6 +85,25 @@ class TestManifest:
         with patch.object(provenance, "VIBE_HOME", tmp_path):
             assert provenance.read_manifest(SESSION_ID) is None
 
+    def test_captures_container_image_ref(self, tmp_path: Path) -> None:
+        """A docker-launched stack records its image ref (the last non-flag arg)."""
+        servers = [
+            {
+                "name": "medmcp-neuro",
+                "command": "docker",
+                "args": ["run", "--rm", "-i", "-v", "/d:/d", "ghcr.io/medmcp/neuro:main"],
+            },
+            {"name": "medmcp-dicom", "version": "0.1.0", "command": "/x/bin/dicom"},
+        ]
+        with patch.object(provenance, "VIBE_HOME", tmp_path):
+            provenance.write_manifest(SESSION_ID, servers=servers, model_name="m")
+            manifest = provenance.read_manifest(SESSION_ID)
+
+        assert manifest is not None
+        assert manifest["stacks"][0]["image"] == "ghcr.io/medmcp/neuro:main"
+        # A uv-tool stack carries no image key.
+        assert "image" not in manifest["stacks"][1]
+
 
 # ── run log ──────────────────────────────────────────────────────────────────
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -12,6 +12,7 @@ from collections.abc import Iterable
 from pathlib import Path
 
 import pytest
+import yaml
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
@@ -302,6 +303,60 @@ class TestSettingsMerge:
         assert harness["stacks"] == {"alpha", "beta"}
         assert harness["workflows"] == {"wf-keep"}
         assert result["restarted"] is False
+
+
+# ── Workflow export / import endpoints ───────────────────────────────────────
+
+
+class TestWorkflowShareEndpoints:
+    """Export/import workflow endpoints: wiring + error mapping."""
+
+    @pytest.fixture
+    def vibe_home(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+        """Point both the server and provenance/share VIBE_HOME at a temp dir."""
+        monkeypatch.setattr(server, "VIBE_HOME", tmp_path)
+        monkeypatch.setattr(provenance, "VIBE_HOME", tmp_path)
+        return tmp_path
+
+    def _envelope(self) -> str:
+        return yaml.safe_dump(
+            {
+                "medmcp_workflow": 1,
+                "name": "demo-flow",
+                "description": "demo",
+                "inputs": [{"name": "in_1", "example": "/d/a.nii.gz"}],
+                "steps": [
+                    {
+                        "server": "medmcp-neuro",
+                        "tool": "skull_strip",
+                        "arguments": {"input_path": "{{in_1}}"},
+                    }
+                ],
+            }
+        )
+
+    def test_import_then_export_round_trip(self, vibe_home: Path) -> None:
+        """A valid envelope imports as a draft and exports back as a YAML download."""
+        client = TestClient(server.app)
+        resp = client.post("/api/workflows/import", json={"content": self._envelope()})
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "demo-flow"
+
+        exp = client.get("/api/workflows/demo-flow/export")
+        assert exp.status_code == 200
+        assert "medmcp_workflow" in exp.text
+        assert exp.headers["content-disposition"].endswith('demo-flow.workflow.yaml"')
+
+    def test_import_malformed_returns_400(self, vibe_home: Path) -> None:
+        """A payload that isn't a workflow envelope maps to HTTP 400."""
+        client = TestClient(server.app)
+        resp = client.post("/api/workflows/import", json={"content": "- not a mapping"})
+        assert resp.status_code == 400
+
+    def test_export_missing_returns_404(self, vibe_home: Path) -> None:
+        """Exporting an unknown workflow maps to HTTP 404."""
+        client = TestClient(server.app)
+        assert client.get("/api/workflows/nope/export").status_code == 404
 
 
 # ── Session resume helpers ───────────────────────────────────────────────────

--- a/tests/test_share.py
+++ b/tests/test_share.py
@@ -1,0 +1,130 @@
+"""Tests for workflow export/import (single inline-YAML sharing)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from medmcp import distill, share
+from medmcp.workflow import Recipe, RecipeStep, StackRequirement, WorkflowInput
+
+
+def _make_draft(root: Path, recipe: Recipe) -> Path:
+    """Write a draft workflow dir (recipe.yaml + SKILL.md + prose.json) under *root*."""
+    draft = root / "draft" / recipe.name
+    draft.mkdir(parents=True)
+    (draft / "recipe.yaml").write_text(
+        yaml.safe_dump(recipe.to_dict(), sort_keys=False), encoding="utf-8"
+    )
+    (draft / "SKILL.md").write_text(distill.render_skill_md(recipe, None), encoding="utf-8")
+    (draft / "prose.json").write_text("null", encoding="utf-8")
+    return draft
+
+
+def _sample_recipe() -> Recipe:
+    return Recipe(
+        name="skull-strip-register",
+        description="Skull strip then register a brain MRI to template.",
+        inputs=[WorkflowInput(name="in_1", example="/data/t1.nii.gz", description="the scan")],
+        steps=[
+            RecipeStep(
+                server="medmcp-neuro",
+                tool="skull_strip",
+                arguments={"input_path": "{{in_1}}"},
+                produces={"brain_path": "step1.brain_path"},
+            ),
+            RecipeStep(
+                server="medmcp-neuro",
+                tool="register_to_template",
+                arguments={"input_path": "{{step1.brain_path}}"},
+            ),
+        ],
+        requires=[
+            StackRequirement(
+                stack="medmcp-neuro", image="ghcr.io/medmcp/neuro:main", digest="sha256:abc"
+            )
+        ],
+        manual_steps=["builtin:bash `convert a b`"],
+    )
+
+
+class TestExport:
+    """export_workflow serializes a workflow dir into the inline-YAML envelope."""
+
+    def test_export_missing_raises(self, tmp_path: Path) -> None:
+        """Exporting a name with no draft/active dir raises FileNotFoundError."""
+        with pytest.raises(FileNotFoundError):
+            share.export_workflow("nope", workflows_root=tmp_path)
+
+    def test_export_contains_envelope_and_docs(self, tmp_path: Path) -> None:
+        """Export emits the versioned envelope with steps, requires, and docs."""
+        _make_draft(tmp_path, _sample_recipe())
+        text = share.export_workflow("skull-strip-register", workflows_root=tmp_path)
+        env = yaml.safe_load(text)
+        assert env[share.FORMAT_KEY] == share.FORMAT_VERSION
+        assert env["name"] == "skull-strip-register"
+        assert [s["tool"] for s in env["steps"]] == ["skull_strip", "register_to_template"]
+        assert env["requires"][0]["digest"] == "sha256:abc"
+        assert env["manual_steps"] == ["builtin:bash `convert a b`"]
+        assert "## Requirements" in env["documentation"]
+
+    def test_export_fills_missing_digest(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A required image with no digest is resolved best-effort at export time."""
+        recipe = _sample_recipe()
+        recipe.requires = [
+            StackRequirement(stack="medmcp-neuro", image="ghcr.io/medmcp/neuro:main")
+        ]
+        _make_draft(tmp_path, recipe)
+
+        def _fake_digest(_image: str) -> str:
+            return "sha256:resolved"
+
+        monkeypatch.setattr(distill, "resolve_digest", _fake_digest)
+        env = yaml.safe_load(share.export_workflow("skull-strip-register", workflows_root=tmp_path))
+        assert env["requires"][0]["digest"] == "sha256:resolved"
+
+
+class TestImport:
+    """import_workflow validates the envelope and reconstructs a reviewable draft."""
+
+    def test_round_trip_preserves_recipe(self, tmp_path: Path) -> None:
+        """Export → import reconstructs an equivalent recipe as a fresh draft."""
+        original = _sample_recipe()
+        _make_draft(tmp_path / "src", original)
+        text = share.export_workflow("skull-strip-register", workflows_root=tmp_path / "src")
+
+        draft = share.import_workflow(text, workflows_root=tmp_path / "dst")
+        assert draft == tmp_path / "dst" / "draft" / "skull-strip-register"
+        imported = distill.load_recipe(draft)
+        assert imported.to_dict() == original.to_dict()
+        assert (draft / "SKILL.md").exists()
+
+    def test_import_rejects_non_mapping(self, tmp_path: Path) -> None:
+        """A payload that isn't a YAML mapping is rejected."""
+        with pytest.raises(share.WorkflowShareError):
+            share.import_workflow("- just\n- a\n- list\n", workflows_root=tmp_path)
+
+    def test_import_rejects_unknown_version(self, tmp_path: Path) -> None:
+        """An envelope with an unrecognized format version is rejected."""
+        text = yaml.safe_dump({share.FORMAT_KEY: 99, "name": "x", "steps": [{"server": "s"}]})
+        with pytest.raises(share.WorkflowShareError, match="unsupported workflow format"):
+            share.import_workflow(text, workflows_root=tmp_path)
+
+    def test_import_rejects_no_steps(self, tmp_path: Path) -> None:
+        """An envelope with no steps is rejected (nothing to replay)."""
+        text = yaml.safe_dump({share.FORMAT_KEY: 1, "name": "x", "steps": []})
+        with pytest.raises(share.WorkflowShareError, match="no steps"):
+            share.import_workflow(text, workflows_root=tmp_path)
+
+    def test_import_collision_gets_suffix(self, tmp_path: Path) -> None:
+        """Importing the same workflow twice never clobbers — the second is suffixed."""
+        _make_draft(tmp_path, _sample_recipe())
+        text = share.export_workflow("skull-strip-register", workflows_root=tmp_path)
+        draft = share.import_workflow(text, workflows_root=tmp_path)
+        assert draft.name == "skull-strip-register-imported"
+        again = share.import_workflow(text, workflows_root=tmp_path)
+        assert again.name == "skull-strip-register-imported-2"


### PR DESCRIPTION
## Summary
Make distilled workflows robust and shareable: distillation no longer leaks internal (`warmup`) or built-in (non-MCP) tool calls into the recipe — so workflows stay replayable — and workflows can now be **exported/imported as a single self-contained `.workflow.yaml`** that documents what they do and pins the stacks they need (version, or image + best-effort digest) for reproducibility.

## Test plan
- [x] `just check` green — 266 tests, ruff lint/format, pyright strict
- [x] New `tests/test_share.py` (export→import round-trip, malformed/unknown-version rejection, name-collision suffixing) + distill/provenance/server cases; `INTERNAL_TOOLS` sync-tested against `proxy._HIDDEN_TOOLS`
- [x] Live end-to-end (real local docker): `warmup` dropped, `edit`→manual step, real digest `sha256:112e8372…` resolved, export→import recipe identical
- [x] CLI wiring: `medmcp export`/`import` happy + error paths (exit codes/messages)
- [x] UI verified via local headless preview (see Screenshots)

## Screenshots
UI checked locally with headless chromium against a host-native instance running this branch (only :8100 is tunneled). The Workflows panel header gains an **Import** control; an expanded workflow shows a **Requires** section (`medmcp-neuro  ghcr.io/medmcp/neuro:main @ sha256:112e8372…`), an amber **manual-steps** note (`builtin:edit …`), and an **Export** button alongside Run/Promote/Rename/Refine/Delete.

## Security & data handling
- Import parses untrusted YAML with `yaml.safe_load` and validates a format version before use; an imported workflow always lands as a **draft** (never auto-promoted, never executed on import). Replay remains gated by the existing preview + explicit confirmation — no new auto-approval path.
- Export/import touch only the workflows directory; digest resolution is offline (`docker inspect` of an already-present image, never a pull).

## Notes
- The new `/api/workflows/import|export` endpoints ship with the frontend in the same image, so the UI controls light up once a `core` image built from this branch is deployed.
- Digest pinning is best-effort: resolved when the image is present locally, otherwise the requirement falls back to `image:tag`.
- `viewedPath`/workspace-note leakage and the batch-replay server reuse are out of scope here.
