### PR TITLE
fix: hide local model's inline <thought> reasoning from the chat UI

### DIFF
--- a/src/medmcp/reasoning.py
+++ b/src/medmcp/reasoning.py
@@ -1,0 +1,77 @@
+"""Strip a local model's inline chain-of-thought from streamed agent text.
+
+Some locally-served models (e.g. gemma via Ollama) emit their reasoning inside
+``<thought>...</thought>`` spans in the *normal message content* rather than a
+separate reasoning channel (vibe's ``agent_thought_chunk``, fed from a model's
+``reasoning_content`` field). That content is relayed to the UI verbatim, so the
+reasoning leaks into the chat.
+
+:class:`ThoughtStripper` removes those spans from a token stream. It is
+streaming-aware: an opening/closing tag may be split across feeds, so it holds
+back only the shortest possible partial-tag suffix and emits everything else.
+"""
+
+from __future__ import annotations
+
+_OPEN = "<thought>"
+_CLOSE = "</thought>"
+
+
+def _held_tail(buf: str, tag: str) -> int:
+    """Length of the longest suffix of *buf* that is a proper prefix of *tag*.
+
+    That suffix might be the start of a tag split across chunk boundaries, so it
+    must be held back until the next feed rather than emitted.
+    """
+    for k in range(min(len(buf), len(tag) - 1), 0, -1):
+        if buf.endswith(tag[:k]):
+            return k
+    return 0
+
+
+class ThoughtStripper:
+    """Streaming remover of ``<thought>...</thought>`` spans (tags may split across feeds)."""
+
+    def __init__(self) -> None:
+        """Start with an empty buffer, outside any thought span."""
+        self._buf = ""
+        self._in_thought = False
+
+    def feed(self, text: str) -> str:
+        """Consume streamed *text*; return only the portion outside thought spans."""
+        self._buf += text
+        out: list[str] = []
+        while self._buf:
+            if not self._in_thought:
+                i = self._buf.find(_OPEN)
+                if i != -1:
+                    out.append(self._buf[:i])
+                    self._buf = self._buf[i + len(_OPEN) :]
+                    self._in_thought = True
+                    continue
+                k = _held_tail(self._buf, _OPEN)
+                cut = len(self._buf) - k
+                out.append(self._buf[:cut])
+                self._buf = self._buf[cut:]
+                break
+            j = self._buf.find(_CLOSE)
+            if j != -1:
+                self._buf = self._buf[j + len(_CLOSE) :]
+                self._in_thought = False
+                continue
+            k = _held_tail(self._buf, _CLOSE)
+            self._buf = self._buf[len(self._buf) - k :]
+            break
+        return "".join(out)
+
+    def flush(self) -> str:
+        """End of turn: emit any safe remainder (only if outside a thought), then reset."""
+        out = "" if self._in_thought else self._buf
+        self._buf = ""
+        self._in_thought = False
+        return out
+
+    def reset(self) -> None:
+        """Discard any partial state at a turn boundary."""
+        self._buf = ""
+        self._in_thought = False

--- a/src/medmcp/server.py
+++ b/src/medmcp/server.py
@@ -62,6 +62,7 @@ from medmcp import (
 from medmcp.acp import PROJECT_ROOT, VIBE_HOME, JsonDict, VibeAcpClient
 from medmcp.backend_broker import BackendBroker
 from medmcp.backend_pool import BackendPool, BackendSpec
+from medmcp.reasoning import ThoughtStripper
 from medmcp.workspace_note import build_workspace_note, strip_workspace_note
 
 _audit: logging.Logger = logging.getLogger("medmcp.audit")
@@ -1086,6 +1087,10 @@ class _ChatConnection:
         # Tool-call state accumulated across frames, keyed by toolCallId; feeds
         # the permission dialog backfill and the provenance run log.
         self._tool_calls: dict[str, JsonDict] = {}
+        # Strips the local model's inline <thought>…</thought> reasoning out of the
+        # streamed agent text before it reaches the browser (it isn't a separate
+        # ACP thought channel, so without this it renders as normal chat content).
+        self._thoughts = ThoughtStripper()
         # In-flight explanation tasks, kept so they aren't GC'd mid-run.
         self._explain_tasks: set[asyncio.Task[None]] = set()
         self._prompted: bool = False
@@ -1241,6 +1246,7 @@ class _ChatConnection:
             )
         )
         completed = False
