### PR TITLE
fix(pool): let concurrent tool calls multiplex on one warm backend

### DIFF
--- a/src/medmcp/backend_pool.py
+++ b/src/medmcp/backend_pool.py
@@ -12,9 +12,12 @@ same primitives as :mod:`medmcp.replay`'s ``mcp_caller``) but does **not** tear
 the session down after a call. Because the MCP/anyio session must be entered and
 exited in the *same* task, each backend runs a dedicated *runner* task that owns
 the session for its whole lifetime: it opens the session, signals readiness, then
-waits for a close signal before unwinding. Calls from other tasks use the live
-``ClientSession`` object (safe — the SDK multiplexes requests by id); calls into a
-single backend are serialized so a stack keeps its one-call-at-a-time assumption.
+waits for a close signal before unwinding. Concurrent calls share that one live
+``ClientSession`` and run in parallel — the SDK multiplexes requests by id and the
+stack server handles each as its own task — so a long-running tool call (e.g. a
+multi-minute skull-strip) no longer blocks shorter calls to the same stack. An
+in-flight counter keeps :attr:`Backend.busy` truthful so the pool never evicts or
+reaps a backend that still has work running.
 
 :class:`BackendPool` owns the set of warm backends and enforces two policies: an
 idle-TTL reaper evicts backends unused past their TTL, and a GPU LRU cap bounds
@@ -109,7 +112,7 @@ class Backend:
         self._started: asyncio.Event = asyncio.Event()
         self._closing: asyncio.Event = asyncio.Event()
         self._start_error: BaseException | None = None
-        self._lock: asyncio.Lock = asyncio.Lock()  # serializes call_tool
+        self._inflight: int = 0  # in-flight call_tool count (drives `busy`)
         self._tools: list[mcp_types.Tool] | None = None
         self._last_used: float = time.monotonic()
 
@@ -200,7 +203,13 @@ class Backend:
     # ── use ──────────────────────────────────────────────────────────────────
 
     async def call(self, tool: str, args: JsonDict) -> mcp_types.CallToolResult:
-        """Call *tool* on this backend (serialized with other calls to it).
+        """Call *tool* on this backend; concurrent calls run in parallel.
+
+        Calls share the one live ``ClientSession`` (the SDK multiplexes requests by
+        id and the stack server handles each in its own task), so a long-running
+        tool call does not block other calls to the same backend. The in-flight
+        count keeps :attr:`busy` truthful so the pool will not evict or reap a
+        backend with work still running.
 
         A transport-level failure (the process having died) propagates so the pool
         can evict and respawn; a tool that merely *reports* failure returns a
@@ -210,12 +219,13 @@ class Backend:
         if session is None or not self.alive:
             raise BackendError(f"backend {self.spec.name!r} is not running")
         timeout = timedelta(seconds=self.spec.tool_timeout_sec)
-        async with self._lock:
+        self._inflight += 1
+        self._last_used = time.monotonic()
+        try:
+            return await session.call_tool(tool, args, read_timeout_seconds=timeout)
+        finally:
+            self._inflight -= 1
             self._last_used = time.monotonic()
-            try:
-                return await session.call_tool(tool, args, read_timeout_seconds=timeout)
-            finally:
-                self._last_used = time.monotonic()
 
     async def list_tools(self) -> list[mcp_types.Tool]:
         """Return the backend's tools (cached after the first call)."""
@@ -254,8 +264,8 @@ class Backend:
 
     @property
     def busy(self) -> bool:
-        """Whether a call is currently in flight (its lock is held)."""
-        return self._lock.locked()
+        """Whether at least one call is currently in flight."""
+        return self._inflight > 0
 
     @property
     def last_used(self) -> float:

--- a/tests/fake_stack_server.py
+++ b/tests/fake_stack_server.py
@@ -8,6 +8,7 @@ warm backend), and ``crash`` (kills the process to exercise death/respawn).
 
 from __future__ import annotations
 
