### PR TITLE
chore: rename dev container paths to /workspaces/medmcp

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -39,4 +39,4 @@ RUN mkdir -p /usr/libexec/docker/cli-plugins; \
         -o /usr/libexec/docker/cli-plugins/docker-compose; \
     chmod +x /usr/libexec/docker/cli-plugins/docker-compose
 
-WORKDIR /workspaces/medmcp-dev
+WORKDIR /workspaces/medmcp

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,11 @@
 {
-  "name": "medmcp-dev",
+  "name": "medmcp",
   "build": {
     "dockerfile": "Dockerfile",
     "args": { "BASE_IMAGE": "medmcp-base:dev" }
   },
-  "workspaceFolder": "/workspaces/medmcp-dev",
-  "workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/medmcp-dev,type=bind",
+  "workspaceFolder": "/workspaces/medmcp",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/medmcp,type=bind",
   "mounts": [
     "source=${localEnv:XDG_RUNTIME_DIR}/docker.sock,target=/var/run/docker.sock,type=bind"
   ],


### PR DESCRIPTION
## Summary
Follow-up to the `medmcp-dev` → `medmcp` repo rename: updates the dev container's in-container paths so nothing references the old name. With this, `git grep medmcp-dev` is empty across the repo.

## Related issue
N/A

## Test plan
- [x] `devcontainer.json` `name`, `workspaceFolder`, and `workspaceMount` target all use `/workspaces/medmcp`
- [x] `Dockerfile` `WORKDIR` matches `workspaceFolder` (`/workspaces/medmcp`)
- [x] `git grep medmcp-dev` returns nothing across all tracked files

## Security & data handling
N/A — dev container configuration only; no change to the runtime image or the workspace mount semantics.

## Notes
- Purely cosmetic in-container path; existing dev containers will rebuild on next reopen to pick up the new `WORKDIR`/mount target.