+        self._thoughts.reset()  # start each turn with a clean reasoning-strip state
         try:
             while True:
                 get_task: asyncio.Task[JsonDict] = asyncio.create_task(self.queue.get())
@@ -1261,6 +1267,9 @@ class _ChatConnection:
                     err = cast("JsonDict", resp["error"])
                     await self._send({"type": "error", "message": str(err.get("message", err))})
                 break
+            tail = self._thoughts.flush()  # emit any real text held back at a tag boundary
+            if tail:
+                await self._send({"type": "chunk", "text": tail})
             await self._send({"type": "done"})
             completed = True
         except asyncio.CancelledError:
@@ -1336,7 +1345,9 @@ class _ChatConnection:
             if update_type == "agent_message_chunk":
                 content = cast("JsonDict", update.get("content") or {})
                 if content.get("type") == "text":
-                    await self._send({"type": "chunk", "text": str(content.get("text") or "")})
+                    visible = self._thoughts.feed(str(content.get("text") or ""))
+                    if visible:
+                        await self._send({"type": "chunk", "text": visible})
             elif update_type == "user_message_chunk":
                 # Replayed user turns (session/load); live prompts are not echoed.
                 content = cast("JsonDict", update.get("content") or {})

--- a/tests/test_reasoning.py
+++ b/tests/test_reasoning.py
@@ -1,0 +1,61 @@
+"""Tests for the streaming <thought> stripper."""
+
+from __future__ import annotations
+
+from medmcp.reasoning import ThoughtStripper
+
+
+def _stream(chunks: list[str]) -> str:
+    """Feed chunks through a fresh stripper and return the concatenated visible text."""
+    s = ThoughtStripper()
+    out = "".join(s.feed(c) for c in chunks)
+    return out + s.flush()
+
+
+def test_no_thought_passes_through() -> None:
+    """Plain text with no thought span is emitted unchanged."""
+    assert _stream(["Hello ", "world."]) == "Hello world."
+
+
+def test_whole_thought_removed() -> None:
+    """A complete thought span (and its tags) is dropped; surrounding text kept."""
+    assert _stream(["before <thought>secret reasoning</thought> after"]) == "before  after"
+
+
+def test_thought_only_yields_nothing() -> None:
+    """A message that is entirely a thought produces no visible output."""
+    assert _stream(["<thought>all of it</thought>"]) == ""
+
+
+def test_tag_split_across_chunks() -> None:
+    """Open/close tags split across feeds are still recognized and stripped."""
+    assert _stream(["ans<thou", "ght>hidden</thou", "ght>=42"]) == "ans=42"
+
+
+def test_open_tag_char_by_char() -> None:
+    """Feeding one char at a time never leaks a partial tag or thought content."""
+    text = "A<thought>B</thought>C"
+    assert _stream(list(text)) == "AC"
+
+
+def test_multiple_thoughts() -> None:
+    """Several thought spans in one stream are all removed."""
+    assert _stream(["a<thought>x</thought>b<thought>y</thought>c"]) == "abc"
+
+
+def test_unterminated_thought_dropped() -> None:
+    """An unclosed thought at end of turn is dropped, not leaked."""
+    assert _stream(["visible <thought>dangling reasoning that never closes"]) == "visible "
+
+
+def test_trailing_partial_open_is_flushed_as_text() -> None:
+    """A literal '<' tail that never becomes a tag is emitted on flush, not lost."""
+    assert _stream(["done<"]) == "done<"
+
+
+def test_reset_clears_in_thought_state() -> None:
+    """reset() drops a half-open thought so the next turn starts clean."""
+    s = ThoughtStripper()
+    assert s.feed("keep <thought>partial") == "keep "
+    s.reset()
+    assert s.feed("fresh answer") == "fresh answer"


### PR DESCRIPTION
Streaming `ThoughtStripper` removes `<thought>…</thought>` spans (which gemma emits in message content, not vibe's reasoning channel) before the relay forwards them to the UI. Tag-boundary aware; reset per turn; unit-tested (9). Full suite green (283).