### PR TITLE
feat: adopt the vibe 2.23 ACP surface (display content, in-place resume, compaction chains)

### DIFF
--- a/.vibe/config.toml
+++ b/.vibe/config.toml
@@ -134,25 +134,7 @@ denylist = []
 
 [tools.bash]
 permission = "ask"
-allowlist = [
-    "ls",
-    "find",
-    "cat",
-    "head",
-    "tail",
-    "wc",
-    "stat",
-    "file",
-    "pwd",
-    "which",
-    "ps",
-    "du",
-    "df",
-    "echo",
-    "sort",
-    "uniq",
-    "diff",
-]
+allowlist = []
 denylist_standalone = []
 sensitive_patterns = [
     "sudo",

--- a/.vibe/config.toml
+++ b/.vibe/config.toml
@@ -28,6 +28,7 @@ disabled_agents = []
 skill_paths = []
 enabled_skills = []
 disabled_skills = [
+    "skill-creator",
     "vibe",
 ]
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -55,7 +55,7 @@ package dependencies and are attributed in [`NOTICE`](NOTICE) instead.
 | mcp | 1.28.1 | MIT |
 | mdit-py-plugins | 0.5.0 | MIT |
 | mdurl | 0.1.2 | MIT |
-| mistral-vibe | 2.23.2 | Apache-2.0 |
+| mistral-vibe | 2.23.3 | Apache-2.0 |
 | mistralai | 2.6.0 | Apache-2.0 |
 | more-itertools | 11.0.2 | MIT |
 | opentelemetry-api | 1.39.1 | Apache-2.0 |

--- a/docker/config.toml
+++ b/docker/config.toml
@@ -86,38 +86,7 @@ denylist = []
 
 [tools.bash]
 permission = "ask"
-allowlist = [
-    "basename",
-    "cat",
-    "cut",
-    "date",
-    "df",
-    "diff",
-    "dirname",
-    "du",
-    "echo",
-    "file",
-    "find",
-    "fold",
-    "grep",
-    "head",
-    "ls",
-    "md5sum",
-    "nl",
-    "od",
-    "ps",
-    "pwd",
-    "readlink",
-    "sha256sum",
-    "sort",
-    "stat",
-    "tail",
-    "tr",
-    "uname",
-    "uniq",
-    "wc",
-    "which",
-]
+allowlist = []
 denylist_standalone = []
 sensitive_patterns = [
     "sudo",

--- a/docker/config.toml
+++ b/docker/config.toml
@@ -32,7 +32,10 @@ enabled_agents = []
 disabled_agents = []
 skill_paths = []
 enabled_skills = []
-disabled_skills = []
+disabled_skills = [
+    "skill-creator",
+    "vibe",
+]
 applied_migrations = [
     "bash_read_only_defaults_v1",
 ]

--- a/frontend/src/chatSocket.ts
+++ b/frontend/src/chatSocket.ts
@@ -54,10 +54,6 @@ export class ChatSocket {
           this.retryDelay = 1000
           // Reattach to this exact session if the socket later drops.
           this.resumeId = frame.sessionId
-        } else if (frame.type === 'session_migrated') {
-          // The session forked on continue; reconnect to the fork, not the
-          // (now-deleted) original, or a drop would lose the conversation.
-          this.resumeId = frame.sessionId
         }
         this.handlers.onFrame(frame)
       } catch {

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -447,14 +447,6 @@ export const Chat = memo(function Chat({
           // locally in send(), so this only fires during history replay).
           setItems((prev) => [...prev, { kind: 'user', text: frame.text }])
           break
-        case 'session_migrated':
-          // Continuing a resumed chat forked it under a new id; track the fork
-          // so resume (localStorage), the menu highlight, and "Save workflow"
-          // all point at the live, complete transcript.
-          sessionIdRef.current = frame.sessionId
-          onSessionEstablishedRef.current?.(frame.sessionId)
-          onPromptedSessionRef.current?.(frame.sessionId)
-          break
         case 'ready':
           // (Re)connect: the server is the transcript's source of truth — a
           // resume replays history, a reconnect reloads it — so rebuild from

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -186,9 +186,6 @@ export type ChatItem =
 /** Frames the server sends over /ws/chat. */
 export type ServerFrame =
   | { type: 'ready'; sessionId: string; model?: string }
-  // A resumed session that vibe-acp forked under a new id when continued; the
-  // client should track this id for resume, distillation, and reconnect.
-  | { type: 'session_migrated'; sessionId: string }
   | { type: 'chunk'; text: string }
   // Replayed user turn from a resumed session (session/load); live prompts are
   // rendered locally on send and are not echoed by the server.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 keywords = ["medical", "image processing", "ai-agent"]
 requires-python = ">=3.12"
 dependencies = [
-    "mistral-vibe>=2.23.2,<3",
+    "mistral-vibe>=2.23.3,<3",
     "tomli-w>=1.0",
     "pyyaml>=6.0",
     "fastapi>=0.141.1",

--- a/src/medmcp/distill.py
+++ b/src/medmcp/distill.py
@@ -656,20 +656,23 @@ def distill_session(
 ) -> Path:
     """Distill *session_id* into a draft workflow directory and return its path.
 
-    Reads the session's ``messages.jsonl``, builds a parameterized recipe, adds
-    a (hybrid) prose narrative, and writes ``recipe.yaml`` + ``SKILL.md`` into
+    Reads the session's ``messages.jsonl`` — concatenated across the session's
+    compaction chain (vibe rolls a compacted conversation over to a new dir;
+    see :func:`provenance.find_vibe_session_dirs`), so tool calls made after a
+    compaction distill too — builds a parameterized recipe, adds a (hybrid)
+    prose narrative, and writes ``recipe.yaml`` + ``SKILL.md`` into
     ``<workflows_root>/draft/<name>/`` for human review.
 
     Raises ``FileNotFoundError`` if the session's raw log cannot be located.
     """
-    session_dir = provenance.find_vibe_session_dir(session_id)
-    if session_dir is None:
+    session_dirs = provenance.find_vibe_session_dirs(session_id)
+    if not session_dirs:
         raise FileNotFoundError(f"no vibe session log found for session {session_id!r}")
-    messages_path = session_dir / "messages.jsonl"
-    if not messages_path.exists():
-        raise FileNotFoundError(f"no messages.jsonl in {session_dir}")
+    message_paths = [d / "messages.jsonl" for d in session_dirs if (d / "messages.jsonl").exists()]
+    if not message_paths:
+        raise FileNotFoundError(f"no messages.jsonl in {session_dirs[0]}")
 
-    messages = parse_messages_file(messages_path)
+    messages = [m for path in message_paths for m in parse_messages_file(path)]
     manifest = provenance.read_manifest(session_id)
     server_names = (
         [str(s.get("name")) for s in cast("list[JsonDict]", manifest.get("stacks") or [])]

--- a/src/medmcp/distill.py
+++ b/src/medmcp/distill.py
@@ -34,7 +34,7 @@ import yaml
 
 from medmcp import provenance
 from medmcp.workflow import Recipe, RecipeStep, StackRequirement, WorkflowInput
-from medmcp.workspace_note import strip_workspace_note
+from medmcp.workspace_note import display_content_text, strip_workspace_note
 
 JsonDict = dict[str, Any]
 
@@ -109,14 +109,21 @@ def parse_messages_file(path: Path) -> list[JsonDict]:
 def _first_user_message(messages: list[JsonDict]) -> str:
     """Return the first non-injected user message, for context/naming.
 
-    The workspace server appends a "[workspace context: …]" note to the prompt
-    text so the agent can resolve "this image" (server.py:_workspace_note). That
-    note is live-turn metadata, not part of the user's request, so it is stripped
-    here (via :func:`strip_workspace_note`) — it would otherwise pollute the
-    distilled workflow's name and description.
+    The workspace server sends a "[workspace context: …]" note with the prompt
+    so the agent can resolve "this image" (server.py:_workspace_note). That note
+    is live-turn metadata, not part of the user's request — it would otherwise
+    pollute the distilled workflow's name and description. vibe ≥2.23 persists
+    the note-free text on the message (``user_display_content``), which is
+    preferred; older transcripts fall back to stripping the note from the stored
+    text (via :func:`strip_workspace_note`).
     """
     for msg in messages:
         if msg.get("role") == "user" and not msg.get("injected"):
+            display = msg.get("user_display_content")
+            if isinstance(display, dict):
+                text = display_content_text(cast("JsonDict", display))
+                if text:
+                    return text
             content = msg.get("content")
             if isinstance(content, str) and content.strip():
                 return strip_workspace_note(content)

--- a/src/medmcp/provenance.py
+++ b/src/medmcp/provenance.py
@@ -308,6 +308,17 @@ def record_tool_event(session_id: str, tc_id: str, info: JsonDict, server_names:
 # ── Vibe session lookup ──────────────────────────────────────────────────────
 
 
+def _read_session_meta(session_dir: Path) -> JsonDict | None:
+    """Read a vibe session dir's ``meta.json``, or ``None`` if absent/invalid."""
+    meta = session_dir / "meta.json"
+    if not meta.exists():
+        return None
+    try:
+        return cast("JsonDict", json.loads(meta.read_text()))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
 def find_vibe_session_dir(session_id: str) -> Path | None:
     """Locate vibe-acp's log dir for *session_id* under ``.vibe/logs/session/``.
 
@@ -320,17 +331,51 @@ def find_vibe_session_dir(session_id: str) -> Path | None:
     short = session_id[:8]
     candidates = sorted(sessions_root.glob(f"session_*_{short}"))
     for candidate in candidates:
-        meta = candidate / "meta.json"
-        if not meta.exists():
-            continue
-        try:
-            data = cast("JsonDict", json.loads(meta.read_text()))
-        except (json.JSONDecodeError, OSError):
+        data = _read_session_meta(candidate)
+        if data is None:
             continue
         if data.get("session_id") == session_id:
             return candidate
     # Fall back to the single prefix match even without a meta confirmation.
     return candidates[0] if candidates else None
+
+
+def find_vibe_session_dirs(session_id: str) -> list[Path]:
+    """Locate *session_id*'s log dir plus its compaction continuations, in order.
+
+    On context compaction vibe rolls the conversation over to a fresh session id
+    and dir, recording the predecessor as ``parent_session_id`` in the new dir's
+    ``meta.json``. Following those backlinks (vibe ≥2.21 writes them) yields the
+    whole chain — original first, then each continuation in creation order — so
+    purge and distillation see one chat, not just its pre-compaction prefix.
+    """
+    root = find_vibe_session_dir(session_id)
+    if root is None:
+        return []
+    sessions_root = VIBE_HOME / "logs" / "session"
+    # One scan builds the parent → children map; session counts are small.
+    children: dict[str, list[tuple[Path, str]]] = {}
+    for candidate in sorted(sessions_root.iterdir()):
+        if not candidate.is_dir():
+            continue
+        data = _read_session_meta(candidate)
+        if data is None:
+            continue
+        child_id = data.get("session_id")
+        parent_id = data.get("parent_session_id")
+        if isinstance(child_id, str) and isinstance(parent_id, str) and parent_id:
+            children.setdefault(parent_id, []).append((candidate, child_id))
+    chain: list[Path] = [root]
+    queue: list[str] = [session_id]
+    seen: set[str] = {session_id}
+    while queue:
+        for child_dir, child_id in children.get(queue.pop(0), []):
+            if child_id in seen:  # defensive: malformed metas must not loop
+                continue
+            seen.add(child_id)
+            chain.append(child_dir)
+            queue.append(child_id)
+    return chain
 
 
 def list_provenance_sessions() -> list[str]:
@@ -361,43 +406,16 @@ def purge_orphans(referenced_ids: set[str]) -> list[str]:
 def purge_session(session_id: str) -> None:
     """Delete all on-disk logs for *session_id*.
 
-    Removes both the provenance directory and vibe-acp's session transcript dir,
-    so deleting a chat leaves nothing orphaned on disk. Best-effort: missing
-    paths are ignored.
+    Removes the provenance directory and every vibe transcript dir in the
+    session's chain (the original plus compaction continuations, see
+    :func:`find_vibe_session_dirs`), so deleting a chat leaves nothing orphaned
+    on disk. Best-effort: missing paths are ignored.
     """
     pdir = provenance_dir(session_id)
     if pdir.exists():
         shutil.rmtree(pdir, ignore_errors=True)
-    delete_vibe_transcript(session_id)
-
-
-def delete_vibe_transcript(session_id: str) -> None:
-    """Delete only vibe-acp's transcript dir for *session_id* (keep provenance).
-
-    Used to retire a session that a fork has superseded: when continuing a
-    reloaded chat, vibe-acp logs under a new id, leaving the original transcript
-    a stale duplicate. Removing it drops the duplicate from vibe's session list
-    while the provenance is relocated to the fork via :func:`move_session_record`.
-    """
-    vibe_dir = find_vibe_session_dir(session_id)
-    if vibe_dir is not None and vibe_dir.exists():
+    for vibe_dir in find_vibe_session_dirs(session_id):
         shutil.rmtree(vibe_dir, ignore_errors=True)
-
-
-def move_session_record(old_id: str, new_id: str) -> None:
-    """Relocate the provenance record from *old_id* to *new_id* (best-effort).
-
-    No-op if the source is absent; if the destination already exists the source
-    is left untouched rather than clobbering it.
-    """
-    src = provenance_dir(old_id)
-    if not src.exists():
-        return
-    dst = provenance_dir(new_id)
-    if dst.exists():
-        return
-    dst.parent.mkdir(parents=True, exist_ok=True)
-    shutil.move(str(src), str(dst))
 
 
 # ── Human-readable report ────────────────────────────────────────────────────

--- a/src/medmcp/server.py
+++ b/src/medmcp/server.py
@@ -63,7 +63,7 @@ from medmcp.acp import PROJECT_ROOT, VIBE_HOME, JsonDict, VibeAcpClient
 from medmcp.backend_broker import BackendBroker
 from medmcp.backend_pool import BackendPool, BackendSpec
 from medmcp.reasoning import ThoughtStripper
-from medmcp.workspace_note import build_workspace_note, strip_workspace_note
+from medmcp.workspace_note import build_workspace_note, display_content_text, strip_workspace_note
 
 _audit: logging.Logger = logging.getLogger("medmcp.audit")
 log: logging.Logger = logging.getLogger(__name__)
@@ -1048,12 +1048,7 @@ def _replayed_user_text(update: JsonDict) -> str:
     if isinstance(meta, dict):
         display = cast("JsonDict", meta).get("user_display_content")
         if isinstance(display, dict):
-            parts = [
-                str(cast("JsonDict", block).get("text") or "")
-                for block in cast("list[object]", cast("JsonDict", display).get("content") or [])
-                if isinstance(block, dict) and cast("JsonDict", block).get("type") == "text"
-            ]
-            text = "\n\n".join(p for p in parts if p)
+            text = display_content_text(cast("JsonDict", display))
             if text:
                 return text
     content = cast("JsonDict", update.get("content") or {})
@@ -1639,6 +1634,12 @@ async def archive_session(session_id: str, payload: ArchiveSessionPayload) -> Js
 @app.delete("/api/sessions/{session_id}")
 async def delete_session(session_id: str) -> JsonDict:
     """Delete a session for good: its transcript, provenance, and UI metadata."""
+    # Let vibe drop the session first (ext method, vibe ≥2.23: closes a live
+    # attachment and deletes its stored copy) so a running agent's session list
+    # doesn't go stale. Best-effort — the purge below sweeps whatever remains on
+    # disk (provenance plus any compaction continuations) either way.
+    with contextlib.suppress(Exception):
+        await _client.request("session/delete", {"sessionId": session_id})
 
     def _delete() -> None:
         provenance.purge_session(session_id)

--- a/src/medmcp/server.py
+++ b/src/medmcp/server.py
@@ -1029,13 +1029,49 @@ def _extract_text(content: object) -> str:
     return "\n".join(p for p in parts if p)
 
 
-# The viewer-context note appended to a prompt in _run_prompt. Its format and the
+# The viewer-context note sent with a prompt in _run_prompt. Its format and the
 # pattern that strips it live in medmcp.workspace_note (shared with distill.py, the
-# other consumer). On transcript replay (session/load) the stored user message
-# still carries the note, and vibe-acp derives a session's title from that first
-# message too, so _strip_workspace_note removes it before showing either to the
-# user.
+# other consumer). Turns sent by vibe ≥2.23 replay with the note-free text in the
+# frame's user_display_content meta; older transcripts (and titles derived from
+# the stored text) still need _strip_workspace_note.
 _strip_workspace_note = strip_workspace_note
+
+
+def _replayed_user_text(update: JsonDict) -> str:
+    """Extract the display text for a replayed ``user_message_chunk`` frame.
+
+    Prefers the ``user_display_content`` meta (vibe ≥2.23 echoes back the
+    note-free text we sent with the prompt); falls back to stripping the
+    workspace note from the stored message text for older transcripts.
+    """
+    meta = update.get("_meta")
+    if isinstance(meta, dict):
+        display = cast("JsonDict", meta).get("user_display_content")
+        if isinstance(display, dict):
+            parts = [
+                str(cast("JsonDict", block).get("text") or "")
+                for block in cast("list[object]", cast("JsonDict", display).get("content") or [])
+                if isinstance(block, dict) and cast("JsonDict", block).get("type") == "text"
+            ]
+            text = "\n\n".join(p for p in parts if p)
+            if text:
+                return text
+    content = cast("JsonDict", update.get("content") or {})
+    if content.get("type") != "text":
+        return ""
+    return _strip_workspace_note(str(content.get("text") or ""))
+
+
+def _visible_permission_options(options: list[JsonDict]) -> list[JsonDict]:
+    """Drop permission options that would create a durable auto-approval.
+
+    vibe ≥2.23 offers ``allow_always_permanent`` ("Always allow"), which
+    persists the approval into ``.vibe/config.toml`` — every future call of
+    that tool would then bypass the permission flow entirely. medmcp's posture
+    is interactive gating only, so the option is never shown to the browser
+    (per-session "allow always" remains available).
+    """
+    return [o for o in options if o.get("optionId") != "allow_always_permanent"]
 
 
 def _workspace_note(viewed_path: str) -> str:
@@ -1077,11 +1113,6 @@ class _ChatConnection:
         self.queue = queue
         self.servers = servers
         self._resumed = resumed
-        # Fork tracking: continuing a resumed session makes vibe-acp log under a
-        # new id (see _maybe_adopt_fork). `_known_ids` is the session set snapshot
-        # before the first continued turn; `_fork` is the adopted new id, if any.
-        self._known_ids: set[str] | None = None
-        self._fork: str | None = None
         self._pending_perms: dict[int, asyncio.Future[str | None]] = {}
         self._prompt_task: asyncio.Task[None] | None = None
         # Tool-call state accumulated across frames, keyed by toolCallId; feeds
@@ -1138,12 +1169,6 @@ class _ChatConnection:
         if not self._prompted and not self._resumed:
             with contextlib.suppress(Exception):
                 await asyncio.to_thread(provenance.purge_session, self.session_id)
-        elif self._fork is not None:
-            # The continuation was logged under the fork (the live transcript);
-            # move our provenance record onto it so the record and transcript
-            # live under one id.
-            with contextlib.suppress(Exception):
-                await asyncio.to_thread(provenance.move_session_record, self.session_id, self._fork)
 
     async def _cancel_prompt(self) -> None:
         """Cancel the running prompt task and tell vibe-acp to abort its loop."""
@@ -1202,11 +1227,12 @@ class _ChatConnection:
         """Send one ``session/prompt`` and stream its frames to the browser.
 
         ``viewed_path`` is the workspace-relative file currently open in the
-        viewer; it is resolved to its absolute on-disk path and appended to the
-        prompt as a context note (see :func:`_workspace_note`) so the agent can
+        viewer; it is resolved to its absolute on-disk path and sent as a
+        context-note content block (see :func:`_workspace_note`) so the agent can
         resolve references like "this image" *and* pass the path the stack tools
-        expect. Appended to the user's text block (not sent as a separate content
-        block) so it survives any prompt handling downstream.
+        expect. The block's ``automatic`` meta keeps it out of vibe's auto-title
+        derivation, and the prompt's ``user_display_content`` meta records the
+        note-free text vibe echoes back on transcript replay.
 
         Race loop: wait for either the next inbound session frame or the
         prompt response, then drain whatever is left in the queue once the
@@ -1223,29 +1249,38 @@ class _ChatConnection:
                             model_name=settings.OLLAMA_MODEL,
                         )
                     )
-        # Snapshot the existing session set before the first continued turn of a
-        # resumed session: vibe-acp logs the continuation under a fresh id, which
-        # _maybe_adopt_fork spots as the one new id afterwards.
-        if self._resumed and self._fork is None and self._known_ids is None:
-            with contextlib.suppress(Exception):
-                self._known_ids = await self._list_session_ids()
         # Frames can still trickle in between a cancel and this prompt
         # (vibe-acp processes session/cancel asynchronously); drop them now so
         # the old turn can't bleed into this one.
         await self._drain_stale_frames()
-        prompt_text = text
+        params: JsonDict = {
+            "session_id": self.session_id,
+            "prompt": [{"type": "text", "text": text}],
+        }
         if viewed_path is not None:
-            prompt_text += _workspace_note(viewed_path)
-        prompt_fut = asyncio.create_task(
-            _client.request(
-                "session/prompt",
+            # The note rides as its own content block flagged `automatic`: vibe
+            # orders it after the user's text and keeps it out of auto-title
+            # derivation. lstrip() because vibe joins blocks with a blank line —
+            # the persisted text stays byte-identical to the old appended format,
+            # so strip_workspace_note keeps working on every transcript vintage.
+            cast("list[JsonDict]", params["prompt"]).append(
                 {
-                    "session_id": self.session_id,
-                    "prompt": [{"type": "text", "text": prompt_text}],
-                },
+                    "type": "text",
+                    "text": _workspace_note(viewed_path).lstrip(),
+                    "_meta": {"automatic": True},
+                }
             )
-        )
-        completed = False
+            # user_display_content is persisted with the turn and echoed back in
+            # replayed user_message_chunk frames, so resumed transcripts show the
+            # user's text without the note (no stripping needed on that path).
+            params["_meta"] = {
+                "user_display_content": {
+                    "version": "1",
+                    "host": "medmcp",
+                    "content": [{"type": "text", "text": text}],
+                }
+            }
+        prompt_fut = asyncio.create_task(_client.request("session/prompt", params))
         self._thoughts.reset()  # start each turn with a clean reasoning-strip state
         try:
             while True:
@@ -1271,7 +1306,6 @@ class _ChatConnection:
             if tail:
                 await self._send({"type": "chunk", "text": tail})
             await self._send({"type": "done"})
-            completed = True
         except asyncio.CancelledError:
             # Deliberately no `done` frame: when a new prompt superseded this
             # one, a stale done would reset the client's busy/permission state
@@ -1287,48 +1321,6 @@ class _ChatConnection:
                 await _client.notify("session/cancel", {"session_id": self.session_id})
             await self._send({"type": "error", "message": str(exc)})
             await self._send({"type": "done"})
-        if completed and self._resumed and self._fork is None:
-            with contextlib.suppress(Exception):
-                await self._maybe_adopt_fork()
-
-    async def _list_session_ids(self) -> set[str]:
-        """Return the set of session ids vibe-acp currently knows for this workspace."""
-        resp = await _client.request("session/list", {"cwd": str(WORKSPACE_ROOT)})
-        result = cast("JsonDict", resp.get("result") or {})
-        ids: set[str] = set()
-        for s in cast("list[JsonDict]", result.get("sessions") or []):
-            sid = s.get("sessionId") or s.get("session_id")
-            if isinstance(sid, str) and sid:
-                ids.add(sid)
-        return ids
-
-    async def _maybe_adopt_fork(self) -> None:
-        """Adopt the new session vibe-acp creates when a resumed chat is continued.
-
-        ``session/load`` logs continuations under a fresh id (the loaded session
-        is left a stale duplicate), so once exactly one new id appears we retire
-        the original transcript and point the browser at the fork. The provenance
-        record is moved onto the fork on close (see :meth:`close`).
-        """
-        if self._known_ids is None:
-            return
-        # vibe writes the fork's transcript as the turn finishes, which can lag
-        # the prompt response by a beat, so poll briefly for the one new id.
-        fork: str | None = None
-        for _ in range(6):
-            new = await self._list_session_ids() - self._known_ids - {self.session_id}
-            if len(new) == 1:
-                fork = next(iter(new))
-                break
-            if len(new) > 1:
-                return  # ambiguous (concurrent session activity) — don't guess
-            await asyncio.sleep(0.3)
-        if fork is None:
-            return  # no fork — vibe appended in place, nothing to reconcile
-        self._fork = fork
-        # Retire the original transcript so the chat shows up once, as the fork.
-        await asyncio.to_thread(provenance.delete_vibe_transcript, self.session_id)
-        await self._send({"type": "session_migrated", "sessionId": fork})
 
     async def _forward_frame(self, msg: JsonDict, *, replay: bool = False) -> None:
         """Translate one inbound vibe-acp frame into a browser message.
@@ -1350,11 +1342,9 @@ class _ChatConnection:
                         await self._send({"type": "chunk", "text": visible})
             elif update_type == "user_message_chunk":
                 # Replayed user turns (session/load); live prompts are not echoed.
-                content = cast("JsonDict", update.get("content") or {})
-                if content.get("type") == "text":
-                    text = _strip_workspace_note(str(content.get("text") or ""))
-                    if text:
-                        await self._send({"type": "user", "text": text})
+                text = _replayed_user_text(update)
+                if text:
+                    await self._send({"type": "user", "text": text})
             elif update_type == "tool_call":
                 tc_id = str(update.get("toolCallId") or "")
                 title = str(update.get("title") or "tool")
@@ -1417,11 +1407,17 @@ class _ChatConnection:
             elif update_type == "usage_update":
                 used = update.get("used")
                 if isinstance(used, int):
-                    # No-I/O accessor: an inline fetch_context_window() here
-                    # would stall the relay of every queued frame behind an
-                    # Ollama round-trip. The cache is warmed at connect time
-                    # in ws_chat.
-                    size = settings.cached_context_window()
+                    # vibe ≥2.23 reports the model's context window on the frame;
+                    # fall back to the cached Ollama fetch (a no-I/O accessor: an
+                    # inline fetch_context_window() here would stall the relay of
+                    # every queued frame behind an Ollama round-trip; the cache is
+                    # warmed at connect time in ws_chat).
+                    size_raw = update.get("size")
+                    size = (
+                        size_raw
+                        if isinstance(size_raw, int) and size_raw > 0
+                        else settings.cached_context_window()
+                    )
                     await self._send({"type": "usage", "used": used, "size": size})
         elif method == "session/request_permission":
             await self._handle_permission(msg)
@@ -1441,7 +1437,7 @@ class _ChatConnection:
             return
         params = cast("JsonDict", msg.get("params") or {})
         tool_call: JsonDict = dict(cast("JsonDict", params.get("toolCall") or {}))
-        options = cast("list[JsonDict]", params.get("options") or [])
+        options = _visible_permission_options(cast("list[JsonDict]", params.get("options") or []))
         tc_id = str(tool_call.get("toolCallId") or "")
         cached = self._tool_calls.get(tc_id, {})
         for key in ("title", "rawInput", "humanReadable", "risks"):
@@ -1616,6 +1612,14 @@ class RenameSessionPayload(BaseModel):
 async def rename_session(session_id: str, payload: RenameSessionPayload) -> JsonDict:
     """Set (or clear, when blank) the user title override for a session."""
     await asyncio.to_thread(sessions.set_title, session_id, payload.title)
+    # Write the title through to vibe's own session metadata (ext method, vibe
+    # ≥2.23) so it also shows up wherever vibe surfaces the session. Best-effort:
+    # the registry override above is what the UI reads, and vibe may not be
+    # running (it starts lazily with the first chat socket).
+    title = payload.title.strip()
+    if title:
+        with contextlib.suppress(Exception):
+            await _client.request("session/set_title", {"sessionId": session_id, "title": title})
     return {"ok": True}
 
 

--- a/src/medmcp/server.py
+++ b/src/medmcp/server.py
@@ -1057,6 +1057,25 @@ def _replayed_user_text(update: JsonDict) -> str:
     return _strip_workspace_note(str(content.get("text") or ""))
 
 
+def _usage_window(update: JsonDict) -> int:
+    """Pick the context-window size for a usage frame (no I/O).
+
+    Ollama's ``num_ctx`` is the deployment truth, so the fetched value wins
+    (vibe's ``size`` comes from its model registry — e.g. 200k for a Gemma
+    served with a 131072 window). The frame's size only stands in before the
+    first successful fetch, ahead of the static default. Never an inline
+    fetch here: it would stall the relay of every queued frame behind an
+    Ollama round-trip; the cache is warmed at connect time in ws_chat.
+    """
+    fetched = settings.fetched_context_window()
+    if fetched is not None:
+        return fetched
+    size_raw = update.get("size")
+    if isinstance(size_raw, int) and size_raw > 0:
+        return size_raw
+    return settings.cached_context_window()
+
+
 def _visible_permission_options(options: list[JsonDict]) -> list[JsonDict]:
     """Drop permission options that would create a durable auto-approval.
 
@@ -1108,6 +1127,8 @@ class _ChatConnection:
         self.queue = queue
         self.servers = servers
         self._resumed = resumed
+        # Relays unsolicited frames before the first prompt (see start_idle_pump).
+        self._idle_pump: asyncio.Task[None] | None = None
         self._pending_perms: dict[int, asyncio.Future[str | None]] = {}
         self._prompt_task: asyncio.Task[None] | None = None
         # Tool-call state accumulated across frames, keyed by toolCallId; feeds
@@ -1132,6 +1153,8 @@ class _ChatConnection:
                     continue
                 viewed = data.get("viewedPath")
                 viewed_path = viewed if isinstance(viewed, str) and viewed else None
+                # The warm-up pump must not race the turn loop for the queue.
+                await self._stop_idle_pump()
                 # A new prompt while one is streaming cancels the old one.
                 await self._cancel_prompt()
                 self._prompt_task = asyncio.create_task(self._run_prompt(text, viewed_path))
@@ -1143,6 +1166,7 @@ class _ChatConnection:
                         option_id = data.get("optionId")
                         fut.set_result(option_id if isinstance(option_id, str) else None)
             elif kind == "cancel":
+                await self._stop_idle_pump()
                 await self._cancel_prompt()
                 # A cancelled task no longer emits its own `done` (a stale one
                 # would clobber a newer turn's state), so an intentional Stop
@@ -1157,6 +1181,7 @@ class _ChatConnection:
         resumed session is never purged on close — it already has history the
         user came back to view.
         """
+        await self._stop_idle_pump()
         await self._cancel_prompt()
         for task in list(self._explain_tasks):
             task.cancel()
@@ -1217,6 +1242,32 @@ class _ChatConnection:
             except asyncio.QueueEmpty:
                 break
             await self._forward_frame(msg, replay=True)
+
+    def start_idle_pump(self) -> None:
+        """Relay unsolicited frames until the first prompt arrives.
+
+        vibe ≥2.21 pushes messages outside any turn — MCP discovery-failure and
+        OAuth notices on session warm-up, plus (on resume) frames landing after
+        ``replay_history``'s non-blocking drain. Without a pump they would sit
+        in the queue until the first prompt, where ``_drain_stale_frames``
+        discards them. The pump stops at the first prompt (or Stop) and never
+        restarts: between turns the queue must stay drainable, because frames
+        trickling in after a cancel belong to the dead turn and must not be
+        relayed as fresh output.
+        """
+        self._idle_pump = asyncio.create_task(self._pump_frames())
+
+    async def _pump_frames(self) -> None:
+        while True:
+            await self._forward_frame(await self.queue.get())
+
+    async def _stop_idle_pump(self) -> None:
+        task = self._idle_pump
+        self._idle_pump = None
+        if task is not None and not task.done():
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
 
     async def _run_prompt(self, text: str, viewed_path: str | None = None) -> None:
         """Send one ``session/prompt`` and stream its frames to the browser.
@@ -1402,18 +1453,7 @@ class _ChatConnection:
             elif update_type == "usage_update":
                 used = update.get("used")
                 if isinstance(used, int):
-                    # vibe ≥2.23 reports the model's context window on the frame;
-                    # fall back to the cached Ollama fetch (a no-I/O accessor: an
-                    # inline fetch_context_window() here would stall the relay of
-                    # every queued frame behind an Ollama round-trip; the cache is
-                    # warmed at connect time in ws_chat).
-                    size_raw = update.get("size")
-                    size = (
-                        size_raw
-                        if isinstance(size_raw, int) and size_raw > 0
-                        else settings.cached_context_window()
-                    )
-                    await self._send({"type": "usage", "used": used, "size": size})
+                    await self._send({"type": "usage", "used": used, "size": _usage_window(update)})
         elif method == "session/request_permission":
             await self._handle_permission(msg)
 
@@ -1726,6 +1766,7 @@ async def ws_chat(ws: WebSocket, resume: str | None = None) -> None:
         )
         if replayed:
             await conn.replay_history()
+        conn.start_idle_pump()
         await conn.run()
     except WebSocketDisconnect:
         pass

--- a/src/medmcp/server.py
+++ b/src/medmcp/server.py
@@ -1608,13 +1608,14 @@ async def rename_session(session_id: str, payload: RenameSessionPayload) -> Json
     """Set (or clear, when blank) the user title override for a session."""
     await asyncio.to_thread(sessions.set_title, session_id, payload.title)
     # Write the title through to vibe's own session metadata (ext method, vibe
-    # ≥2.23) so it also shows up wherever vibe surfaces the session. Best-effort:
-    # the registry override above is what the UI reads, and vibe may not be
-    # running (it starts lazily with the first chat socket).
+    # ≥2.23; ACP extension methods are underscore-prefixed on the wire) so it
+    # also shows up wherever vibe surfaces the session. Best-effort: the registry
+    # override above is what the UI reads, and vibe may not be running (it
+    # starts lazily with the first chat socket).
     title = payload.title.strip()
     if title:
         with contextlib.suppress(Exception):
-            await _client.request("session/set_title", {"sessionId": session_id, "title": title})
+            await _client.request("_session/set_title", {"sessionId": session_id, "title": title})
     return {"ok": True}
 
 
@@ -1639,7 +1640,7 @@ async def delete_session(session_id: str) -> JsonDict:
     # doesn't go stale. Best-effort — the purge below sweeps whatever remains on
     # disk (provenance plus any compaction continuations) either way.
     with contextlib.suppress(Exception):
-        await _client.request("session/delete", {"sessionId": session_id})
+        await _client.request("_session/delete", {"sessionId": session_id})
 
     def _delete() -> None:
         provenance.purge_session(session_id)

--- a/src/medmcp/settings.py
+++ b/src/medmcp/settings.py
@@ -110,6 +110,16 @@ def cached_context_window() -> int:
     )
 
 
+def fetched_context_window() -> int | None:
+    """Return the Ollama-fetched window size, or ``None`` when not yet fetched (no I/O).
+
+    Unlike :func:`cached_context_window` this does not substitute the static
+    default, so callers with a better fallback (e.g. the size vibe reports on a
+    usage frame) can tell "known" from "guessed".
+    """
+    return _context_window_tokens
+
+
 # Tracks which discovered stacks are enabled; defaults to all when absent.
 ACTIVE_STACKS_PATH: Path = VIBE_HOME / "active_stacks.json"
 # Tracks which personal workflows are enabled (loaded as skills); all when absent.

--- a/src/medmcp/workspace_note.py
+++ b/src/medmcp/workspace_note.py
@@ -1,12 +1,15 @@
 """The viewer "workspace context" note and its inverse.
 
-When a file is open in the viewer, the workspace server appends a
-``[workspace context: …]`` note to the prompt text it sends the agent. The note
+When a file is open in the viewer, the workspace server sends a
+``[workspace context: …]`` note with the prompt (as a content block flagged
+``automatic``, which vibe ≥2.23 keeps out of auto-title derivation). The note
 lets the agent resolve references like "this image" *and* hands it the absolute
 on-disk path the stack tools expect (the workspace is bind-mounted at the
 identical absolute path — path parity). The note is live-turn metadata, not part
-of the user's request, so it is stripped wherever the prompt text resurfaces:
-session titles, replayed turns, and workflow distillation.
+of the user's request: replayed turns carry the note-free text natively (the
+prompt's ``user_display_content`` meta), while the persisted prompt text still
+contains the note, so :func:`strip_workspace_note` remains the fallback for
+pre-2.23 transcripts and for distillation's seed request.
 
 The note's format (:func:`build_workspace_note`) and the pattern that removes it
 (:func:`strip_workspace_note`) live here together so they stay in sync — they

--- a/src/medmcp/workspace_note.py
+++ b/src/medmcp/workspace_note.py
@@ -19,6 +19,7 @@ were previously duplicated across ``server.py`` and ``distill.py``.
 from __future__ import annotations
 
 import re
+from typing import Any, cast
 
 # The note is always appended last, separated by a blank line, so the strip
 # pattern cuts from its marker to the end of the text — this also handles a title
@@ -43,3 +44,23 @@ def build_workspace_note(absolute_path: str) -> str:
 def strip_workspace_note(text: str) -> str:
     """Remove the appended ``[workspace context: …]`` note from *text*."""
     return _NOTE_RE.sub("", text).strip()
+
+
+def display_content_text(display: dict[str, Any]) -> str:
+    """Join the text blocks of a ``user_display_content`` payload (``""`` if none).
+
+    The payload is the ``{version, host, content: [...]}`` dict the server sends
+    with a prompt; vibe persists it on the user message and echoes it in replayed
+    ``user_message_chunk`` frames, so both the server (replay) and distillation
+    (the seed request) can recover the note-free user text from it.
+    """
+    blocks = display.get("content")
+    if not isinstance(blocks, list):
+        return ""
+    parts: list[str] = []
+    for block in cast("list[object]", blocks):
+        if isinstance(block, dict):
+            b = cast("dict[str, Any]", block)
+            if b.get("type") == "text":
+                parts.append(str(b.get("text") or ""))
+    return "\n\n".join(p for p in parts if p).strip()

--- a/tests/test_distill.py
+++ b/tests/test_distill.py
@@ -249,6 +249,37 @@ class TestFirstUserMessage:
         """A message with no note is returned, trimmed."""
         assert distill._first_user_message([{"role": "user", "content": "  do it  "}]) == "do it"
 
+    def test_prefers_persisted_display_content(self) -> None:
+        """The note-free user_display_content (vibe ≥2.23) wins over the stored text."""
+        messages = [
+            {
+                "role": "user",
+                "content": "Skull strip this scan\n\n[workspace context: …]",
+                "user_display_content": {
+                    "version": "1",
+                    "host": "medmcp",
+                    "content": [{"type": "text", "text": "Skull strip this scan"}],
+                },
+            }
+        ]
+        assert distill._first_user_message(messages) == "Skull strip this scan"
+
+    def test_empty_display_content_falls_back_to_stripping(self) -> None:
+        """A present-but-empty display payload does not blank the seed request."""
+        empty: list[object] = []
+        messages = [
+            {
+                "role": "user",
+                "content": (
+                    "Register this scan\n\n"
+                    '[workspace context: the file "/data/t1.nii.gz" is currently open '
+                    "in the viewer]"
+                ),
+                "user_display_content": {"version": "1", "host": "medmcp", "content": empty},
+            }
+        ]
+        assert distill._first_user_message(messages) == "Register this scan"
+
 
 class TestRenderSkillMd:
     """render_skill_md produces a valid SKILL.md with or without prose."""

--- a/tests/test_distill.py
+++ b/tests/test_distill.py
@@ -400,6 +400,47 @@ def test_distill_session_missing_log_raises(tmp_path: Path) -> None:
     raise AssertionError("expected FileNotFoundError")
 
 
+def test_distill_session_spans_compaction_chain(tmp_path: Path) -> None:
+    """Tool calls made after a context compaction distill too.
+
+    vibe rolls a compacted conversation over to a new session dir whose
+    meta.json backlinks the original via parent_session_id; distillation must
+    read the whole chain, not just the pre-compaction prefix.
+    """
+    _write_fake_session(tmp_path)
+    cont_id = "ef567890-9999-8888-7777-666655554444"
+    cont = tmp_path / "logs" / "session" / f"session_20260101_010000_{cont_id[:8]}"
+    cont.mkdir(parents=True)
+    (cont / "meta.json").write_text(
+        json.dumps({"session_id": cont_id, "parent_session_id": SESSION_ID})
+    )
+    post_compaction: list[JsonDict] = [
+        _assistant_call(
+            "c9",
+            "medmcp-neuro_coregister",
+            {"input_path": "data/x/t1_mni.nii.gz", "reference": "data/x/flair.nii.gz"},
+        ),
+        _tool_result(
+            "c9", "ok: True\nstructured: {'coregistered_path': 'data/x/flair_reg.nii.gz'}"
+        ),
+    ]
+    with (cont / "messages.jsonl").open("w") as f:
+        for msg in post_compaction:
+            f.write(json.dumps(msg) + "\n")
+
+    with patch.object(provenance, "VIBE_HOME", tmp_path):
+        draft_dir = distill.distill_session(
+            SESSION_ID, use_llm=False, workflows_root=tmp_path / "workflows"
+        )
+
+    recipe = yaml.safe_load((draft_dir / "recipe.yaml").read_text())
+    assert [s["tool"] for s in recipe["steps"]] == [
+        "skull_strip",
+        "register_to_template",
+        "coregister",
+    ]
+
+
 def test_promote_moves_draft_to_active(tmp_path: Path) -> None:
     """Promote relocates a reviewed draft into active/ for skill discovery."""
     draft = tmp_path / "workflows" / "draft" / "my-flow"

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -216,56 +216,66 @@ def test_purge_session_is_safe_when_absent(tmp_path: Path) -> None:
         provenance.purge_session(SESSION_ID)  # no error
 
 
-FORK_ID = "ef567890-9999-8888-7777-666655554444"
+# ── compaction chains ────────────────────────────────────────────────────────
+
+CONT_ID = "ef567890-9999-8888-7777-666655554444"
+CONT2_ID = "01234567-aaaa-bbbb-cccc-ddddeeeeffff"
 
 
-def test_delete_vibe_transcript_keeps_provenance(tmp_path: Path) -> None:
-    """delete_vibe_transcript drops the transcript dir but leaves provenance."""
-    vibe_dir = tmp_path / "logs" / "session" / "session_20260101_000000_abcd1234"
-    vibe_dir.mkdir(parents=True)
-    (vibe_dir / "meta.json").write_text(json.dumps({"session_id": SESSION_ID}))
+def _make_vibe_session(
+    root: Path, timestamp: str, session_id: str, parent_id: str | None = None
+) -> Path:
+    """Create a vibe-style transcript dir with a meta.json (and empty log)."""
+    d = root / "logs" / "session" / f"session_{timestamp}_{session_id[:8]}"
+    d.mkdir(parents=True)
+    meta: dict[str, object] = {"session_id": session_id}
+    if parent_id is not None:
+        meta["parent_session_id"] = parent_id
+    (d / "meta.json").write_text(json.dumps(meta))
+    (d / "messages.jsonl").write_text("")
+    return d
+
+
+def test_find_vibe_session_dirs_follows_compaction_chain(tmp_path: Path) -> None:
+    """The chain lists the original dir first, then continuations in order."""
+    original = _make_vibe_session(tmp_path, "20260101_000000", SESSION_ID)
+    cont = _make_vibe_session(tmp_path, "20260101_010000", CONT_ID, parent_id=SESSION_ID)
+    cont2 = _make_vibe_session(tmp_path, "20260101_020000", CONT2_ID, parent_id=CONT_ID)
+    _make_vibe_session(tmp_path, "20260101_030000", "99999999-0000-0000-0000-000000000000")
+    with patch.object(provenance, "VIBE_HOME", tmp_path):
+        assert provenance.find_vibe_session_dirs(SESSION_ID) == [original, cont, cont2]
+
+
+def test_find_vibe_session_dirs_without_continuations(tmp_path: Path) -> None:
+    """A session that never compacted yields just its own dir."""
+    original = _make_vibe_session(tmp_path, "20260101_000000", SESSION_ID)
+    with patch.object(provenance, "VIBE_HOME", tmp_path):
+        assert provenance.find_vibe_session_dirs(SESSION_ID) == [original]
+
+
+def test_find_vibe_session_dirs_unknown_session(tmp_path: Path) -> None:
+    """An unknown id yields an empty chain."""
+    (tmp_path / "logs" / "session").mkdir(parents=True)
+    with patch.object(provenance, "VIBE_HOME", tmp_path):
+        assert provenance.find_vibe_session_dirs(SESSION_ID) == []
+
+
+def test_purge_session_removes_compaction_continuations(tmp_path: Path) -> None:
+    """Purging a chat also deletes the transcript dirs compaction rolled over to."""
+    original = _make_vibe_session(tmp_path, "20260101_000000", SESSION_ID)
+    cont = _make_vibe_session(tmp_path, "20260101_010000", CONT_ID, parent_id=SESSION_ID)
+    unrelated = _make_vibe_session(
+        tmp_path, "20260101_020000", "99999999-0000-0000-0000-000000000000"
+    )
     with patch.object(provenance, "VIBE_HOME", tmp_path):
         provenance.append_run_event(SESSION_ID, {"tool": "a"})
-        prov_dir = provenance.provenance_dir(SESSION_ID)
 
-        provenance.delete_vibe_transcript(SESSION_ID)
+        provenance.purge_session(SESSION_ID)
 
-        assert not vibe_dir.exists()
-        assert prov_dir.exists()  # provenance is preserved for relocation
-
-
-def test_move_session_record_relocates(tmp_path: Path) -> None:
-    """The provenance record moves from the old id to the fork id."""
-    with patch.object(provenance, "VIBE_HOME", tmp_path):
-        provenance.append_run_event(SESSION_ID, {"tool": "a"})
-        old_dir = provenance.provenance_dir(SESSION_ID)
-        new_dir = provenance.provenance_dir(FORK_ID)
-
-        provenance.move_session_record(SESSION_ID, FORK_ID)
-
-        assert not old_dir.exists()
-        assert (new_dir / "run.jsonl").exists()
-
-
-def test_move_session_record_no_clobber(tmp_path: Path) -> None:
-    """An existing destination is left intact (the source is not moved over it)."""
-    with patch.object(provenance, "VIBE_HOME", tmp_path):
-        provenance.append_run_event(SESSION_ID, {"tool": "old"})
-        provenance.append_run_event(FORK_ID, {"tool": "new"})
-
-        provenance.move_session_record(SESSION_ID, FORK_ID)
-
-        # Destination kept its own record; source remains rather than overwriting.
-        assert provenance.provenance_dir(SESSION_ID).exists()
-        events = provenance.read_run_events(FORK_ID)
-        assert [e.get("tool") for e in events] == ["new"]
-
-
-def test_move_session_record_absent_source(tmp_path: Path) -> None:
-    """Moving a record that doesn't exist is a no-op, not an error."""
-    with patch.object(provenance, "VIBE_HOME", tmp_path):
-        provenance.move_session_record(SESSION_ID, FORK_ID)  # no error
-        assert not provenance.provenance_dir(FORK_ID).exists()
+        assert not provenance.provenance_dir(SESSION_ID).exists()
+        assert not original.exists()
+        assert not cont.exists()
+        assert unrelated.exists()
 
 
 # ── orphan GC ────────────────────────────────────────────────────────────────

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -389,6 +389,75 @@ class TestStripWorkspaceNote:
         assert server._strip_workspace_note(text) == "Hi"
 
 
+class TestReplayedUserText:
+    """Replayed user turns prefer the note-free display content vibe echoes back."""
+
+    def test_prefers_user_display_content(self) -> None:
+        """The ``user_display_content`` meta wins over the stored text."""
+        update = {
+            "sessionUpdate": "user_message_chunk",
+            "content": {"type": "text", "text": "segment this\n\n[workspace context: …]"},
+            "_meta": {
+                "user_display_content": {
+                    "version": "1",
+                    "host": "medmcp",
+                    "content": [{"type": "text", "text": "segment this"}],
+                }
+            },
+        }
+        assert server._replayed_user_text(update) == "segment this"
+
+    def test_falls_back_to_stripping_the_note(self) -> None:
+        """Transcripts from before the display-content meta still strip cleanly."""
+        update = {
+            "sessionUpdate": "user_message_chunk",
+            "content": {
+                "type": "text",
+                "text": 'segment this\n\n[workspace context: the file "a/b.nii.gz" is currently '
+                "open in the viewer]",
+            },
+        }
+        assert server._replayed_user_text(update) == "segment this"
+
+    def test_empty_display_content_falls_back(self) -> None:
+        """A present-but-empty display meta does not blank the message."""
+        empty: list[object] = []
+        update = {
+            "sessionUpdate": "user_message_chunk",
+            "content": {"type": "text", "text": "plain question"},
+            "_meta": {"user_display_content": {"version": "1", "host": "x", "content": empty}},
+        }
+        assert server._replayed_user_text(update) == "plain question"
+
+    def test_non_text_content_is_ignored(self) -> None:
+        """Image/resource chunks yield no text (the UI only renders text turns)."""
+        update = {
+            "sessionUpdate": "user_message_chunk",
+            "content": {"type": "image", "data": "…"},
+        }
+        assert server._replayed_user_text(update) == ""
+
+
+class TestVisiblePermissionOptions:
+    """The durable auto-approval option is never offered to the browser."""
+
+    def test_drops_allow_always_permanent(self) -> None:
+        """``allow_always_permanent`` is filtered; the interactive options stay."""
+        options = [
+            {"optionId": "allow_once", "name": "Allow once"},
+            {"optionId": "allow_always", "name": "Allow for remainder of this session"},
+            {"optionId": "allow_always_permanent", "name": "Always allow"},
+            {"optionId": "reject_once", "name": "Deny"},
+        ]
+        visible = server._visible_permission_options(options)
+        assert [o["optionId"] for o in visible] == ["allow_once", "allow_always", "reject_once"]
+
+    def test_passes_unknown_options_through(self) -> None:
+        """Only the durable option is dropped — future option ids are relayed."""
+        options = [{"optionId": "allow_once"}, {"optionId": "something_new"}]
+        assert server._visible_permission_options(options) == options
+
+
 class TestSessionsApi:
     """GET /api/sessions maps vibe-acp's session/list to the UI shape."""
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -8,8 +8,10 @@ exercisable without a live vibe-acp subprocess.
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Iterable
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
 import yaml
@@ -436,6 +438,79 @@ class TestReplayedUserText:
             "content": {"type": "image", "data": "…"},
         }
         assert server._replayed_user_text(update) == ""
+
+
+class _StubWs:
+    """Collects frames a _ChatConnection would send to the browser."""
+
+    def __init__(self) -> None:
+        self.sent: list[dict[str, object]] = []
+
+    async def send_json(self, msg: dict[str, object]) -> None:
+        self.sent.append(msg)
+
+
+class TestIdlePump:
+    """Unsolicited vibe frames (e.g. MCP failure notices) reach the browser."""
+
+    @pytest.mark.asyncio
+    async def test_pump_relays_queued_notice(self) -> None:
+        """A warm-up agent message queued before any prompt is forwarded."""
+        queue: asyncio.Queue[dict[str, object]] = asyncio.Queue()
+        conn = server._ChatConnection(cast("Any", _StubWs()), "sid", cast("Any", queue), [])
+        await queue.put(
+            {
+                "method": "session/update",
+                "params": {
+                    "update": {
+                        "sessionUpdate": "agent_message_chunk",
+                        "content": {
+                            "type": "text",
+                            "text": "The following MCP servers failed to connect:\n- x: boom",
+                        },
+                    }
+                },
+            }
+        )
+        conn.start_idle_pump()
+        await asyncio.sleep(0.05)
+        await conn._stop_idle_pump()
+        ws = cast("_StubWs", conn.ws)
+        assert any(
+            m.get("type") == "chunk" and "failed to connect" in str(m.get("text")) for m in ws.sent
+        )
+
+    @pytest.mark.asyncio
+    async def test_stop_is_idempotent_and_halts_relay(self) -> None:
+        """After stopping, queued frames stay queued (drained by the turn loop)."""
+        queue: asyncio.Queue[dict[str, object]] = asyncio.Queue()
+        conn = server._ChatConnection(cast("Any", _StubWs()), "sid", cast("Any", queue), [])
+        conn.start_idle_pump()
+        await conn._stop_idle_pump()
+        await conn._stop_idle_pump()  # no error
+        await queue.put({"method": "session/update", "params": {}})
+        await asyncio.sleep(0.05)
+        assert cast("_StubWs", conn.ws).sent == []
+        assert queue.qsize() == 1
+
+
+class TestUsageWindow:
+    """The context meter denominator: Ollama's num_ctx wins over vibe's registry figure."""
+
+    def test_fetched_ollama_value_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A fetched num_ctx beats the frame's size (vibe reports its registry figure)."""
+        monkeypatch.setattr(settings, "_context_window_tokens", 131072)
+        assert server._usage_window({"used": 1, "size": 200000}) == 131072
+
+    def test_frame_size_stands_in_before_first_fetch(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Before the cache is warmed, vibe's size beats the static default."""
+        monkeypatch.setattr(settings, "_context_window_tokens", None)
+        assert server._usage_window({"size": 200000}) == 200000
+
+    def test_static_default_last(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """With no fetch and no frame size, the static default applies."""
+        monkeypatch.setattr(settings, "_context_window_tokens", None)
+        assert server._usage_window({}) == settings.DEFAULT_CONTEXT_WINDOW
 
 
 class TestVisiblePermissionOptions:

--- a/uv.lock
+++ b/uv.lock
@@ -772,7 +772,7 @@ test = [
 requires-dist = [
     { name = "fastapi", specifier = ">=0.141.1" },
     { name = "httpx", specifier = ">=0.27" },
-    { name = "mistral-vibe", specifier = ">=2.23.2,<3" },
+    { name = "mistral-vibe", specifier = ">=2.23.3,<3" },
     { name = "python-multipart", specifier = ">=0.0.18" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "tomli-w", specifier = ">=1.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -804,7 +804,7 @@ test = [
 
 [[package]]
 name = "mistral-vibe"
-version = "2.23.2"
+version = "2.23.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "agent-client-protocol" },
@@ -905,9 +905,9 @@ dependencies = [
     { name = "zipp" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e3/a6/fd5103713ef96ba0a35032073b599a8beff825ee4269863964bca501683b/mistral_vibe-2.23.2.tar.gz", hash = "sha256:9938ef615a7d36c7c547de70d2d35f2ef4e1740ba819058e7b244e3b92cfd16c", size = 1617824, upload-time = "2026-07-30T08:26:41.577Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/b3/bca9e4bae4d8140bc2a79c74bde7057e4e996db114a06d16b496c1c04871/mistral_vibe-2.23.3.tar.gz", hash = "sha256:89da5ae8e74482ec322c67acd55ab454e2da9d1ca65c23836354fab9c0883dba", size = 1645949, upload-time = "2026-08-03T13:01:07.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/a0/a0d3917565a3e9146563764432307d59c6cf2611876db9ac195160ab9143/mistral_vibe-2.23.2-py3-none-any.whl", hash = "sha256:84e5dce6c405d9e0ce0d38dede1565c792ff573225fc6d864a3366048f05261f", size = 917962, upload-time = "2026-07-30T08:26:39.658Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/55/b945146ed3c2276705d746a7e807daa250af618736385b4ac0dd54c4fecd/mistral_vibe-2.23.3-py3-none-any.whl", hash = "sha256:0b3dc1d615ec45ec6b06dedfde40252612d5e902f622f9e80decf0f8e4a6fcc5", size = 928665, upload-time = "2026-08-03T13:01:05.163Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Integrates the ACP improvements from the mistral-vibe 2.17 → 2.23 jump (merged in #88) and bumps to 2.23.3: the workspace-context note now uses vibe's native display-content/automatic-block mechanism, the continue-after-reload fork machinery is removed (resume appends in place since 2.23), compaction continuations are followed via the new `parent_session_id` backlinks, and the new durable auto-approval permission option is filtered out to preserve the interactive-gating posture.

## Test plan
- [x] `just check` green (296 passed; 9 new tests: replayed-user-text preference, permission-option filtering, compaction-chain lookup/purge/distill, display-content seed preference)
- [x] `npm run lint` + `npm run build` green
- [x] Verified against the installed vibe 2.23.3 source that `session/load` resumes in place (same id, same `messages.jsonl`), that `user_display_content` is persisted and echoed on replay, that `automatic` blocks are excluded from auto-titles, and that compaction still rolls to a new dir but now records `parent_session_id` in `meta.json`
- [x] Live smoke test, main suite (scripted against a running workspace + Ollama, throwaway session only): chat streaming, resume keeps the id and appends in place (no fork dir), replayed user turn is note-free via display content while the persisted text keeps the legacy note format, auto-title clean, usage frames carry vibe's context window, provenance recorded, transcript + provenance fully purged on delete
- [x] Live smoke test found one real bug — the ACP extension methods must be underscore-prefixed on the wire (`_session/set_title`, `_session/delete`); unprefixed calls got a silently-suppressed "Method not found". Fixed and confirmed against a standalone vibe-acp over raw JSON-RPC
- [x] Live smoke test, phase 2: mutating bash + write_file prompt correctly and denials stick; rename write-through lands in vibe's `meta.json` with the underscore fix; workflow-skill invocation works (activating the draft via settings, `/skull-strip-register` surfaces as a “Loading skill” tool call, the `skill` call pair persists in the transcript, distillation ignores it); sessions deleted and settings restored afterward

## Security & data handling
- vibe 2.23 adds an `allow_always_permanent` permission option that would persist an auto-approval into `config.toml`; `_visible_permission_options` drops it before the browser sees it, so tool calls stay interactively gated (per-session allow-always is unchanged).
- The `skill-creator` builtin skill is disabled in both configs (agent-authored skills would bypass the distill → review → promote path); the container config now also disables the `vibe` builtin, matching dev.
- Deleting a chat now purges its whole transcript chain (original + compaction continuations) — strictly less data left behind than before.

- [x] Re-audit pass ("is it really ready?"): found and fixed three more issues — (1) MCP discovery-failure notices arrive outside any prompt turn and were silently discarded; a pre-first-prompt idle pump now relays them (verified live with a deliberately broken stack manifest: the "failed to connect" notice reaches the chat); (2) the context meter preferred vibe's registry figure (200k) over Ollama's served `num_ctx` (131072) — the fetched Ollama value now wins, with the frame size only as a pre-fetch stand-in; (3) the `mistral-vibe` floor is raised to 2.23.3 to encode the semantics the code now assumes

- [x] Full main smoke suite re-run against the final commit: 26/27 (the sole failure is a stale JSON key in the test driver itself, disproven by a passing equivalent check in the phase-2 driver). Highlights on final code: `ls` now prompts (empty allowlist verified live), permission options are exactly allow_once/allow_always/reject_once, the context meter reports the served 131072, rename write-through lands, resume appends in place, native delete clean

## Security & data handling (smoke-test finding)
- vibe's bash allowlist (from the `bash_read_only_defaults_v1` migration, present in both tracked configs and also vibe's code default) auto-allows read-only commands — and the smoke test caught a real bypass: **an output redirect from an allowlisted command writes files without any prompt** (`echo "" > file`, `ls > file`). vibe's parser even tags the command with `<redirect>`, but the allowlist prefix-match ignores it, so after three honored denials the model created the probe file via a redirect with no fourth prompt. Verified deterministically against `resolve_permission`: `echo "" > f`, `ls > f`, `cat a > b`, `sort x > y` all resolve to `permission=always` with the default allowlist; `touch f` correctly asks. **Mitigation applied:** `allowlist = []` in both tracked configs (confirmed effective — an explicit empty list overrides vibe's code default through the deep-merge; with it, every bash command resolves to ask). Cost: read-only commands now prompt too. Revisit when vibe fixes the matcher upstream (`_matches_pattern` in `core/tools/builtins/bash.py` ignores the parser's own `<redirect>` tag).

## Notes
- Follow-up commits on review feedback: distillation's seed request now prefers the persisted `user_display_content` (shared extraction helper in `workspace_note.py`), and `DELETE /api/sessions/{id}` asks vibe to drop the session natively (ext `session/delete`, best-effort) before the disk purge so a running agent's session list stays consistent.
- The fork machinery had to go with this upgrade, not later: with in-place resume its only remaining trigger would have been compaction, where it would delete the pre-compaction transcript (real history loss).
- `session/set_title` write-through is best-effort — a rename while vibe isn't running just keeps the registry override, as before.
- Known edge left open: resuming after a compaction **and** a vibe restart may load only the pre-compaction prefix (vibe resolves the original id to the original dir). Needs a live repro; tracked in the local design notes.