### PR TITLE
ci: auto-regenerate third-party notices on Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-notices.yml
+++ b/.github/workflows/dependabot-notices.yml
@@ -1,0 +1,61 @@
+name: Dependabot notices
+
+# Dependabot bumps pyproject.toml/uv.lock (and the frontend lockfile) but never
+# regenerates THIRD_PARTY_NOTICES.md, so its PRs land the checked-in notices
+# stale. The CI `notices` job only *detects* that drift; this workflow *fixes*
+# it in place — it regenerates the file on Dependabot PRs and commits the result
+# back onto the PR branch, so the notices are already correct at merge time and
+# no follow-up PR is needed.
+
+on:
+  pull_request:
+    paths:
+      - "uv.lock"
+      - "frontend/package-lock.json"
+
+# Needed to push the regenerated file back to the PR branch. For Dependabot-
+# triggered runs the GITHUB_TOKEN is read-only by default; this block elevates it
+# to contents:write for this same-repo branch.
+permissions:
+  contents: write
+
+jobs:
+  regenerate:
+    # Only Dependabot PRs — human PRs are expected to run `just notices`
+    # themselves (and the CI `notices` job guards that).
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Check out the PR head branch so the regen commit lands on it. A push
+          # made with GITHUB_TOKEN does not re-trigger workflows, so this can't
+          # loop.
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Sync Python runtime deps
+        run: uv sync --no-dev
+      - name: Install frontend deps
+        run: npm ci
+        working-directory: frontend
+      - name: Regenerate third-party notices
+        run: uv run python scripts/gen_third_party_notices.py
+      - name: Commit refreshed notices if changed
+        run: |
+          if git diff --quiet THIRD_PARTY_NOTICES.md; then
+            echo "THIRD_PARTY_NOTICES.md already up to date — nothing to commit."
+            exit 0
+          fi
+          git config user.name "dependabot[bot]"
+          git config user.email "49699333+dependabot[bot]@users.noreply.github.com"
+          git add THIRD_PARTY_NOTICES.md
+          git commit -m "chore: regenerate third-party notices"
+          git push


### PR DESCRIPTION
## Summary
Add a workflow that keeps `THIRD_PARTY_NOTICES.md` in sync on Dependabot PRs. Dependabot bumps `uv.lock`/`frontend/package-lock.json` but never regenerates the derived notices file, so its PRs land it stale (e.g. #57 → the follow-up #77). The existing CI `notices` job only *detects* drift; this workflow *fixes* it in place by regenerating and committing the refreshed file back onto the PR branch, so the notices are already correct at merge time.

## Related issue
Follow-up to #57 / #77. No tracking issue.

## Test plan
- [x] `just notices` regeneration reproduced locally against the bumped lockfiles (basis for #77) — the generator this workflow runs is the same one CI uses
- [x] Workflow YAML validated (`yaml.safe_load`)
- [ ] End-to-end verified on the next Dependabot PR (the trigger cannot fire on this PR — it is gated on `github.actor == dependabot[bot]`)

## Security & data handling
- Runs on Dependabot PRs only (`if: github.actor == 'dependabot[bot]'`) and only when a lockfile changed (`paths:` filter).
- Grants `permissions: contents: write` so it can push the regen commit back to the **same-repo** Dependabot branch. For Dependabot-triggered runs the `GITHUB_TOKEN` is read-only by default and has **no access to secrets**; this block elevates only `contents` for this repo. No other scope is granted.
- It runs `uv sync --no-dev` on the bumped lock (installing the new dependency versions) with that write-scoped token in scope — the same code that runs at image-build/merge time anyway. Blast radius is limited to pushing to this repo; no secrets are exposed.
- A push made with `GITHUB_TOKEN` does not re-trigger workflows, so there is no loop; a later Dependabot rebase re-runs the job and re-applies the regen (self-healing).

## Notes
- Mirrors the toolchain setup of the existing CI `notices` job (checkout@v7, setup-uv@v7, setup-node@v6, `uv sync --no-dev` + `npm ci`).
- If a push is ever rejected with 403, check **Settings → Actions → General → Workflow permissions** is not forcing read-only in a way that blocks per-workflow elevation. The "Allow GitHub Actions to create and approve pull requests" toggle is **not** required (this pushes commits, it does not open/approve PRs).
- Once this is in, the manual #77-style follow-up is no longer needed.