### PR TITLE
chore: point the neuro stack at medmcp-neuro-core

### DIFF
--- a/catalog.ghcr.json
+++ b/catalog.ghcr.json
@@ -8,9 +8,9 @@
       "gpu": false
     },
     {
-      "name": "medmcp-neuro",
-      "image": "ghcr.io/medmcp/neuro:main",
-      "description": "Brain extraction (HD-BET) and image registration (ANTs).",
+      "name": "medmcp-neuro-core",
+      "image": "ghcr.io/medmcp/neuro-core:main",
+      "description": "Brain extraction (HD-BET), image registration (ANTs), and whole-brain segmentation (FastSurfer).",
       "gpu": true
     },
     {

--- a/catalog.json
+++ b/catalog.json
@@ -8,9 +8,9 @@
       "gpu": false
     },
     {
-      "name": "medmcp-neuro",
-      "image": "medmcp-neuro:dev",
-      "description": "Brain extraction (HD-BET) and image registration (ANTs).",
+      "name": "medmcp-neuro-core",
+      "image": "medmcp-neuro-core:dev",
+      "description": "Brain extraction (HD-BET), image registration (ANTs), and whole-brain segmentation (FastSurfer).",
       "gpu": true
     },
     {

--- a/tests/test_neuro_integration.py
+++ b/tests/test_neuro_integration.py
@@ -1,7 +1,7 @@
-"""Integration tests for the medmcp-neuro stack.
+"""Integration tests for the medmcp-neuro-core stack.
 
-These tests require the medmcp-neuro stack to be installed as an isolated uv
-tool (``just install-stack medmcp-neuro``) and are skipped otherwise.
+These tests require the medmcp-neuro-core stack to be installed as an isolated uv
+tool (``just install-stack medmcp-neuro-core``) and are skipped otherwise.
 """
 
 from __future__ import annotations
@@ -14,19 +14,19 @@ import pytest
 
 
 def _neuro_installed() -> bool:
-    """Return True if medmcp-neuro is present in the uv tool store."""
+    """Return True if medmcp-neuro-core is present in the uv tool store."""
     result = subprocess.run(
         ["uv", "tool", "list"],
         capture_output=True,
         text=True,
     )
-    return "medmcp-neuro" in result.stdout
+    return "medmcp-neuro-core" in result.stdout
 
 
 neuro_available = _neuro_installed()
 
 skip_no_neuro = pytest.mark.skipif(
-    not neuro_available, reason="medmcp-neuro not installed via uv tool"
+    not neuro_available, reason="medmcp-neuro-core not installed via uv tool"
 )
 
 JsonDict = dict[str, Any]
@@ -66,16 +66,16 @@ def _write(proc: subprocess.Popen[str], msg: str) -> None:
 
 
 def _neuro_executable() -> str:
-    """Return the absolute path to medmcp-neuro inside its isolated uv tool env."""
+    """Return the absolute path to medmcp-neuro-core inside its isolated uv tool env."""
     from pathlib import Path
 
     result = subprocess.run(["uv", "tool", "dir"], capture_output=True, text=True)
-    candidate = Path(result.stdout.strip()) / "medmcp-neuro" / "bin" / "medmcp-neuro"
-    return str(candidate) if candidate.exists() else "medmcp-neuro"
+    candidate = Path(result.stdout.strip()) / "medmcp-neuro-core" / "bin" / "medmcp-neuro-core"
+    return str(candidate) if candidate.exists() else "medmcp-neuro-core"
 
 
 def _start_server() -> subprocess.Popen[str]:
-    """Spawn the medmcp-neuro MCP server via its isolated uv tool environment."""
+    """Spawn the medmcp-neuro-core MCP server via its isolated uv tool environment."""
     return subprocess.Popen(
         [_neuro_executable()],
         stdin=subprocess.PIPE,
@@ -102,7 +102,7 @@ def _initialize(proc: subprocess.Popen[str]) -> JsonDict:
 
 @skip_no_neuro
 def test_neuro_server_starts() -> None:
-    """The medmcp-neuro MCP server starts and responds to initialize."""
+    """The medmcp-neuro-core MCP server starts and responds to initialize."""
     proc = _start_server()
     try:
         resp = _initialize(proc)
@@ -114,7 +114,7 @@ def test_neuro_server_starts() -> None:
 
 @skip_no_neuro
 def test_neuro_server_exposes_tools() -> None:
-    """The medmcp-neuro MCP server advertises at least one tool via tools/list."""
+    """The medmcp-neuro-core MCP server advertises at least one tool via tools/list."""
     proc = _start_server()
     try:
         _initialize(proc)
@@ -126,7 +126,7 @@ def test_neuro_server_exposes_tools() -> None:
         )
         result_payload: JsonDict = cast("JsonDict", tools_response["result"])
         tools: list[Any] = cast("list[Any]", result_payload.get("tools", []))
-        assert len(tools) > 0, "medmcp-neuro server registered zero tools"
+        assert len(tools) > 0, "medmcp-neuro-core server registered zero tools"
     finally:
         proc.kill()
         proc.wait()


### PR DESCRIPTION
## Summary

The `medmcp-neuro` stack is being renamed to **`medmcp-neuro-core`** (see medmcp-neuro-dev#15). This points the core at the new name: both catalogs and the integration test. The `medmcp-neuro-ms` and `medmcp-neuro-cancer` stacks are deliberately untouched.

## Related issue

Companion to the rename PR in `medmcp-neuro-core` (medmcp-neuro-dev#15).

## Test plan

- [x] `just check` passes (267 passed, 2 skipped — the neuro integration tests, skipped because the stack isn't installed via `uv tool`)
- [x] `catalog.json` / `catalog.ghcr.json` still parse as JSON; only the `medmcp-neuro` entry changed (name + image), `-ms` / `-cancer` left intact
- [x] `tests/test_neuro_integration.py` references the new command name

## Security & data handling

N/A — catalog metadata + a test rename; no new tool surface, network calls, or file-write paths.

## Notes

- Only **tracked** files change. The `stacks.d/*.toml` launch manifests are gitignored and regenerated from the image's `org.medmcp.stack` label at install time, so no manifest edit is needed here.
- **Merge ordering:** land this only after the renamed image is published (`ghcr.io/medmcp/neuro-core:main`), i.e. after medmcp-neuro-dev#15 merges and its Image workflow runs — otherwise `catalog.ghcr.json` points at an image that doesn't exist yet.
- Left as-is (cosmetic, non-functional): `medmcp-neuro` strings used as illustrative names in other tests, docstrings, and docs.
