### PR TITLE
System-prompt hardening, explanation risk labels, and workspace-note consolidation

### DIFF
--- a/.vibe/prompts/medmcp.md
+++ b/.vibe/prompts/medmcp.md
@@ -1,31 +1,50 @@
 You are MedMCP, an AI assistant for medical imaging workflows.
-You help clinicians, radiologists, and researchers run validated medical imaging
+You help clinicians, radiologists, and researchers to run validated medical image
 analysis pipelines through natural-language instructions.
 
-**Tool results**
-When a tool result contains a `_render` field, follow its instructions exactly to
-produce your response — it contains per-call display rules and a required next action.
-
-**Skills**
-Before starting any task, load the skill that matches the task name
-(e.g. call `skill("explore-data")` before exploring a DICOM directory). Skills are
-named after tasks, not servers. Load a skill once per task type per session.
-If no matching skill exists, proceed without one — do not block or invent skill names.
-Follow the workflow and gotchas in the skill exactly.
+**Scope of use**
+- You run image analysis pipelines and assist users in doing so — you do not provide
+  medical diagnosis, clinical interpretation, or treatment advice.
+- Report tool outputs as results for the responsible clinician to review;
+  leave judgments about what they mean for a patient to that clinician.
 
 **Style**
 - Be concise. Default to 1–3 short sentences for casual questions.
 - Never repeat yourself. If you've made a point, don't restate it.
 - Stop as soon as you've answered. Do not pad with summaries, restatements, or "let me know if…" closers.
 
+**Operational rules**
+- You run entirely on-premise. Never suggest sending data to external services.
+- `web_fetch` is for retrieving public references only — never put patient data, identifiers, or image contents in a web request.
+- Always confirm before executing destructive operations on imaging data.
+- When a tool is unavailable, explain what is missing and how to install it.
+- Prefer composing small, tested tool invocations over monolithic scripts.
+
 **Honesty about capabilities**
 - Describe only the tools and skills that are actually available to you in this session.
 - Do NOT invent, list, or speculate about tools, skills, or features you don't have.
 - If you're unsure whether a capability exists, say so plainly instead of guessing.
-- When the user asks "what can you do" or "what skills do you have", list only your real available tools (e.g. `bash`, `read_file`, `write_file`, `grep`, `todo`, `web_fetch`). Group skills from one MCP server. Do not pad the list.
+- When the user asks "what can you do" or "what skills do you have", list only your real available tools.
+  Group skills/tools from one MCP server. Do not pad the list.
 
-**Operational rules**
-- You run entirely on-premise. Never suggest sending data to external services.
-- Always confirm before executing destructive operations on imaging data.
-- When a tool is unavailable, explain what is missing and how to install it.
-- Prefer composing small, tested tool invocations over monolithic scripts.
+**Workspace features**
+- When asked, you may accurately explain the workspace's own capabilities: activating or installing additional tool **stacks** (which adds their tools), and distilling a session into a reusable **workflow** that can be **replayed** on new data — including in batch — after a preview-and-confirm step.
+- Replay runs the recorded tool steps **without the LLM and without per-call approval**, which is why the user confirms the previewed steps first. Describe this at a high level; don't fabricate specific steps or UI controls — point the user to the workspace UI for the exact buttons.
+
+**Tool results**
+- When a tool result contains a `_render` field, follow its instructions exactly to
+  produce your response — it contains per-call display rules and a required next action.
+
+**Skills**
+- Before starting any task, load the skill that matches the task name.
+- If no matching skill exists, proceed without one — do not block or invent skill names.
+- Follow the workflow and gotchas in the skill exactly.
+
+**Paths**
+- Pass tools **absolute on-disk paths** — the workspace is mounted at that same absolute path, and a relative path will miss. Use the path the user or viewer gave you as-is; don't invent or rewrite it. If you're unsure a path exists, list its directory **once** rather than re-checking before every call.
+
+**Reproducibility**
+- When a stack provides an MCP tool for a task, use it instead of an equivalent
+  shell command: tool calls are recorded and can be replayed or shared as a
+  reusable workflow, whereas ad-hoc `bash` steps cannot be replayed and survive
+  only as manual notes.

--- a/src/medmcp/distill.py
+++ b/src/medmcp/distill.py
@@ -34,6 +34,7 @@ import yaml
 
 from medmcp import provenance
 from medmcp.workflow import Recipe, RecipeStep, StackRequirement, WorkflowInput
+from medmcp.workspace_note import strip_workspace_note
 
 JsonDict = dict[str, Any]
 
@@ -105,25 +106,20 @@ def parse_messages_file(path: Path) -> list[JsonDict]:
     return messages
 
 
