### PR TITLE
feat: register medmcp-cohort in the install catalog

### DIFF
--- a/catalog.ghcr.json
+++ b/catalog.ghcr.json
@@ -36,6 +36,12 @@
       "image": "ghcr.io/medmcp/qc:main",
       "description": "Visual QC reports for segmentations (brain extraction, lesions, tumor, parcellations).",
       "gpu": false
+    },
+    {
+      "name": "medmcp-cohort",
+      "image": "ghcr.io/medmcp/cohort:main",
+      "description": "Clinical cohort assembly, imaging-biomarker stratification, and association analysis (ehrapy).",
+      "gpu": false
     }
   ]
 }

--- a/catalog.json
+++ b/catalog.json
@@ -36,6 +36,12 @@
       "image": "medmcp-qc:dev",
       "description": "Visual QC reports for segmentations (brain extraction, lesions, tumor, parcellations).",
       "gpu": false
+    },
+    {
+      "name": "medmcp-cohort",
+      "image": "medmcp-cohort:dev",
+      "description": "Clinical cohort assembly, imaging-biomarker stratification, and association analysis (ehrapy).",
+      "gpu": false
     }
   ]
 }


### PR DESCRIPTION
Adds the **medmcp-cohort** stack (CPU-only) to `catalog.json` (`:dev`) and `catalog.ghcr.json` (`ghcr.io/medmcp/cohort:main`) so it appears in Settings → Stacks → Available.

medmcp-cohort = clinical cohort assembly, imaging-biomarker stratification, and association analysis (ehrapy-first AnnData spine; data-driven subject/session id resolution; user-chosen statistical tests). Repo: https://github.com/medmcp/medmcp-cohort (CI green, image published to GHCR).

Validated end-to-end on open data: MSLesSeg (longitudinal, lesion volume ~ EDSS r≈0.31; our volume == authors tabulated r=1.0) and Mendeley MS (near-null, clinico-radiological paradox).