### PR TITLE
fix(workflows,viewer): keep overlay on resize, flag missing/mismatched stacks, batch multi-input workflows

### DIFF
--- a/frontend/src/components/Viewer.tsx
+++ b/frontend/src/components/Viewer.tsx
@@ -58,6 +58,23 @@ const LABEL_COLORMAP = labelColorMap()
 // use its numeric value.
 const COLORMAP_TYPE_TRANSPARENT_BELOW_MIN = 1
 
+/** Add `url` as a styled label overlay on top of `nv`'s base volume: a discrete
+ *  label colormap (distinct color per integer label) with the background label
+ *  dropped out in both the 2D slices and the 3D render. Shared by the user
+ *  overlay action and the post-load restore so they style identically. */
+async function addStyledOverlay(nv: Niivue, url: string, opacity: number): Promise<void> {
+  await nv.addVolumeFromUrl({ url, opacity })
+  const overlay = nv.volumes[nv.volumes.length - 1]
+  overlay.setColormapLabel(LABEL_COLORMAP)
+  // The label LUT's zero-alpha hides the background only in the 2D slices. In the
+  // 3D volume render, transparency is driven by colormapType + cal_min: mark
+  // sub-min voxels transparent and put the threshold just above 0 so the
+  // background label (0) drops out there too.
+  overlay.colormapType = COLORMAP_TYPE_TRANSPARENT_BELOW_MIN
+  overlay.cal_min = 0.5
+  nv.updateGLVolume()
+}
+
 // Legacy standalone convention key — still read once to migrate the preference
 // into the consolidated viewer settings below.
 const RADIOLOGICAL_KEY = 'medmcp.radiologicalView'