-# The workspace server appends a "[workspace context: …]" note to the prompt
-# text so the agent can resolve "this image" (server.py:_workspace_note). That
-# note is live-turn metadata, not part of the user's request — strip it here or
-# it leaks into the distilled workflow's name and description. Keep this in sync
-# with server.py's _WORKSPACE_NOTE_RE.
-_WORKSPACE_NOTE_RE = re.compile(r"\n\n\[workspace context:.*$", re.DOTALL)
-
-
 def _first_user_message(messages: list[JsonDict]) -> str:
     """Return the first non-injected user message, for context/naming.
 
-    The appended workspace-context note is stripped — it would otherwise pollute
-    the distilled workflow's name and description.
+    The workspace server appends a "[workspace context: …]" note to the prompt
+    text so the agent can resolve "this image" (server.py:_workspace_note). That
+    note is live-turn metadata, not part of the user's request, so it is stripped
+    here (via :func:`strip_workspace_note`) — it would otherwise pollute the
+    distilled workflow's name and description.
     """
     for msg in messages:
         if msg.get("role") == "user" and not msg.get("injected"):
             content = msg.get("content")
             if isinstance(content, str) and content.strip():
-                return _WORKSPACE_NOTE_RE.sub("", content).strip()
+                return strip_workspace_note(content)
     return ""
 
 

--- a/src/medmcp/explain.py
+++ b/src/medmcp/explain.py
@@ -87,7 +87,7 @@ async def generate_explanation(tc: JsonDict) -> tuple[str, list[str]] | None:
     if len(raw_input_str) > 400:
         raw_input_str = raw_input_str[:400] + "\n… (truncated)"
 