+import asyncio
 import os
 
 from mcp.server.fastmcp import FastMCP
@@ -35,6 +36,13 @@ def warmup() -> dict[str, bool]:
 def warmup_count() -> dict[str, int]:
     """Return how many times ``warmup`` ran in this process."""
     return {"count": _warmups}
+
+
+@mcp.tool()
+async def sleep(seconds: float) -> dict[str, float]:
+    """Sleep *seconds* then return; used to prove calls overlap, not serialize."""
+    await asyncio.sleep(seconds)
+    return {"slept": seconds}
 
 
 @mcp.tool()

--- a/tests/test_backend_pool.py
+++ b/tests/test_backend_pool.py
@@ -62,6 +62,27 @@ async def test_backend_start_call_and_close() -> None:
 
 
 @pytest.mark.asyncio
+async def test_concurrent_calls_overlap_on_one_backend() -> None:
+    """Two slow calls to one warm backend run in parallel, not back-to-back."""
+    pool = BackendPool(resolve_spec=_resolver({"fake": _spec("fake")}))
+    try:
+        backend = await pool.ensure("fake")
+        assert not backend.busy
+        started = time.monotonic()
+        results = await asyncio.gather(
+            pool.call("fake", "sleep", {"seconds": 0.5}),
+            pool.call("fake", "sleep", {"seconds": 0.5}),
+        )
+        elapsed = time.monotonic() - started
+        # Serialized these would take ~1.0s; multiplexed they finish in ~0.5s.
+        assert elapsed < 0.9, f"concurrent calls serialized ({elapsed:.2f}s)"
+        assert all(replay.extract_structured(r) == {"slept": 0.5} for r in results)
+        assert not backend.busy  # in-flight count returns to zero
+    finally:
+        await pool.aclose()
+
+
+@pytest.mark.asyncio
 async def test_pool_ensure_reuses_then_evicts() -> None:
     """Ensure returns the same warm backend; evict tears it down."""
     pool = BackendPool(resolve_spec=_resolver({"fake": _spec("fake")}))


### PR DESCRIPTION
## Summary
Distilled-pool tool calls were serialized per backend, so a long-running tool (a multi-minute `skull_strip`) blocked every later call to the same stack — it "didn't start." A hung call was worse: it held the per-backend lock indefinitely and the idle reaper only reaps *non-busy* backends, so the stack stayed wedged until the call read-timeout fired. This removes that serialization so concurrent calls multiplex on the one warm backend.

## Related issue
N/A — follow-up to #55 (persistent backend pool).

## Test plan
- [x] `just check` green — 249 tests, ruff lint/format, pyright strict
- [x] New `tests/test_backend_pool.py::test_concurrent_calls_overlap_on_one_backend`: two `sleep(0.5)` calls on one warm backend finish in ~0.5s (parallel), asserting they don't serialize to ~1.0s; `busy` returns to false afterwards
- [x] Existing pool lifecycle tests (reuse, GPU LRU cap, idle reap, crash-respawn) still pass — `busy` semantics preserved (now `inflight > 0`)
- [x] Verified the MCP SDK server dispatches each request via `tg.start_soon` (its own task), so parallelism is real, not just client-side

## Security & data handling
None. No new tool surface, network calls, or file-write paths; no change to the permission flow. The GPU LRU cap (`max_warm_gpu`) is still honored — all concurrency stays inside the single warm GPU backend rather than spawning extra GPU containers.

## Notes
- Root cause: `Backend._lock` (an `asyncio.Lock`) wrapped every `call_tool`. The lock was conservative — the SDK already multiplexes requests by id on one `ClientSession`. Replaced with an in-flight counter that keeps `busy` truthful for the cap/reaper.
- Behavioral effect once deployed: a slow/stuck `skull_strip` no longer blocks subsequent neuro calls. Takes effect after a `core` image built from this branch is deployed (the running container still has the serialized build).
