### PR TITLE
feat: rewind a chat to before a message

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -4,6 +4,7 @@ import type {
   GpuInfo,
   InstalledStack,
   ReplayPreviewStep,
+  RewindResult,
   SessionInfo,
   SettingsState,
   TreeNode,
@@ -144,6 +145,21 @@ export async function renameSession(id: string, title: string): Promise<void> {
 
 export async function archiveSession(id: string, archived: boolean): Promise<void> {
   await postJson(`/api/sessions/${encodeURIComponent(id)}/archive`, { archived })
+}
+
+/** Preview a rewind: which workspace files would be restored. */
+export async function previewRewind(id: string, messageId: string): Promise<RewindResult> {
+  const res = await postJson(`/api/sessions/${encodeURIComponent(id)}/rewind`, {
+    messageId,
+    preview: true,
+  })
+  return (await res.json()) as RewindResult
+}
+
+/** Rewind the live chat to before a message (truncates + restores files). */
+export async function rewindTo(id: string, messageId: string): Promise<RewindResult> {
+  const res = await postJson(`/api/sessions/${encodeURIComponent(id)}/rewind`, { messageId })
+  return (await res.json()) as RewindResult
 }
 
 /** Delete a session for good (transcript + provenance + UI metadata). */

--- a/frontend/src/chatSocket.ts
+++ b/frontend/src/chatSocket.ts
@@ -95,4 +95,11 @@ export class ChatSocket {
     }
     this.ws?.close()
   }
+
+  /** Drop the connection and reattach to the same session (server-side state
+   * changed under us — e.g. a rewind truncated the transcript — and the
+   * reconnect's history replay is the clean way to rebuild it). */
+  reconnect(): void {
+    this.ws?.close()
+  }
 }

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -5,6 +5,7 @@ import remarkMath from 'remark-math'
 import rehypeKatex from 'rehype-katex'
 import { ChatSocket } from '../chatSocket'
 import type { ChatSocketStatus } from '../chatSocket'
+import { previewRewind, rewindTo } from '../api'
 import type { ChatItem, PermissionRequest, ServerFrame, ToolCallState } from '../types'
 import { ChatsMenu } from './ChatsMenu'
 import { ShieldIcon } from './icons'