-    valid_keys = ", ".join(RISK_CATEGORIES)
+    risk_options = "\n".join(f"- {key}: {label}" for key, (label, _) in RISK_CATEGORIES.items())
     prompt = (
         "You are a security-aware assistant helping a physician review an AI action "
         "before it runs on their computer. Your job is to explain what the action does "
@@ -98,8 +98,9 @@ async def generate_explanation(tc: JsonDict) -> tuple[str, list[str]] | None:
         "'filesystem path', 'subprocess', or 'flag' into everyday language "
         "(e.g. 'runs a program', 'opens a file', 'contacts a website').\n"
         "- State what the action will DO and what will CHANGE as a result.\n\n"
-        "Then select every applicable risk from this fixed list (use the exact keys):\n"
-        f"{valid_keys}\n\n"
+        "Then select every applicable risk from this fixed list — output the exact key "
+        "shown before each colon, and pick none if the action is harmless:\n"
+        f"{risk_options}\n\n"
         "Respond with ONLY a JSON object — no markdown fences, no extra text:\n"
         '{"explanation": "<one sentence>", "risks": ["<key>", ...]}\n\n'
         f"Tool: {title}\n"

--- a/src/medmcp/server.py
+++ b/src/medmcp/server.py
@@ -36,7 +36,6 @@ import asyncio
 import contextlib
 import logging
 import os
-import re
 import shutil
 import time
 from collections.abc import AsyncGenerator
@@ -53,6 +52,7 @@ from medmcp import distill, explain, provenance, replay, sessions, settings, sha
 from medmcp.acp import PROJECT_ROOT, VIBE_HOME, JsonDict, VibeAcpClient
 from medmcp.backend_broker import BackendBroker
 from medmcp.backend_pool import BackendPool, BackendSpec
+from medmcp.workspace_note import build_workspace_note, strip_workspace_note
 
 _audit: logging.Logger = logging.getLogger("medmcp.audit")
 log: logging.Logger = logging.getLogger(__name__)
@@ -974,21 +974,13 @@ def _extract_text(content: object) -> str:
     return "\n".join(p for p in parts if p)
 
 
-# The viewer-context note appended to a prompt in _run_prompt. On transcript
-# replay (session/load) the stored user message still carries it, and vibe-acp
-# derives a session's title from that first message too, so we strip it before
-# showing either to the user. The note is always appended last, so we cut from
-# its marker to the end — this also handles a title truncated mid-note (no
-# closing ``]``). The ``\n\n`` anchor avoids touching a bracketed phrase a user
-# happened to type inline. distill.py keeps a copy of this pattern (it strips the
-# note from the request that seeds a distilled workflow's name/description) —
-# keep the two in sync.
-_WORKSPACE_NOTE_RE = re.compile(r"\n\n\[workspace context:.*$", re.DOTALL)
-
-
-def _strip_workspace_note(text: str) -> str:
-    """Remove the appended ``[workspace context: …]`` note from text."""
-    return _WORKSPACE_NOTE_RE.sub("", text).strip()
+# The viewer-context note appended to a prompt in _run_prompt. Its format and the
+# pattern that strips it live in medmcp.workspace_note (shared with distill.py, the
+# other consumer). On transcript replay (session/load) the stored user message
+# still carries the note, and vibe-acp derives a session's title from that first
+# message too, so _strip_workspace_note removes it before showing either to the
+# user.
+_strip_workspace_note = strip_workspace_note
 
 
 def _workspace_note(viewed_path: str) -> str:
@@ -999,13 +991,10 @@ def _workspace_note(viewed_path: str) -> str:
     bind-mounted at the identical absolute path (path parity). Handing the agent
     the **absolute** path lets its first tool call hit; a relative path misses and
     only recovers after the agent searches the filesystem. Resolution mirrors
-    replay's :func:`_resolve_input_path` (an unknown/absolute value is unchanged).
+    replay's :func:`_resolve_input_path` (an unknown/absolute value is unchanged);
+    the note's text format comes from :func:`build_workspace_note`.
     """
-    absolute = _resolve_input_path(viewed_path)
-    return (
-        f'\n\n[workspace context: the file "{absolute}" is currently open in the '
-        'viewer; references like "this image" or "the current image" mean that file]'
-    )
+    return build_workspace_note(_resolve_input_path(viewed_path))
 
 
 class _ChatConnection:

--- a/src/medmcp/workspace_note.py
+++ b/src/medmcp/workspace_note.py
@@ -1,0 +1,42 @@
+"""The viewer "workspace context" note and its inverse.
+
+When a file is open in the viewer, the workspace server appends a
+``[workspace context: …]`` note to the prompt text it sends the agent. The note
+lets the agent resolve references like "this image" *and* hands it the absolute
+on-disk path the stack tools expect (the workspace is bind-mounted at the
+identical absolute path — path parity). The note is live-turn metadata, not part
+of the user's request, so it is stripped wherever the prompt text resurfaces:
+session titles, replayed turns, and workflow distillation.
+
+The note's format (:func:`build_workspace_note`) and the pattern that removes it
+(:func:`strip_workspace_note`) live here together so they stay in sync — they
+were previously duplicated across ``server.py`` and ``distill.py``.
+"""
+
+from __future__ import annotations
+
+import re
+
+# The note is always appended last, separated by a blank line, so the strip
+# pattern cuts from its marker to the end of the text — this also handles a title
+# truncated mid-note (no closing "]"). The "\n\n" anchor avoids touching a
+# bracketed phrase a user happened to type inline.
+_NOTE_RE = re.compile(r"\n\n\[workspace context:.*$", re.DOTALL)
+
+
+def build_workspace_note(absolute_path: str) -> str:
+    """Build the ``[workspace context: …]`` note for the file open in the viewer.
+
+    *absolute_path* must already be resolved to its on-disk absolute path (path
+    parity) — handing the agent the absolute path lets its first tool call hit
+    instead of recovering after a filesystem search.
+    """
+    return (
+        f'\n\n[workspace context: the file "{absolute_path}" is currently open in the '
+        'viewer; references like "this image" or "the current image" mean that file]'
+    )
+
+
+def strip_workspace_note(text: str) -> str:
+    """Remove the appended ``[workspace context: …]`` note from *text*."""
+    return _NOTE_RE.sub("", text).strip()


### PR DESCRIPTION
## Summary
Three small, independent improvements, one per commit: consolidate the duplicated viewer "workspace context" note into a single module, give the permission‑explanation model human‑readable risk labels instead of bare keys, and expand/tighten the MedMCP system prompt.

## Related issue
N/A

## Test plan
- [x] `just check` green — ruff + format‑check + pyright (strict) + 269 tests
- [x] `tests/test_permission_prompt.py` (19) pass; the explanation prompt still contains "physician" and lists every `RISK_CATEGORIES` key
- [x] Workspace‑note consolidation is behavior‑preserving — the note format and strip regex are byte‑identical, now single‑sourced in `medmcp.workspace_note` and imported by `server.py`/`distill.py`
- [x] System‑prompt change is prose‑only (no code paths touched)

## Security & data handling
- **System prompt** adds guardrails (no new agent capability): a clinical scope‑of‑use limit (run pipelines, not diagnosis/interpretation), a PHI note that `web_fetch` is for public references only — never patient data/identifiers, and an absolute‑path rule.
- **explain.py** change is prompt‑text only — the model still emits the exact risk key, so `resolve_risks()` and the JSON output contract are unchanged. No new tool surface, network calls, file‑write paths, or auto‑approval paths.

## Notes
N/A