@@ -169,11 +186,19 @@ function VolumeView({
   settings,
   refreshSignal,
   isResizing,
+  overlayPath,
+  overlayOpacity,
+  onOverlayChange,
+  onOpacityChange,
 }: {
   path: string
   settings: ViewerSettings
   refreshSignal?: number
   isResizing?: boolean
+  overlayPath: string
+  overlayOpacity: number
+  onOverlayChange: (path: string) => void
+  onOpacityChange: (opacity: number) => void
 }) {
   const url = rawUrl(path)
   const canvasRef = useRef<HTMLCanvasElement>(null)
@@ -183,8 +208,6 @@ function VolumeView({
   const [loadError, setLoadError] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
   const [volumePaths, setVolumePaths] = useState<string[]>([])
-  const [overlayPath, setOverlayPath] = useState<string>('')
-  const [overlayOpacity, setOverlayOpacity] = useState(0.5)
   const [dragOver, setDragOver] = useState(false)
   // Read inside the url-keyed load effect (constructor seeding + post-load) and
   // the live-settings effect without making settings a dependency of the load
@@ -198,6 +221,18 @@ function VolumeView({
   useEffect(() => {
     isResizingRef.current = isResizing
   }, [isResizing])
+  // Overlay path + opacity are owned by the parent Viewer so they survive the
+  // resize-rebuild remount. Mirror them into refs so the url-keyed load effect
+  // can restore the overlay after the base volume loads, without taking them as
+  // dependencies (which would tear down and reload the base volume).
+  const overlayPathRef = useRef(overlayPath)
+  useEffect(() => {
+    overlayPathRef.current = overlayPath
+  }, [overlayPath])
+  const overlayOpacityRef = useRef(overlayOpacity)
+  useEffect(() => {
+    overlayOpacityRef.current = overlayOpacity
+  }, [overlayOpacity])
 
   // Size the dropzone (Niivue's observed parent) to the panel. We NEVER do this
   // during a separator drag: Niivue leaks GPU resources each time its canvas
@@ -282,14 +317,21 @@ function VolumeView({
         if (cancelled) return
         await nv.loadVolumes([{ url }])
         applyViewerSettings(nv, settingsRef.current)
+        // Restore a persisted overlay so it survives the resize-rebuild remount
+        // (which rebuilds this view fresh — see the parent Viewer). The overlay
+        // path/opacity are owned there and mirrored into refs above.
+        if (overlayPathRef.current && !cancelled) {
+          await addStyledOverlay(nv, rawUrl(overlayPathRef.current), overlayOpacityRef.current)
+        }
       } catch (e) {
         if (!cancelled) setLoadError(String(e))
       } finally {
         if (!cancelled) setLoading(false)
       }
     }
-    // Seed the overlay-op chain with the base load so an overlay dropped
-    // before the base image finished loading can't race it.
+    // Seed the overlay-op chain with the base load (which now also restores a
+    // persisted overlay) so an overlay dropped before the base finished loading
+    // can't race it.
     overlayOpRef.current = load()
     return () => {
       cancelled = true
@@ -338,8 +380,10 @@ function VolumeView({
   const overlayOpRef = useRef<Promise<void>>(Promise.resolve())
 
   const setOverlay = (newPath: string) => {
-    // Only ever called from event handlers (drop/select/remove), where ref
-    // writes are fine — the lint rule just can't see the call sites.
+    // Persist in the parent Viewer so the overlay survives a resize-rebuild
+    // remount. Only ever called from event handlers (drop/select/remove), where
+    // ref writes are fine — the lint rule just can't see the call sites.
+    onOverlayChange(newPath)
     // eslint-disable-next-line react-hooks/immutability
     overlayOpRef.current = overlayOpRef.current.then(() => applyOverlay(newPath))
   }
@@ -352,31 +396,18 @@ function VolumeView({
       while (nv.volumes.length > 1) {
         nv.removeVolume(nv.volumes[nv.volumes.length - 1])
       }
-      setOverlayPath(newPath)
       if (newPath) {
-        await nv.addVolumeFromUrl({ url: rawUrl(newPath), opacity: overlayOpacity })
-        // Render as discrete labels: each integer value gets a distinct color,
-        // value 0 stays transparent. Nicer than a single-hue ramp for masks
-        // and segmentations alike.
-        const overlay = nv.volumes[nv.volumes.length - 1]
-        overlay.setColormapLabel(LABEL_COLORMAP)
-        // The label LUT's zero-alpha hides the background only in the 2D slices.
-        // In the 3D volume render, transparency is driven by colormapType +
-        // cal_min: mark sub-min voxels transparent and put the threshold just
-        // above 0 so the background label (0) drops out there too.
-        overlay.colormapType = COLORMAP_TYPE_TRANSPARENT_BELOW_MIN
-        overlay.cal_min = 0.5
-        nv.updateGLVolume()
+        await addStyledOverlay(nv, rawUrl(newPath), overlayOpacityRef.current)
       }
       setLoadError(null)
     } catch (e) {
-      setOverlayPath('')
+      onOverlayChange('')
       setLoadError(`Could not load overlay: ${String(e)}`)
     }
   }
 
   const setOpacity = (value: number) => {
-    setOverlayOpacity(value)
+    onOpacityChange(value)
     const nv = nvRef.current
     if (nv && nv.volumes.length > 1) {
       nv.setOpacity(1, value)
@@ -518,6 +549,19 @@ export const Viewer = memo(function Viewer({
   const didResizeRef = useRef(false)
   const [settings, setSettings] = useState<ViewerSettings>(loadViewerSettings)
   const [settingsOpen, setSettingsOpen] = useState(false)
+  // Overlay selection lives here, not in VolumeView, so it survives the
+  // resize-rebuild remount (which bumps resizeGen and rebuilds VolumeView fresh).
+  // It's tagged with the base file it belongs to, so it's transparently ignored
+  // once a different file is opened — no state reset (which the hooks lint
+  // forbids both in render and in effects) is needed.
+  const [overlay, setOverlay] = useState<{ base: string; path: string; opacity: number }>({
+    base: '',
+    path: '',
+    opacity: 0.5,
+  })
+  const overlayForThisFile = overlay.base === path
+  const overlayPath = overlayForThisFile ? overlay.path : ''
+  const overlayOpacity = overlayForThisFile ? overlay.opacity : 0.5
   const updateSettings = useCallback((patch: Partial<ViewerSettings>) => {
     setSettings((prev) => {
       const next = { ...prev, ...patch }
@@ -597,6 +641,22 @@ export const Viewer = memo(function Viewer({
               settings={settings}
               refreshSignal={refreshSignal}
               isResizing={isResizing}
+              overlayPath={overlayPath}
+              overlayOpacity={overlayOpacity}
+              onOverlayChange={(p) =>
+                setOverlay((prev) => ({
+                  base: path,
+                  path: p,
+                  opacity: prev.base === path ? prev.opacity : 0.5,
+                }))
+              }
+              onOpacityChange={(o) =>
+                setOverlay((prev) => ({
+                  base: path,
+                  path: prev.base === path ? prev.path : '',
+                  opacity: o,
+                }))
+              }
             />
             {rebuilding && (
               <div className="volume-loading">

--- a/frontend/src/components/WorkflowPanel.tsx
+++ b/frontend/src/components/WorkflowPanel.tsx
@@ -966,15 +966,23 @@ export const WorkflowPanel = memo(function WorkflowPanel({
           const inputNames = d.inputs.map((i) => i.name)
           const emptyRow = (): Record<string, string> =>
             Object.fromEntries(inputNames.map((n) => [n, '']))
-          // Append one row per selected explorer file, filling the first input;
-          // other inputs default to the last filled row so a shared input (e.g. a
-          // template) carries down. Drops leading blank rows.
+          // Distribute the selected files across rows: every N files (N = number
+          // of inputs) fill one row's inputs in order. So a 2-input workflow turns
+          // 2 selected files into one run (in_1, in_2), 4 files into two runs, etc.
+          // A single-input workflow gets one row per file. Drops blank rows.
           const addFromSelection = () => {
-            const first = inputNames[0]
-            if (!first) return
+            const k = inputNames.length
+            if (k === 0 || selectedPaths.length === 0) return
+            const added: Record<string, string>[] = []
+            for (let i = 0; i < selectedPaths.length; i += k) {
+              const row = emptyRow()
+              inputNames.forEach((n, j) => {
+                const file = selectedPaths[i + j]
+                if (file) row[n] = file
+              })
+              added.push(row)
+            }
             const filled = m.rows.filter((r) => Object.values(r).some((v) => v.trim()))
-            const template = filled[filled.length - 1] ?? emptyRow()
-            const added = selectedPaths.map((p) => ({ ...template, [first]: p }))
             setMode({ ...m, rows: [...filled, ...added] })
           }
           const singleIncomplete = inputNames.some((n) => !(m.values[n] ?? '').trim())
@@ -1033,8 +1041,9 @@ export const WorkflowPanel = memo(function WorkflowPanel({
               ) : (
                 <>
                   <div className="wf-hint">
-                    One row per run — each runs the whole workflow on its own inputs. Drag files into
-                    a cell, or select files in the explorer and “Add from selection”.
+                    One row per run — each runs the whole workflow on its own inputs. Drag a file
+                    into any cell, or select files in the explorer and “Add from selection” (every{' '}
+                    {d.inputs.length} selected file{d.inputs.length === 1 ? '' : 's'} fill one row).
                   </div>
                   <div className="wf-batch-table">
                     <div className="wf-batch-row wf-batch-head">
@@ -1091,7 +1100,7 @@ export const WorkflowPanel = memo(function WorkflowPanel({
                         title={
                           selectedPaths.length === 0
                             ? 'Select files in the explorer first'
-                            : 'Add one row per selected file (fills the first input)'
+                            : `Group the ${selectedPaths.length} selected file(s) into rows of ${d.inputs.length} (one per input)`
                         }
                         onClick={addFromSelection}
                       >

--- a/frontend/src/components/WorkflowPanel.tsx
+++ b/frontend/src/components/WorkflowPanel.tsx
@@ -30,6 +30,7 @@ import {
   RefreshIcon,
   StopSquareIcon,
   UploadIcon,
+  XIcon,
 } from './icons'
 
 type ReplayStepFrame = Extract<ReplayFrame, { type: 'step' }>
@@ -42,19 +43,19 @@ type Mode =
   | { kind: 'view' }
   | { kind: 'rename'; value: string }
   | { kind: 'refine'; value: string }
-  | { kind: 'inputs'; values: Record<string, string>; batchInput: string | null }
+  | { kind: 'inputs'; batch: boolean; values: Record<string, string>; rows: Record<string, string>[] }
   | {
       kind: 'preview'
+      batch: boolean
       values: Record<string, string>
-      batchInput: string | null
-      batchValues: string[]
+      rows: Record<string, string>[]
+      runs: Record<string, string>[]
       steps: ReplayPreviewStep[]
     }
   | {
       kind: 'running'
       name: string
       runs: Record<string, string>[]
-      batchInput: string | null
       total: number
       stepsPerItem: number
       startedAt: number
@@ -66,7 +67,6 @@ type Mode =
       kind: 'done'
       name: string
       runs: Record<string, string>[]
-      batchInput: string | null
       total: number
       stepsPerItem: number
       startedAt: number
@@ -86,16 +86,14 @@ function runProgress(m: Extract<Mode, { kind: 'running' }>): number {
   return (m.items.length + currentFrac) / m.total
 }
 
-/** One run's input bindings per batch item (a single run is a batch of one). */
+/** The runs to execute: a single binding, or every fully-filled table row. Each
+ *  run is an independent full input binding ({in_1, in_2, …}). */
 function buildRuns(
-  values: Record<string, string>,
-  batchInput: string | null,
-  batchValues: string[],
+  st: { batch: boolean; values: Record<string, string>; rows: Record<string, string>[] },
+  inputNames: string[],
 ): Record<string, string>[] {
-  if (batchInput && batchValues.length > 0) {
-    return batchValues.map((v) => ({ ...values, [batchInput]: v }))
-  }
-  return [values]
+  if (!st.batch) return [st.values]
+  return st.rows.filter((r) => inputNames.every((n) => (r[n] ?? '').trim() !== ''))
 }
 
 /** "1m 23s" / "45s" from a millisecond duration. */
@@ -121,10 +119,17 @@ function inputOptionLabel(i: Input): string {
   return bits.length > 0 ? `${i.name} — ${bits.join(' · ')}` : i.name
 }
 
-/** Short label for batch item *i* — its batched input's filename, else "Item N". */
-function itemLabel(runs: Record<string, string>[], batchInput: string | null, i: number): string {
-  const v = batchInput ? runs[i]?.[batchInput] : undefined
-  return v ? basename(v) : `Item ${i + 1}`
+/** The file basenames of a run's input values, joined (e.g. "subjA.nii + atlas.nii"). */
+function runFiles(run: Record<string, string>): string {
+  return Object.values(run)
+    .filter((v) => v.trim() !== '')
+    .map(basename)
+    .join(' + ')
+}
+
+/** Short label for batch item *i* — its input filenames, else "Item N". */
+function itemLabel(runs: Record<string, string>[], i: number): string {
+  return runFiles(runs[i] ?? {}) || `Item ${i + 1}`
 }
 
 /** 1-based step number currently in progress for the active item. */
@@ -227,8 +232,18 @@ function InputField({
 }
 
 /** The stacks a workflow needs, pinned by image(+digest) or version. */
+const REQ_STATUS: Record<
+  NonNullable<StackRequirement['status']>,
+  { icon: string; cls: string; title: string }
+> = {
+  ok: { icon: '✓', cls: 'ok', title: 'installed' },
+  missing: { icon: '✗', cls: 'missing', title: 'not installed' },
+  mismatch: { icon: '⚠', cls: 'mismatch', title: 'installed, but a different version' },
+}
+
 function Requirements({ requires }: { requires: StackRequirement[] }) {
   if (requires.length === 0) return null
+  const mismatched = requires.filter((r) => r.status === 'mismatch')
   return (
     <div className="wf-requires">
       <div className="wf-requires-title">Requires</div>
@@ -239,14 +254,26 @@ function Requirements({ requires }: { requires: StackRequirement[] }) {
             : r.version
               ? `v${r.version}`
               : ''
+          const s = r.status ? REQ_STATUS[r.status] : null
           return (
             <li key={r.stack}>
+              {s && (
+                <span className={`wf-req-status ${s.cls}`} title={s.title}>
+                  {s.icon}
+                </span>
+              )}
               <code>{r.stack}</code>
               {pin && <span className="wf-req-pin">{pin}</span>}
             </li>
           )
         })}
       </ul>
+      {mismatched.length > 0 && (
+        <div className="wf-req-warn">
+          A different version of {mismatched.map((r) => r.stack).join(', ')} is installed than this
+          workflow was built with — results may not reproduce exactly.
+        </div>
+      )}
     </div>
   )
 }
@@ -269,19 +296,17 @@ function RunLog({
   log,
   total = 1,
   runs,
-  batchInput,
 }: {
   log: ReplayStepFrame[]
   total?: number
   runs?: Record<string, string>[]
-  batchInput?: string | null
 }) {
   const rows: ReactNode[] = []
   let lastItem = -1
   for (const s of log) {
     const item = s.item ?? 0
     if (total > 1 && item !== lastItem) {
-      const file = runs && batchInput ? basename(runs[item]?.[batchInput] ?? '') : ''
+      const file = runs ? runFiles(runs[item] ?? {}) : ''
       rows.push(
         <div key={`item-${item}`} className="wf-runitem">
           Item {item + 1} of {total}
@@ -321,26 +346,40 @@ function ProgressBar({ frac, label, active }: { frac: number; label: string; act
   )
 }
 
-/** Read-only view of the explorer selection feeding the batched input. */
-function BatchSelection({ paths }: { paths: string[] }) {
-  if (paths.length === 0) {
-    return (
-      <div className="wf-hint">
-        Select the files to process in the explorer — ctrl/shift-click for multiple.
-      </div>
-    )
-  }
+/** One batch-table cell: a compact path input that also accepts a file drag. */
+function BatchCell({
+  value,
+  example,
+  onChange,
+}: {
+  value: string
+  example: string
+  onChange: (v: string) => void
+}) {
+  const [dropReady, setDropReady] = useState(false)
   return (
-    <div className="wf-batch-selection">
-      <div className="wf-hint">
-        Using the explorer selection ({paths.length} file{paths.length === 1 ? '' : 's'}):
-      </div>
-      <div className="wf-batch-chips">
-        {paths.map((p) => (
-          <code key={p}>{p}</code>
-        ))}
-      </div>
-    </div>
+    <input
+      className={dropReady ? 'wf-batch-cell drop-ready' : 'wf-batch-cell'}
+      value={value}
+      placeholder={example ? `e.g. ${basename(example)}` : 'path'}
+      title={value || undefined}
+      onChange={(e) => onChange(e.target.value)}
+      onDragOver={(e) => {
+        if (e.dataTransfer.types.includes(DRAG_PATH_MIME) || getDraggedFilePath() !== null) {
+          e.preventDefault()
+          setDropReady(true)
+        }
+      }}
+      onDragLeave={() => setDropReady(false)}
+      onDrop={(e) => {
+        const path = e.dataTransfer.getData(DRAG_PATH_MIME) || getDraggedFilePath()
+        if (path) {
+          e.preventDefault()
+          onChange(path)
+        }
+        setDropReady(false)
+      }}
+    />
   )
 }
 
@@ -415,9 +454,9 @@ export const WorkflowPanel = memo(function WorkflowPanel({
   const [prevSel, setPrevSel] = useState<string[]>(selectedPaths)
   if (selectedPaths !== prevSel) {
     setPrevSel(selectedPaths)
-    if (mode.kind === 'inputs' && mode.batchInput === null && selectedPaths.length > 0) {
+    if (mode.kind === 'inputs' && !mode.batch && selectedPaths.length > 0) {
       setMode((m) => {
-        if (m.kind !== 'inputs' || m.batchInput !== null) return m
+        if (m.kind !== 'inputs' || m.batch) return m
         const fields = Object.keys(m.values)
         const values = { ...m.values }
         if (fields.length === 1) {
@@ -546,26 +585,29 @@ export const WorkflowPanel = memo(function WorkflowPanel({
 
   const toPreview = (
     name: string,
-    values: Record<string, string>,
-    batchInput: string | null,
-    batchValues: string[],
+    st: { batch: boolean; values: Record<string, string>; rows: Record<string, string>[] },
+    inputNames: string[],
   ) =>
     withBusy('Resolving steps…', async () => {
-      // Preview resolves the first batch item; the others differ only in the
-      // batched input's value, which the preview screen lists alongside.
-      const res = await replayPreview(name, buildRuns(values, batchInput, batchValues)[0])
+      const runs = buildRuns(st, inputNames)
+      if (runs.length === 0) {
+        setError('add at least one run with every input filled')
+        return
+      }
+      // Preview resolves the first run; a batch's other runs differ only in their
+      // input values, which the preview screen lists alongside.
+      const res = await replayPreview(name, runs[0])
       if (!res.ok) {
         setError(res.error ?? 'this workflow cannot be replayed')
         return
       }
-      setMode({ kind: 'preview', values, batchInput, batchValues, steps: res.steps })
+      setMode({ kind: 'preview', batch: st.batch, values: st.values, rows: st.rows, runs, steps: res.steps })
     })
 
   const startRun = (
     name: string,
     runs: Record<string, string>[],
     stepsPerItem: number,
-    batchInput: string | null,
     startedAt: number,
   ) => {
     const proto = location.protocol === 'https:' ? 'wss' : 'ws'
@@ -576,7 +618,6 @@ export const WorkflowPanel = memo(function WorkflowPanel({
       kind: 'running',
       name,
       runs,
-      batchInput,
       total: runs.length,
       stepsPerItem,
       startedAt,
@@ -621,7 +662,6 @@ export const WorkflowPanel = memo(function WorkflowPanel({
                 kind: 'done',
                 name: m.name,
                 runs: m.runs,
-                batchInput: m.batchInput,
                 total: m.total,
                 stepsPerItem: m.stepsPerItem,
                 startedAt: m.startedAt,
@@ -643,7 +683,6 @@ export const WorkflowPanel = memo(function WorkflowPanel({
                 kind: 'done',
                 name: m.name,
                 runs: m.runs,
-                batchInput: m.batchInput,
                 total: m.total,
                 stepsPerItem: m.stepsPerItem,
                 startedAt: m.startedAt,
@@ -661,14 +700,11 @@ export const WorkflowPanel = memo(function WorkflowPanel({
 
   const beginRun = (d: WorkflowDetail) => {
     if (d.inputs.length === 0) {
-      void toPreview(d.name, {}, null, [])
+      void toPreview(d.name, { batch: false, values: {}, rows: [] }, [])
       return
     }
-    setMode({
-      kind: 'inputs',
-      values: Object.fromEntries(d.inputs.map((i) => [i.name, ''])),
-      batchInput: null,
-    })
+    const empty = Object.fromEntries(d.inputs.map((i) => [i.name, '']))
+    setMode({ kind: 'inputs', batch: false, values: empty, rows: [{ ...empty }] })
   }
 
   const renderRunning = (m: Extract<Mode, { kind: 'running' }>) => (
@@ -685,10 +721,10 @@ export const WorkflowPanel = memo(function WorkflowPanel({
       />
       <div className="wf-active">
         {m.items.length < m.total ? (
-          m.batchInput ? (
+          m.total > 1 ? (
             <span>
-              Processing <strong>{basename(m.runs[m.items.length]?.[m.batchInput] ?? '')}</strong> —
-              item {m.items.length + 1} of {m.total} · step {currentStep(m)} of {m.stepsPerItem}
+              Processing <strong>{itemLabel(m.runs, m.items.length)}</strong> — item{' '}
+              {m.items.length + 1} of {m.total} · step {currentStep(m)} of {m.stepsPerItem}
             </span>
           ) : (
             <span>
@@ -700,7 +736,7 @@ export const WorkflowPanel = memo(function WorkflowPanel({
         )}
       </div>
       <div className="wf-timing">{runTiming(m, now)}</div>
-      <RunLog log={m.log} total={m.total} runs={m.runs} batchInput={m.batchInput} />
+      <RunLog log={m.log} total={m.total} runs={m.runs} />
       <div className="wf-actions">
         <button className="btn-danger" onClick={() => runWs.current?.close()}>
           <StopSquareIcon size={12} /> Stop
@@ -725,14 +761,14 @@ export const WorkflowPanel = memo(function WorkflowPanel({
             <span className="tally-muted">in {formatDuration(duration)}</span>
           </div>
         )}
-        <RunLog log={m.log} total={m.total} runs={m.runs} batchInput={m.batchInput} />
+        <RunLog log={m.log} total={m.total} runs={m.runs} />
         {m.total > 1 && (
           <div className="wf-batch-summary">
             {m.items.map((it, i) => (
               <div key={i} className={it.ok ? 'wf-runstep ok' : 'wf-runstep fail'}>
                 <span className={`status-dot ${it.ok ? 'ok' : 'fail'}`} />
                 <span>
-                  {itemLabel(m.runs, m.batchInput, i)}:{' '}
+                  {itemLabel(m.runs, i)}:{' '}
                   {it.ok ? (
                     it.outputs.length > 0 ? (
                       <>
@@ -773,7 +809,7 @@ export const WorkflowPanel = memo(function WorkflowPanel({
             <button
               className="btn-primary"
               title="Re-run only the items that failed or didn't finish"
-              onClick={() => startRun(m.name, retryRuns, m.stepsPerItem, m.batchInput, Date.now())}
+              onClick={() => startRun(m.name, retryRuns, m.stepsPerItem, Date.now())}
             >
               <RefreshIcon size={12} /> Retry {retryRuns.length}
             </button>
@@ -925,83 +961,171 @@ export const WorkflowPanel = memo(function WorkflowPanel({
         </form>
       )}
 
-      {mode.kind === 'inputs' && (
-        <form
-          className="wf-form"
-          onSubmit={(e) => {
-            e.preventDefault()
-            // Snapshot the explorer selection now so later clicks in the
-            // explorer can't change what the preview confirmed.
-            void toPreview(d.name, mode.values, mode.batchInput, selectedPaths)
-          }}
-        >
-          <div className="wf-hint">
-            Provide a value for each input — select a file in the explorer to fill it, or type /
-            drag a path.
-          </div>
-          {d.inputs.map((i) =>
-            i.name === mode.batchInput ? null : (
-              <InputField
-                key={i.name}
-                name={i.name}
-                example={i.example}
-                description={i.description}
-                value={mode.values[i.name] ?? ''}
-                onChange={(v) => setMode({ ...mode, values: { ...mode.values, [i.name]: v } })}
-              />
-            ),
-          )}
-          <label className="wf-input-row">
-            <span className="wf-input-label">
-              Batch over
-              <span className="wf-input-desc">
-                run once per file selected in the explorer, bound to this input
-              </span>
-            </span>
-            <select
-              className="wf-input"
-              value={mode.batchInput ?? ''}
-              onChange={(e) => setMode({ ...mode, batchInput: e.target.value || null })}
+      {mode.kind === 'inputs' &&
+        ((m: Extract<Mode, { kind: 'inputs' }>) => {
+          const inputNames = d.inputs.map((i) => i.name)
+          const emptyRow = (): Record<string, string> =>
+            Object.fromEntries(inputNames.map((n) => [n, '']))
+          // Append one row per selected explorer file, filling the first input;
+          // other inputs default to the last filled row so a shared input (e.g. a
+          // template) carries down. Drops leading blank rows.
+          const addFromSelection = () => {
+            const first = inputNames[0]
+            if (!first) return
+            const filled = m.rows.filter((r) => Object.values(r).some((v) => v.trim()))
+            const template = filled[filled.length - 1] ?? emptyRow()
+            const added = selectedPaths.map((p) => ({ ...template, [first]: p }))
+            setMode({ ...m, rows: [...filled, ...added] })
+          }
+          const singleIncomplete = inputNames.some((n) => !(m.values[n] ?? '').trim())
+          const completeRows = m.rows.filter((r) => inputNames.every((n) => (r[n] ?? '').trim()))
+          const previewDisabled = m.batch ? completeRows.length === 0 : singleIncomplete
+          return (
+            <form
+              className="wf-form"
+              onSubmit={(e) => {
+                e.preventDefault()
+                void toPreview(d.name, { batch: m.batch, values: m.values, rows: m.rows }, inputNames)
+              }}
             >
-              <option value="">— single run —</option>
-              {d.inputs.map((i) => (
-                <option key={i.name} value={i.name} title={i.example || undefined}>
-                  {inputOptionLabel(i)}
-                </option>
-              ))}
-            </select>
-          </label>
-          {mode.batchInput &&
-            (() => {
-              const bi = d.inputs.find((i) => i.name === mode.batchInput)
-              return bi && (bi.description || bi.example) ? (
-                <div className="wf-hint">
-                  Batching <code>{bi.name}</code>
-                  {bi.description ? ` — ${bi.description}` : ''}
-                  {bi.example ? ` (e.g. ${basename(bi.example)})` : ''}
-                </div>
-              ) : null
-            })()}
-          {mode.batchInput && <BatchSelection paths={selectedPaths} />}
-          <div className="wf-actions">
-            <button
-              className="btn-primary"
-              type="submit"
-              disabled={
-                d.inputs.some(
-                  (i) => i.name !== mode.batchInput && !(mode.values[i.name] ?? '').trim(),
-                ) ||
-                (mode.batchInput !== null && selectedPaths.length === 0)
-              }
-            >
-              Preview steps
-            </button>
-            <button className="btn-plain" type="button" onClick={() => setMode({ kind: 'view' })}>
-              Cancel
-            </button>
-          </div>
-        </form>
-      )}
+              <div className="wf-mode-toggle">
+                <button
+                  type="button"
+                  className={!m.batch ? 'active' : ''}
+                  onClick={() => setMode({ ...m, batch: false })}
+                >
+                  Single run
+                </button>
+                <button
+                  type="button"
+                  className={m.batch ? 'active' : ''}
+                  onClick={() =>
+                    setMode({
+                      ...m,
+                      batch: true,
+                      rows: m.rows.some((r) => Object.values(r).some((v) => v.trim()))
+                        ? m.rows
+                        : [{ ...m.values }],
+                    })
+                  }
+                >
+                  Batch
+                </button>
+              </div>
+
+              {!m.batch ? (
+                <>
+                  <div className="wf-hint">
+                    Provide a value for each input — select a file in the explorer to fill it, or
+                    type / drag a path.
+                  </div>
+                  {d.inputs.map((i) => (
+                    <InputField
+                      key={i.name}
+                      name={i.name}
+                      example={i.example}
+                      description={i.description}
+                      value={m.values[i.name] ?? ''}
+                      onChange={(v) => setMode({ ...m, values: { ...m.values, [i.name]: v } })}
+                    />
+                  ))}
+                </>
+              ) : (
+                <>
+                  <div className="wf-hint">
+                    One row per run — each runs the whole workflow on its own inputs. Drag files into
+                    a cell, or select files in the explorer and “Add from selection”.
+                  </div>
+                  <div className="wf-batch-table">
+                    <div className="wf-batch-row wf-batch-head">
+                      <span className="wf-batch-idx">#</span>
+                      {d.inputs.map((i) => (
+                        <span key={i.name} className="wf-batch-col" title={inputOptionLabel(i)}>
+                          {i.name}
+                        </span>
+                      ))}
+                      <span className="wf-batch-rm" />
+                    </div>
+                    {m.rows.map((row, ri) => (
+                      <div key={ri} className="wf-batch-row">
+                        <span className="wf-batch-idx">{ri + 1}</span>
+                        {d.inputs.map((i) => (
+                          <BatchCell
+                            key={i.name}
+                            value={row[i.name] ?? ''}
+                            example={i.example}
+                            onChange={(v) =>
+                              setMode({
+                                ...m,
+                                rows: m.rows.map((r, j) =>
+                                  j === ri ? { ...r, [i.name]: v } : r,
+                                ),
+                              })
+                            }
+                          />
+                        ))}
+                        <button
+                          type="button"
+                          className="btn-icon wf-batch-rm"
+                          title="Remove row"
+                          onClick={() =>
+                            setMode({ ...m, rows: m.rows.filter((_, j) => j !== ri) })
+                          }
+                        >
+                          <XIcon size={12} />
+                        </button>
+                      </div>
+                    ))}
+                    <div className="wf-batch-tools">
+                      <button
+                        type="button"
+                        className="btn-plain"
+                        onClick={() => setMode({ ...m, rows: [...m.rows, emptyRow()] })}
+                      >
+                        + Add row
+                      </button>
+                      <button
+                        type="button"
+                        className="btn-plain"
+                        disabled={selectedPaths.length === 0}
+                        title={
+                          selectedPaths.length === 0
+                            ? 'Select files in the explorer first'
+                            : 'Add one row per selected file (fills the first input)'
+                        }
+                        onClick={addFromSelection}
+                      >
+                        Add from selection ({selectedPaths.length})
+                      </button>
+                    </div>
+                  </div>
+                  {completeRows.length > 0 && (
+                    <div className="wf-hint">
+                      {completeRows.length} run{completeRows.length === 1 ? '' : 's'} ready
+                      {m.rows.length > completeRows.length
+                        ? ` (${m.rows.length - completeRows.length} incomplete row(s) skipped)`
+                        : ''}
+                      .
+                    </div>
+                  )}
+                </>
+              )}
+
+              <div className="wf-actions">
+                <button className="btn-primary" type="submit" disabled={previewDisabled}>
+                  Preview steps
+                </button>
+                <button
+                  className="btn-plain"
+                  type="button"
+                  onClick={() => setMode({ kind: 'view' })}
+                >
+                  Cancel
+                </button>
+              </div>
+            </form>
+          )
+        })(mode)}
 
       {mode.kind === 'preview' && (
         <div className="wf-form">
@@ -1009,16 +1133,14 @@ export const WorkflowPanel = memo(function WorkflowPanel({
             Replay will run these exact steps — no LLM, no permission prompts. Review before
             running.
           </div>
-          {mode.batchInput && mode.batchValues.length > 0 && (
+          {mode.runs.length > 1 && (
             <div className="wf-hint">
-              Batch: runs {mode.batchValues.length}×, with <code>{mode.batchInput}</code> set to
-              each of:
+              Batch: {mode.runs.length} runs — the steps below show the first. All runs:
               <span className="wf-batch-chips">
-                {mode.batchValues.map((v) => (
-                  <code key={v}>{v}</code>
+                {mode.runs.map((_run, i) => (
+                  <code key={i}>{itemLabel(mode.runs, i)}</code>
                 ))}
               </span>
-              The steps below show the first item.
             </div>
           )}
           <ol className="wf-steps">
@@ -1034,15 +1156,7 @@ export const WorkflowPanel = memo(function WorkflowPanel({
           <div className="wf-actions">
             <button
               className="btn-primary"
-              onClick={() =>
-                startRun(
-                  d.name,
-                  buildRuns(mode.values, mode.batchInput, mode.batchValues),
-                  d.steps.length,
-                  mode.batchInput,
-                  Date.now(),
-                )
-              }
+              onClick={() => startRun(d.name, mode.runs, d.steps.length, Date.now())}
             >
               <PlayIcon size={12} /> Run now
             </button>
@@ -1050,7 +1164,12 @@ export const WorkflowPanel = memo(function WorkflowPanel({
               className="btn-plain"
               onClick={() =>
                 d.inputs.length > 0
-                  ? setMode({ kind: 'inputs', values: mode.values, batchInput: mode.batchInput })
+                  ? setMode({
+                      kind: 'inputs',
+                      batch: mode.batch,
+                      values: mode.values,
+                      rows: mode.rows,
+                    })
                   : setMode({ kind: 'view' })
               }
             >

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1864,6 +1864,33 @@ textarea.wf-input {
   font-size: 11px;
 }
 
+.wf-req-status {
+  display: inline-block;
+  width: 1em;
+  margin-right: 5px;
+  font-weight: 700;
+  text-align: center;
+}
+
+.wf-req-status.ok {
+  color: var(--ok);
+}
+
+.wf-req-status.missing {
+  color: var(--red);
+}
+
+.wf-req-status.mismatch {
+  color: var(--warn);
+}
+
+.wf-req-warn {
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--warn);
+  line-height: 1.45;
+}
+
 .wf-runlog {
   display: flex;
   flex-direction: column;
@@ -1988,6 +2015,100 @@ textarea.wf-input {
   border: 1px solid var(--border2);
   border-radius: 5px;
   background: var(--card);
+}
+
+.wf-mode-toggle {
+  display: inline-flex;
+  align-self: flex-start;
+  border: 1px solid var(--border2);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.wf-mode-toggle button {
+  font: inherit;
+  font-size: 12px;
+  padding: 4px 12px;
+  background: transparent;
+  color: var(--muted);
+  border: none;
+  cursor: pointer;
+}
+
+.wf-mode-toggle button + button {
+  border-left: 1px solid var(--border2);
+}
+
+.wf-mode-toggle button.active {
+  background: var(--blue);
+  color: #fff;
+}
+
+.wf-batch-table {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.wf-batch-row {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.wf-batch-idx {
+  width: 18px;
+  flex: none;
+  text-align: right;
+  font-size: 11px;
+  color: var(--muted);
+  font-family: var(--mono);
+}
+
+.wf-batch-col {
+  flex: 1;
+  min-width: 0;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--muted);
+  font-family: var(--mono);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wf-batch-rm {
+  width: 22px;
+  flex: none;
+}
+
+.wf-batch-cell {
+  flex: 1;
+  min-width: 0;
+  font: inherit;
+  font-size: 12px;
+  font-family: var(--mono);
+  background: var(--dark2);
+  color: var(--text);
+  border: 1px solid var(--border2);
+  border-radius: 6px;
+  padding: 5px 8px;
+}
+
+.wf-batch-cell:focus {
+  outline: none;
+  border-color: var(--blue-l);
+}
+
+.wf-batch-cell.drop-ready {
+  border-color: var(--blue-xl);
+  box-shadow: 0 0 0 2px rgba(127, 168, 245, 0.25);
+}
+
+.wf-batch-tools {
+  display: flex;
+  gap: 8px;
+  margin-top: 2px;
 }
 
 .wf-batch-summary {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -115,6 +115,10 @@ export interface StackRequirement {
   version?: string
   image?: string
   digest?: string
+  /** Availability of this stack in the current environment (server-computed). */
+  status?: 'ok' | 'missing' | 'mismatch'
+  /** Digest of the locally-present image, when it differs from the pinned one. */
+  installed_digest?: string
 }
 
 /** Full recipe detail from GET /api/workflows/{name}. */

--- a/src/medmcp/provenance.py
+++ b/src/medmcp/provenance.py
@@ -99,7 +99,7 @@ def _read_model_config(model_name: str) -> JsonDict:
     return {}
 
 
-def _docker_image_ref(server: JsonDict) -> str | None:
+def docker_image_ref(server: JsonDict) -> str | None:
     """Return the container image ref for a ``docker``-launched stack, else ``None``.
 
     MedMCP container stacks launch via ``docker run … <image>`` with no trailing
@@ -122,7 +122,7 @@ def _stack_manifest_entry(server: JsonDict) -> JsonDict:
         "version": server.get("version"),
         "command": server.get("command"),
     }
-    image = _docker_image_ref(server)
+    image = docker_image_ref(server)
     if image:
         entry["image"] = image
     return entry

--- a/src/medmcp/replay.py
+++ b/src/medmcp/replay.py
@@ -311,7 +311,14 @@ def validate(recipe: Recipe, inputs: dict[str, Any], servers: list[JsonDict]) ->
     installed = {str(s["name"]) for s in servers}
     needed = sorted({s.server for s in recipe.steps} - installed)
     if needed:
-        return f"required stack(s) not installed: {', '.join(needed)}"
+        # Make the message actionable: name each missing stack with the image or
+        # version it's pinned to in the recipe's requirements, so a colleague who
+        # received this workflow knows exactly what to install.
+        pins = {
+            r.stack: (r.image or (f"v{r.version}" if r.version else "")) for r in recipe.requires
+        }
+        labels = [f"{s} ({pins[s]})" if pins.get(s) else s for s in needed]
+        return f"required stack(s) not installed: {', '.join(labels)}"
 
     if not recipe.steps:
         return "this workflow has no replayable steps"

--- a/src/medmcp/server.py
+++ b/src/medmcp/server.py
@@ -49,7 +49,7 @@ from fastapi.responses import FileResponse, JSONResponse, Response
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
-from medmcp import distill, explain, provenance, replay, sessions, settings, share
+from medmcp import distill, explain, provenance, replay, sessions, settings, share, workflow
 from medmcp.acp import PROJECT_ROOT, VIBE_HOME, JsonDict, VibeAcpClient
 from medmcp.backend_broker import BackendBroker
 from medmcp.backend_pool import BackendPool, BackendSpec
@@ -554,6 +554,32 @@ def _workflow_dir(name: str) -> Path | None:
     return None
 
 
+def _requirement_statuses(recipe: workflow.Recipe, servers: list[JsonDict]) -> list[JsonDict]:
+    """Each requirement enriched with its availability against the installed stacks.
+
+    ``status`` is ``"missing"`` (the stack isn't installed), ``"mismatch"`` (it is,
+    but the locally-present image digest differs from the pinned one — results may
+    not reproduce), or ``"ok"``. Offline (reads already-present image digests) and
+    best-effort: a digest it can't resolve is treated as ``"ok"`` rather than a
+    false alarm.
+    """
+    by_name = {str(s.get("name")): s for s in servers}
+    statuses: list[JsonDict] = []
+    for req in recipe.requires:
+        entry = req.to_dict()
+        server = by_name.get(req.stack)
+        if server is None:
+            entry["status"] = "missing"
+        else:
+            image = provenance.docker_image_ref(server)
+            local = settings.resolve_image_digest(image) if image else None
+            if local:
+                entry["installed_digest"] = local
+            entry["status"] = "mismatch" if req.digest and local and req.digest != local else "ok"
+        statuses.append(entry)
+    return statuses
+
+
 def _workflow_detail(name: str) -> JsonDict:
     """Load a workflow's recipe and replayability state (blocking; run in a thread)."""
     d = _workflow_dir(name)
@@ -561,7 +587,8 @@ def _workflow_detail(name: str) -> JsonDict:
         raise FileNotFoundError(f"no workflow named {name!r}")
     recipe = distill.load_recipe(d)
     examples = {i.name: i.example for i in recipe.inputs}
-    replay_error = replay.validate(recipe, examples, settings.active_servers())
+    servers = settings.active_servers()
+    replay_error = replay.validate(recipe, examples, servers)
     return {
         "name": recipe.name,
         "kind": d.parent.name,
@@ -570,7 +597,7 @@ def _workflow_detail(name: str) -> JsonDict:
         "steps": [
             {"server": s.server, "tool": s.tool, "arguments": s.arguments} for s in recipe.steps
         ],
-        "requires": [r.to_dict() for r in recipe.requires],
+        "requires": _requirement_statuses(recipe, servers),
         "manual_steps": list(recipe.manual_steps),
         "replayable": replay_error is None,
         "replay_error": replay_error,

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -10,7 +10,7 @@ import mcp.types as mcp_types
 import pytest
 
 from medmcp import replay
-from medmcp.workflow import Recipe, RecipeStep, WorkflowInput
+from medmcp.workflow import Recipe, RecipeStep, StackRequirement, WorkflowInput
 
 # pyright: reportPrivateUsage=false
 
@@ -165,6 +165,21 @@ class TestValidate:
         recipe = _recipe([RecipeStep(server="medmcp-cardiac", tool="t", arguments={})])
         msg = replay.validate(recipe, {}, _SERVERS)
         assert msg is not None and "medmcp-cardiac" in msg
+
+    def test_missing_stack_message_names_the_pin(self) -> None:
+        """The missing-stack message names the image/version from requires."""
+        recipe = Recipe(
+            name="wf",
+            description="d",
+            inputs=[],
+            steps=[RecipeStep(server="medmcp-cardiac", tool="t", arguments={})],
+            requires=[
+                StackRequirement(stack="medmcp-cardiac", image="ghcr.io/medmcp/cardiac:main")
+            ],
+        )
+        msg = replay.validate(recipe, {}, _SERVERS)
+        assert msg is not None
+        assert "medmcp-cardiac" in msg and "ghcr.io/medmcp/cardiac:main" in msg
 
     def test_no_steps(self) -> None:
         """A recipe with no steps has nothing to replay."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -522,3 +522,44 @@ class TestSessionsApi:
         resp = client.delete("/api/sessions/abc")
         assert resp.status_code == 200
         assert calls == [("purge", "abc"), ("remove", "abc")]
+
+
+def test_requirement_statuses(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Per-requirement status flags missing stacks and image-digest mismatches."""
+    from medmcp.workflow import Recipe, RecipeStep, StackRequirement
+
+    recipe = Recipe(
+        name="wf",
+        description="d",
+        inputs=[],
+        steps=[RecipeStep(server="medmcp-neuro", tool="t", arguments={})],
+        requires=[
+            StackRequirement(
+                stack="medmcp-neuro", image="ghcr.io/medmcp/neuro:main", digest="sha256:aaa"
+            ),
+            StackRequirement(stack="medmcp-cardiac", image="ghcr.io/medmcp/cardiac:main"),
+        ],
+    )
+    servers = [
+        {
+            "name": "medmcp-neuro",
+            "command": "docker",
+            "args": ["run", "-i", "ghcr.io/medmcp/neuro:main"],
+        }
+    ]
+
+    def _installed_digest(_image: str) -> str | None:
+        return "sha256:zzz"  # differs from the pinned sha256:aaa
+
+    monkeypatch.setattr(settings, "resolve_image_digest", _installed_digest)
+    by_stack = {s["stack"]: s for s in server._requirement_statuses(recipe, servers)}
+    assert by_stack["medmcp-neuro"]["status"] == "mismatch"
+    assert by_stack["medmcp-neuro"]["installed_digest"] == "sha256:zzz"
+    assert by_stack["medmcp-cardiac"]["status"] == "missing"  # not in servers
+
+    def _matching_digest(_image: str) -> str | None:
+        return "sha256:aaa"  # matches the pin
+
+    monkeypatch.setattr(settings, "resolve_image_digest", _matching_digest)
+    ok = {s["stack"]: s for s in server._requirement_statuses(recipe, servers)}
+    assert ok["medmcp-neuro"]["status"] == "ok"


### PR DESCRIPTION
## Summary
Three workspace UX fixes: an overlaid volume no longer disappears when the viewer panel is resized; deterministic replay now tells you when a workflow's required stacks are missing or a different version than pinned; and multi-input workflows can finally be batched via a table (one row per run, a column per input) instead of the old "batch over a single input" model.

## Related issue
N/A — user-reported UX issues.

## Test plan
- [x] `just check` green — 269 tests, ruff lint/format, pyright strict
- [x] New backend tests: `replay.validate` names the image/version of a missing stack (`test_replay.py`); `server._requirement_statuses` flags `missing` / `mismatch` (digest differs) / `ok` (`test_server.py`)
- [x] Frontend `tsc -b` + eslint clean; `npm run build` bundles
- [x] Live preview on `:8100` (branch overlaid on the running container), on a two-input workflow (`in_1`, `in_2`):
  - Viewer: an overlaid volume is retained across viewer-panel separator drags; opening a different base file still clears it.
  - Requires: the detail returns `requires` with a per-stack status (`ok` here, with `installed_digest` matching the pinned digest — the version check resolves a real local digest); missing/mismatch render as ✗ / ⚠ with a "may not reproduce" warning.
  - Batch: Run → Batch shows a 2-column table; Add from selection groups the selection into rows of N (one per input), so a moving+fixed pair becomes one run; cells also accept a file drag; Preview → Run now executes each row independently.

## Security & data handling
No new tool surface, network calls, or auth/permission changes. Replay remains gated by the existing preview + explicit confirmation. The new requirement-availability check is offline — it reads the digest of an already-present image (`docker inspect`, never a pull) and never raises. `provenance._docker_image_ref` was made public (`docker_image_ref`) so the server can reuse it.

## Notes
- The backend already accepted independent multi-input runs (`/ws/replay` takes `runs: [{in_1, in_2, …}, …]`); this PR only adds the front-end table to build them, and drops the now-unused single-input `batchInput`/`BatchSelection` path.
- Version-mismatch detection uses the image **digest** (the reliable signal for container stacks); `active_servers()` carries no package version, so uv-tool version mismatches aren't detected yet.
- The viewer overlay state moved up to the parent `Viewer` (tagged with its base file) so it survives the deliberate resize-rebuild remount that exists to avoid Niivue's GPU-memory leak on canvas resize.
