### PR TITLE
feat: register medmcp-qc stack in the install catalog

### DIFF
--- a/catalog.ghcr.json
+++ b/catalog.ghcr.json
@@ -30,6 +30,12 @@
       "image": "ghcr.io/medmcp/monai:main",
       "description": "Run pretrained MONAI Model-Zoo bundles (spleen / multi-organ / whole-body CT segmentation).",
       "gpu": true
+    },
+    {
+      "name": "medmcp-qc",
+      "image": "ghcr.io/medmcp/qc:main",
+      "description": "Visual QC reports for segmentations (brain extraction, lesions, tumor, parcellations).",
+      "gpu": false
     }
   ]
 }

--- a/catalog.json
+++ b/catalog.json
@@ -30,6 +30,12 @@
       "image": "medmcp-monai:dev",
       "description": "Run pretrained MONAI Model-Zoo bundles (spleen / multi-organ / whole-body CT segmentation).",
       "gpu": true
+    },
+    {
+      "name": "medmcp-qc",
+      "image": "medmcp-qc:dev",
+      "description": "Visual QC reports for segmentations (brain extraction, lesions, tumor, parcellations).",
+      "gpu": false
     }
   ]
 }


### PR DESCRIPTION
## What

Registers the new **medmcp-qc** stack in the install catalog so it shows in **Settings → Stacks → Available** and installs from the UI.

- `catalog.json` → `medmcp-qc:dev` (local build)
- `catalog.ghcr.json` → `ghcr.io/medmcp/qc:main` (published private GHCR image)
- `gpu: false` — CPU-only stack

## What it is

medmcp-qc renders **visual QC reports for segmentations** (brain extraction, lesions, tumor, parcellations): mask-driven slice selection, crop-to-bbox magnification for small lesions, a self-contained offline HTML report + a machine-readable `qc.json` sidecar. Pure-Python engine (nilearn/matplotlib/nibabel), no GPU.

Repo: `medmcp/medmcp-qc-dev` · image: `ghcr.io/medmcp/qc:main` (Image workflow green; smoke test + label check pass).

## Why no code changes

The install path keys the GPU decision off the image's `org.medmcp.stack` label, not the catalog. The QC image labels `gpu:false`, so `install_stack_image` writes a CPU `docker run -i` manifest (no `--device`) automatically.

## Validation

- `tests/test_stacks_install.py` 14/14 pass
- Against the **real local image**: core reads the label (`name=medmcp-qc, gpu=false, timeout=600`) and writes a correct CPU manifest (no `--device`, image arg resolved)
- `load_catalog()` returns the new entry from both catalogs (6 stacks each)
