### PR TITLE
feat(viewer): render HTML files (QC reports) instead of source

### DIFF
--- a/frontend/src/components/Viewer.tsx
+++ b/frontend/src/components/Viewer.tsx
@@ -151,12 +151,15 @@ function applyViewerSettings(nv: Niivue, s: ViewerSettings): void {
   nv.drawScene()
 }
 
-type FileKind = 'volume' | 'pdf' | 'image' | 'text' | 'other'
+type FileKind = 'volume' | 'pdf' | 'html' | 'image' | 'text' | 'other'
 
 function classify(path: string): FileKind {
   const lower = path.toLowerCase()
   if (VOLUME_EXT.test(lower)) return 'volume'
   if (lower.endsWith('.pdf')) return 'pdf'
+  // Render HTML (e.g. QC reports) rather than showing source — checked before
+  // TEXT_EXT, which also matches .html.
+  if (lower.endsWith('.html') || lower.endsWith('.htm')) return 'html'
   if (IMAGE_EXT.test(lower)) return 'image'
   if (TEXT_EXT.test(lower)) return 'text'
   return 'other'
@@ -667,6 +670,12 @@ export const Viewer = memo(function Viewer({
           </div>
         )}
         {kind === 'pdf' && <iframe className="pdf-frame" src={url} title={path} />}
+        {kind === 'html' && (
+          // Render reports (e.g. the QC report.html) instead of showing source.
+          // sandbox="allow-scripts" runs self-contained inline JS (the QC flicker
+          // toggle) while isolating the frame: no same-origin access, no navigation.
+          <iframe className="html-frame" src={url} title={path} sandbox="allow-scripts" />
+        )}
         {kind === 'image' && <img className="image-view" src={url} alt={path} />}
         {kind === 'text' && <TextView key={url} url={url} />}
         {kind === 'other' && (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -696,7 +696,8 @@ button:hover {
   }
 }
 
-.pdf-frame {
+.pdf-frame,
+.html-frame {
   width: 100%;
   height: 100%;
   border: none;
@@ -717,7 +718,8 @@ button:hover {
 
 /* The PDF iframe only needs to stop painting / swallowing the drag's pointer
  * events; visibility avoids an iframe reload that display:none can trigger. */
-.is-resizing .pdf-frame {
+.is-resizing .pdf-frame,
+.is-resizing .html-frame {
   visibility: hidden;
 }
 


### PR DESCRIPTION
The viewer classified `.html` as text and showed raw source, so the **medmcp-qc `report.html`** (and any HTML report) was unreadable in the UI.

Adds an `html` file kind rendered in a **sandboxed iframe** (`sandbox="allow-scripts"` runs the report's self-contained inline JS — e.g. the QC flicker toggle — while isolating it: no same-origin, no navigation). Mirrors the existing PDF iframe path. The QC report is self-contained (base64-inlined PNGs), so this makes it render as designed.