@@ -320,6 +321,13 @@ export const Chat = memo(function Chat({
   const [model, setModel] = useState<string | null>(null)
   const [usage, setUsage] = useState<{ used: number; size: number | null } | null>(null)
   const [permission, setPermission] = useState<PermissionRequest | null>(null)
+  // Pending rewind confirmation: set after the preview call, cleared on
+  // confirm/cancel/reconnect. `paths` are the workspace files a rewind restores.
+  const [rewind, setRewind] = useState<{
+    messageId: string
+    paths: string[]
+    busy: boolean
+  } | null>(null)
   const socketRef = useRef<ChatSocket | null>(null)
   const sessionIdRef = useRef<string | null>(null)
   const bottomRef = useRef<HTMLDivElement>(null)
@@ -445,7 +453,10 @@ export const Chat = memo(function Chat({
         case 'user':
           // A replayed user turn from a resumed session (live sends are added
           // locally in send(), so this only fires during history replay).
-          setItems((prev) => [...prev, { kind: 'user', text: frame.text }])
+          setItems((prev) => [
+            ...prev,
+            { kind: 'user', text: frame.text, messageId: frame.messageId },
+          ])
           break
         case 'ready':
           // (Re)connect: the server is the transcript's source of truth — a
@@ -462,6 +473,7 @@ export const Chat = memo(function Chat({
           setToolCalls({})
           setBusy(false)
           setPermission(null)
+          setRewind(null)
           if (frame.model) setModel(frame.model)
           onSessionEstablishedRef.current?.(frame.sessionId)
           break
@@ -512,6 +524,38 @@ export const Chat = memo(function Chat({
     }
   }
 
+  const askRewind = async (messageId: string) => {
+    const sid = sessionIdRef.current
+    if (!sid) return
+    try {
+      const res = await previewRewind(sid, messageId)
+      setRewind({ messageId, paths: res.paths ?? [], busy: false })
+    } catch (e) {
+      setItems((prev) => [
+        ...prev,
+        { kind: 'error', text: `Rewind preview failed: ${(e as Error).message}` },
+      ])
+    }
+  }
+
+  const doRewind = async () => {
+    const sid = sessionIdRef.current
+    if (!rewind || !sid) return
+    setRewind({ ...rewind, busy: true })
+    try {
+      await rewindTo(sid, rewind.messageId)
+      // The transcript is truncated server-side; the reconnect's history
+      // replay is the clean rebuild (ready clears items and rewind state).
+      socketRef.current?.reconnect()
+    } catch (e) {
+      setRewind(null)
+      setItems((prev) => [
+        ...prev,
+        { kind: 'error', text: `Rewind failed: ${(e as Error).message}` },
+      ])
+    }
+  }
+
   return (
     <div className="panel">
       <div className="panel-header">
@@ -546,10 +590,56 @@ export const Chat = memo(function Chat({
             return tc ? <ToolCard key={i} tc={tc} /> : null
           }
           if (item.kind === 'user') {
+            const mid = item.messageId
             return (
-              <div key={i} className="msg msg-user">
-                <div className="msg-avatar avatar-user">You</div>
-                <div className="msg-bubble bubble-user">{item.text}</div>
+              <div key={i} className="user-turn">
+                <div className="msg msg-user">
+                  {mid && !busy && (
+                    <button
+                      className="btn-icon rewind-btn"
+                      title="Rewind the chat to before this message"
+                      onClick={() => void askRewind(mid)}
+                    >
+                      ↺
+                    </button>
+                  )}
+                  <div className="msg-avatar avatar-user">You</div>
+                  <div className="msg-bubble bubble-user">{item.text}</div>
+                </div>
+                {rewind && rewind.messageId === mid && (
+                  <div className="rewind-confirm">
+                    <div className="rewind-confirm-title">Rewind to before this message?</div>
+                    <div>
+                      The conversation from here on is discarded.
+                      {rewind.paths.length > 0
+                        ? ` ${rewind.paths.length} workspace file(s) will be restored:`
+                        : ' No workspace files need restoring.'}
+                    </div>
+                    {rewind.paths.length > 0 && (
+                      <ul className="rewind-paths">
+                        {rewind.paths.map((p) => (
+                          <li key={p}>{p}</li>
+                        ))}
+                      </ul>
+                    )}
+                    <div className="rewind-actions">
+                      <button
+                        className="btn-plain"
+                        disabled={rewind.busy}
+                        onClick={() => setRewind(null)}
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        className="btn-danger"
+                        disabled={rewind.busy}
+                        onClick={() => void doRewind()}
+                      >
+                        {rewind.busy ? 'Rewinding…' : 'Rewind'}
+                      </button>
+                    </div>
+                  </div>
+                )}
               </div>
             )
           }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -778,6 +778,56 @@ button:hover {
   flex-direction: row-reverse;
 }
 
+/* Rewind (replayed user turns): ghost button revealed on hover, plus the
+ * confirmation card that lists the workspace files a rewind would restore. */
+.user-turn {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+}
+
+.rewind-btn {
+  align-self: center;
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+.msg-user:hover .rewind-btn,
+.rewind-btn:focus-visible {
+  opacity: 1;
+}
+
+.rewind-confirm {
+  max-width: 70%;
+  background: var(--card);
+  border: 1px solid var(--border2);
+  border-radius: 8px;
+  padding: 10px 12px;
+  font-size: 12.5px;
+  color: var(--muted2);
+}
+
+.rewind-confirm-title {
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 4px;
+}
+
+.rewind-paths {
+  margin: 6px 0 0;
+  padding-left: 18px;
+  font-family: var(--mono);
+  font-size: 11.5px;
+}
+
+.rewind-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  margin-top: 10px;
+}
+
 .msg-ai {
   align-self: flex-start;
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -178,10 +178,19 @@ export type ReplayFrame =
 
 /** Ordered chat transcript entries. Tool calls render as inline cards. */
 export type ChatItem =
-  | { kind: 'user'; text: string }
+  // messageId (replayed turns only) anchors per-turn actions like rewind.
+  | { kind: 'user'; text: string; messageId?: string }
   | { kind: 'assistant'; text: string }
   | { kind: 'tool'; toolCallId: string }
   | { kind: 'error'; text: string }
+
+/** What a rewind would restore (preview) / did restore (perform). */
+export interface RewindResult {
+  paths?: string[]
+  messageContent?: string
+  restoredPaths?: string[]
+  restoreErrors?: string[]
+}
 
 /** Frames the server sends over /ws/chat. */
 export type ServerFrame =
@@ -189,7 +198,7 @@ export type ServerFrame =
   | { type: 'chunk'; text: string }
   // Replayed user turn from a resumed session (session/load); live prompts are
   // rendered locally on send and are not echoed by the server.
-  | { type: 'user'; text: string }
+  | { type: 'user'; text: string; messageId?: string }
   | {
       type: 'tool_call'
       toolCallId: string

--- a/src/medmcp/server.py
+++ b/src/medmcp/server.py
@@ -46,7 +46,7 @@ import uvicorn
 from fastapi import FastAPI, HTTPException, UploadFile, WebSocket, WebSocketDisconnect
 from fastapi.responses import FileResponse, JSONResponse, Response
 from fastapi.staticfiles import StaticFiles
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from medmcp import (
     batchplan,
@@ -1395,7 +1395,12 @@ class _ChatConnection:
                 # Replayed user turns (session/load); live prompts are not echoed.
                 text = _replayed_user_text(update)
                 if text:
-                    await self._send({"type": "user", "text": text})
+                    frame: JsonDict = {"type": "user", "text": text}
+                    # The message id anchors per-turn actions (rewind targets).
+                    mid = update.get("messageId")
+                    if isinstance(mid, str) and mid:
+                        frame["messageId"] = mid
+                    await self._send(frame)
             elif update_type == "tool_call":
                 tc_id = str(update.get("toolCallId") or "")
                 title = str(update.get("title") or "tool")
@@ -1709,6 +1714,47 @@ async def rename_session(session_id: str, payload: RenameSessionPayload) -> Json
             tip = await asyncio.to_thread(provenance.vibe_chain_tip, session_id)
             await _client.request("_session/set_title", {"sessionId": tip, "title": title})
     return {"ok": True}
+
+
+class RewindPayload(BaseModel):
+    """Request body for previewing/performing a chat rewind."""
+
+    message_id: str = Field(alias="messageId")
+    preview: bool = False
+    restore_files: bool = Field(default=True, alias="restoreFiles")
+
+
+@app.post("/api/sessions/{session_id}/rewind")
+async def rewind_session(session_id: str, payload: RewindPayload) -> JsonDict:
+    """Preview or perform an in-place rewind of a live chat (vibe ≥2.23 ext method).
+
+    ``preview`` returns the workspace files a rewind would restore; without it
+    the conversation is truncated to before ``messageId`` (and, with
+    ``restoreFiles``, the files are restored). Requires the chat to be open —
+    vibe only rewinds live sessions — and targets the chain tip (the id vibe
+    holds live). The UI must confirm with the user before the non-preview call:
+    it truncates conversation history and rewrites workspace files.
+    """
+    await _client.ensure_started()
+    tip = await asyncio.to_thread(provenance.vibe_chain_tip, session_id)
+    if payload.preview:
+        method = "_rewind/preview"
+        params: JsonDict = {"sessionId": tip, "messageId": payload.message_id}
+    else:
+        _audit.info("rewind requested: %s -> message %s", session_id, payload.message_id)
+        method = "_rewind/to"
+        params = {
+            "sessionId": tip,
+            "messageId": payload.message_id,
+            "restoreFiles": payload.restore_files,
+        }
+    resp = await _client.request(method, params)
+    if "error" in resp:
+        err = cast("JsonDict", resp["error"])
+        raise HTTPException(status_code=409, detail=str(err.get("message", err)))
+    if not payload.preview:
+        _audit.info("rewind performed: %s -> message %s", session_id, payload.message_id)
+    return cast("JsonDict", resp.get("result") or {})
 
 
 class ArchiveSessionPayload(BaseModel):


### PR DESCRIPTION
## Summary
Adds an "undo from here" affordance to the chat: hovering a replayed user turn reveals a rewind button; the flow previews which workspace files a rewind would restore, asks for explicit confirmation, then performs vibe 2.23's **in-place** rewind (`_rewind/to` ext method) and reconnects the socket so the history replay rebuilds the truncated transcript.

**Stacked on #90** (uses the chain-tip mapping); merge that first — this PR's base is `feat/compaction-chain-collapse`.

## Test plan
- [x] `just check` green (308 passed), `npm run lint` + `npm run build` green
- [x] Live test against a running workspace: replayed turns carry messageIds, preview returns the restorable paths, the rewind truncates in place (returning the rewound message text), and the next replay shows only the pre-rewind transcript (8/8 checks)
- [x] Headless-chromium screenshot of the workspace with the new bundle — no visual regression (the button itself is hover-revealed)
- [ ] Manual hover/click pass in a real browser (the confirm card and hover affordance)

## Screenshots
The rewind button is hover-revealed on replayed user turns; static capture shows no layout change.

## Security & data handling
- Rewind restores workspace files (`restoreFiles`, default true) — a mutation, so the UI always previews and asks for explicit confirmation first, and every rewind is written to the `medmcp.audit` log.
- The endpoint only works on live (open) chats — vibe refuses others; errors map to 409.

## Notes
- Live turns sent in the current connection don't carry a messageId (vibe generates it internally); after any reconnect the replay provides ids for all turns. The button therefore appears on replayed turns only — v1 scope.
- The rewound message text is returned by vibe; refilling the input box with it is a possible follow-up nicety.