### PR TITLE
feat: rewind a chat to before a message

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -4,6 +4,7 @@ import type {
   GpuInfo,
   InstalledStack,
   ReplayPreviewStep,
+  RewindResult,
   SessionInfo,
   SettingsState,
   TreeNode,
@@ -144,6 +145,21 @@ export async function renameSession(id: string, title: string): Promise<void> {
 
 export async function archiveSession(id: string, archived: boolean): Promise<void> {
   await postJson(`/api/sessions/${encodeURIComponent(id)}/archive`, { archived })
+}
+
+/** Preview a rewind: which workspace files would be restored. */
+export async function previewRewind(id: string, messageId: string): Promise<RewindResult> {
+  const res = await postJson(`/api/sessions/${encodeURIComponent(id)}/rewind`, {
+    messageId,
+    preview: true,
+  })
+  return (await res.json()) as RewindResult
+}
+
+/** Rewind the live chat to before a message (truncates + restores files). */
+export async function rewindTo(id: string, messageId: string): Promise<RewindResult> {
+  const res = await postJson(`/api/sessions/${encodeURIComponent(id)}/rewind`, { messageId })
+  return (await res.json()) as RewindResult
 }
 
 /** Delete a session for good (transcript + provenance + UI metadata). */

--- a/frontend/src/chatSocket.ts
+++ b/frontend/src/chatSocket.ts
@@ -95,4 +95,11 @@ export class ChatSocket {
     }
     this.ws?.close()
   }
+
+  /** Drop the connection and reattach to the same session (server-side state
+   * changed under us — e.g. a rewind truncated the transcript — and the
+   * reconnect's history replay is the clean way to rebuild it). */
+  reconnect(): void {
+    this.ws?.close()
+  }
 }

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -5,6 +5,7 @@ import remarkMath from 'remark-math'
 import rehypeKatex from 'rehype-katex'
 import { ChatSocket } from '../chatSocket'
 import type { ChatSocketStatus } from '../chatSocket'
+import { previewRewind, rewindTo } from '../api'
 import type { ChatItem, PermissionRequest, ServerFrame, ToolCallState } from '../types'
 import { ChatsMenu } from './ChatsMenu'
 import { ShieldIcon } from './icons'
@@ -320,6 +321,13 @@ export const Chat = memo(function Chat({
   const [model, setModel] = useState<string | null>(null)
   const [usage, setUsage] = useState<{ used: number; size: number | null } | null>(null)
   const [permission, setPermission] = useState<PermissionRequest | null>(null)
+  // Pending rewind confirmation: set after the preview call, cleared on
+  // confirm/cancel/reconnect. `paths` are the workspace files a rewind restores.
+  const [rewind, setRewind] = useState<{
+    messageId: string
+    paths: string[]
+    busy: boolean
+  } | null>(null)
   const socketRef = useRef<ChatSocket | null>(null)
   const sessionIdRef = useRef<string | null>(null)
   const bottomRef = useRef<HTMLDivElement>(null)
@@ -445,7 +453,10 @@ export const Chat = memo(function Chat({
         case 'user':
           // A replayed user turn from a resumed session (live sends are added
           // locally in send(), so this only fires during history replay).
-          setItems((prev) => [...prev, { kind: 'user', text: frame.text }])
+          setItems((prev) => [
+            ...prev,
+            { kind: 'user', text: frame.text, messageId: frame.messageId },
+          ])
           break
         case 'ready':
           // (Re)connect: the server is the transcript's source of truth — a
@@ -462,6 +473,7 @@ export const Chat = memo(function Chat({
           setToolCalls({})
           setBusy(false)
           setPermission(null)
+          setRewind(null)
           if (frame.model) setModel(frame.model)
           onSessionEstablishedRef.current?.(frame.sessionId)
           break
@@ -512,6 +524,38 @@ export const Chat = memo(function Chat({
     }
   }
 
+  const askRewind = async (messageId: string) => {
+    const sid = sessionIdRef.current
+    if (!sid) return
+    try {
+      const res = await previewRewind(sid, messageId)
+      setRewind({ messageId, paths: res.paths ?? [], busy: false })
+    } catch (e) {
+      setItems((prev) => [
+        ...prev,
+        { kind: 'error', text: `Rewind preview failed: ${(e as Error).message}` },
+      ])
+    }
+  }
+
+  const doRewind = async () => {
+    const sid = sessionIdRef.current
+    if (!rewind || !sid) return
+    setRewind({ ...rewind, busy: true })
+    try {
+      await rewindTo(sid, rewind.messageId)
+      // The transcript is truncated server-side; the reconnect's history
+      // replay is the clean rebuild (ready clears items and rewind state).
+      socketRef.current?.reconnect()
+    } catch (e) {
+      setRewind(null)
+      setItems((prev) => [
+        ...prev,
+        { kind: 'error', text: `Rewind failed: ${(e as Error).message}` },
+      ])
+    }
+  }
+
   return (
     <div className="panel">
       <div className="panel-header">
@@ -546,10 +590,56 @@ export const Chat = memo(function Chat({
             return tc ? <ToolCard key={i} tc={tc} /> : null
           }
           if (item.kind === 'user') {
+            const mid = item.messageId
             return (
-              <div key={i} className="msg msg-user">
-                <div className="msg-avatar avatar-user">You</div>
-                <div className="msg-bubble bubble-user">{item.text}</div>
+              <div key={i} className="user-turn">
+                <div className="msg msg-user">
+                  {mid && !busy && (
+                    <button
+                      className="btn-icon rewind-btn"
+                      title="Rewind the chat to before this message"
+                      onClick={() => void askRewind(mid)}
+                    >
+                      ↺
+                    </button>
+                  )}
+                  <div className="msg-avatar avatar-user">You</div>
+                  <div className="msg-bubble bubble-user">{item.text}</div>
+                </div>
+                {rewind && rewind.messageId === mid && (
+                  <div className="rewind-confirm">
+                    <div className="rewind-confirm-title">Rewind to before this message?</div>
+                    <div>
+                      The conversation from here on is discarded.
+                      {rewind.paths.length > 0
+                        ? ` ${rewind.paths.length} workspace file(s) will be restored:`
+                        : ' No workspace files need restoring.'}
+                    </div>
+                    {rewind.paths.length > 0 && (
+                      <ul className="rewind-paths">
+                        {rewind.paths.map((p) => (
+                          <li key={p}>{p}</li>
+                        ))}
+                      </ul>
+                    )}
+                    <div className="rewind-actions">
+                      <button
+                        className="btn-plain"
+                        disabled={rewind.busy}
+                        onClick={() => setRewind(null)}
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        className="btn-danger"
+                        disabled={rewind.busy}
+                        onClick={() => void doRewind()}
+                      >
+                        {rewind.busy ? 'Rewinding…' : 'Rewind'}
+                      </button>
+                    </div>
+                  </div>
+                )}
               </div>
             )
           }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -778,6 +778,56 @@ button:hover {
   flex-direction: row-reverse;
 }
 
+/* Rewind (replayed user turns): ghost button revealed on hover, plus the
+ * confirmation card that lists the workspace files a rewind would restore. */
+.user-turn {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+}
+
+.rewind-btn {
+  align-self: center;
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+.msg-user:hover .rewind-btn,
+.rewind-btn:focus-visible {
+  opacity: 1;
+}
+
+.rewind-confirm {
+  max-width: 70%;
+  background: var(--card);
+  border: 1px solid var(--border2);
+  border-radius: 8px;
+  padding: 10px 12px;
+  font-size: 12.5px;
+  color: var(--muted2);
+}
+
+.rewind-confirm-title {
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 4px;
+}
+
+.rewind-paths {
+  margin: 6px 0 0;
+  padding-left: 18px;
+  font-family: var(--mono);
+  font-size: 11.5px;
+}
+
+.rewind-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  margin-top: 10px;
+}
+
 .msg-ai {
   align-self: flex-start;
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -178,10 +178,19 @@ export type ReplayFrame =
 
 /** Ordered chat transcript entries. Tool calls render as inline cards. */
 export type ChatItem =
-  | { kind: 'user'; text: string }
+  // messageId (replayed turns only) anchors per-turn actions like rewind.
+  | { kind: 'user'; text: string; messageId?: string }
   | { kind: 'assistant'; text: string }
   | { kind: 'tool'; toolCallId: string }
   | { kind: 'error'; text: string }
+
+/** What a rewind would restore (preview) / did restore (perform). */
+export interface RewindResult {
+  paths?: string[]
+  messageContent?: string
+  restoredPaths?: string[]
+  restoreErrors?: string[]
+}
 
 /** Frames the server sends over /ws/chat. */
 export type ServerFrame =
@@ -189,7 +198,7 @@ export type ServerFrame =
   | { type: 'chunk'; text: string }
   // Replayed user turn from a resumed session (session/load); live prompts are
   // rendered locally on send and are not echoed by the server.
-  | { type: 'user'; text: string }
+  | { type: 'user'; text: string; messageId?: string }
   | {
       type: 'tool_call'
       toolCallId: string

--- a/src/medmcp/provenance.py
+++ b/src/medmcp/provenance.py
@@ -378,6 +378,48 @@ def find_vibe_session_dirs(session_id: str) -> list[Path]:
     return chain
 
 
+def vibe_session_parents() -> dict[str, str]:
+    """Map each vibe session id to its ``parent_session_id`` backlink.
+
+    Only sessions that *have* a parent appear as keys. Both compaction
+    continuations and explicit forks carry the backlink — callers that must
+    distinguish them need an additional signal (the UI session registry: a
+    chat the user can see is never a hidden continuation).
+    """
+    sessions_root = VIBE_HOME / "logs" / "session"
+    if not sessions_root.is_dir():
+        return {}
+    parents: dict[str, str] = {}
+    for candidate in sessions_root.iterdir():
+        if not candidate.is_dir():
+            continue
+        data = _read_session_meta(candidate)
+        if data is None:
+            continue
+        child = data.get("session_id")
+        parent = data.get("parent_session_id")
+        if isinstance(child, str) and isinstance(parent, str) and parent:
+            parents[child] = parent
+    return parents
+
+
+def vibe_chain_tip(session_id: str) -> str:
+    """Follow compaction continuations from *session_id* to the newest link.
+
+    Returns *session_id* itself when it has no continuation (or is unknown).
+    Resuming the tip instead of the root restores the post-compaction context;
+    the root dir only holds the pre-compaction prefix. With several children
+    (defensive — pure compaction rolls over to at most one) the newest dir in
+    the chain wins.
+    """
+    dirs = find_vibe_session_dirs(session_id)
+    if len(dirs) < 2:
+        return session_id
+    data = _read_session_meta(dirs[-1])
+    tip = data.get("session_id") if data is not None else None
+    return tip if isinstance(tip, str) and tip else session_id
+
+
 def list_provenance_sessions() -> list[str]:
     """Return the session ids that currently have a provenance directory."""
     root = VIBE_HOME / "provenance"

--- a/src/medmcp/server.py
+++ b/src/medmcp/server.py
@@ -46,7 +46,7 @@ import uvicorn
 from fastapi import FastAPI, HTTPException, UploadFile, WebSocket, WebSocketDisconnect
 from fastapi.responses import FileResponse, JSONResponse, Response
 from fastapi.staticfiles import StaticFiles
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from medmcp import (
     batchplan,
@@ -1395,7 +1395,12 @@ class _ChatConnection:
                 # Replayed user turns (session/load); live prompts are not echoed.
                 text = _replayed_user_text(update)
                 if text:
-                    await self._send({"type": "user", "text": text})
+                    frame: JsonDict = {"type": "user", "text": text}
+                    # The message id anchors per-turn actions (rewind targets).
+                    mid = update.get("messageId")
+                    if isinstance(mid, str) and mid:
+                        frame["messageId"] = mid
+                    await self._send(frame)
             elif update_type == "tool_call":
                 tc_id = str(update.get("toolCallId") or "")
                 title = str(update.get("title") or "tool")
@@ -1709,6 +1714,47 @@ async def rename_session(session_id: str, payload: RenameSessionPayload) -> Json
             tip = await asyncio.to_thread(provenance.vibe_chain_tip, session_id)
             await _client.request("_session/set_title", {"sessionId": tip, "title": title})
     return {"ok": True}
+
+
+class RewindPayload(BaseModel):
+    """Request body for previewing/performing a chat rewind."""
+
+    message_id: str = Field(alias="messageId")
+    preview: bool = False
+    restore_files: bool = Field(default=True, alias="restoreFiles")
+
+
+@app.post("/api/sessions/{session_id}/rewind")
+async def rewind_session(session_id: str, payload: RewindPayload) -> JsonDict:
+    """Preview or perform an in-place rewind of a live chat (vibe ≥2.23 ext method).
+
+    ``preview`` returns the workspace files a rewind would restore; without it
+    the conversation is truncated to before ``messageId`` (and, with
+    ``restoreFiles``, the files are restored). Requires the chat to be open —
+    vibe only rewinds live sessions — and targets the chain tip (the id vibe
+    holds live). The UI must confirm with the user before the non-preview call:
+    it truncates conversation history and rewrites workspace files.
+    """
+    await _client.ensure_started()
+    tip = await asyncio.to_thread(provenance.vibe_chain_tip, session_id)
+    if payload.preview:
+        method = "_rewind/preview"
+        params: JsonDict = {"sessionId": tip, "messageId": payload.message_id}
+    else:
+        _audit.info("rewind requested: %s -> message %s", session_id, payload.message_id)
+        method = "_rewind/to"
+        params = {
+            "sessionId": tip,
+            "messageId": payload.message_id,
+            "restoreFiles": payload.restore_files,
+        }
+    resp = await _client.request(method, params)
+    if "error" in resp:
+        err = cast("JsonDict", resp["error"])
+        raise HTTPException(status_code=409, detail=str(err.get("message", err)))
+    if not payload.preview:
+        _audit.info("rewind performed: %s -> message %s", session_id, payload.message_id)
+    return cast("JsonDict", resp.get("result") or {})
 
 
 class ArchiveSessionPayload(BaseModel):

--- a/src/medmcp/server.py
+++ b/src/medmcp/server.py
@@ -1113,6 +1113,7 @@ class _ChatConnection:
         servers: list[JsonDict],
         *,
         resumed: bool = False,
+        canonical_id: str | None = None,
     ) -> None:
         """Bind the websocket to its registered session queue.
 
@@ -1121,9 +1122,13 @@ class _ChatConnection:
         cannot go stale within a connection's lifetime. ``resumed`` marks a
         session reattached via ``session/load`` — it already has a transcript,
         so it must not be purged as an abandoned empty session on close.
+        ``canonical_id`` is the chain-root id the browser and provenance key
+        on; it differs from ``session_id`` (the vibe RPC target) when a resume
+        was mapped onto a compaction continuation (see ``ws_chat``).
         """
         self.ws = ws
         self.session_id = session_id
+        self.canonical_id = canonical_id or session_id
         self.queue = queue
         self.servers = servers
         self._resumed = resumed
@@ -1188,7 +1193,7 @@ class _ChatConnection:
         _client.unregister_session(self.session_id)
         if not self._prompted and not self._resumed:
             with contextlib.suppress(Exception):
-                await asyncio.to_thread(provenance.purge_session, self.session_id)
+                await asyncio.to_thread(provenance.purge_session, self.canonical_id)
 
     async def _cancel_prompt(self) -> None:
         """Cancel the running prompt task and tell vibe-acp to abort its loop."""
@@ -1290,7 +1295,7 @@ class _ChatConnection:
                 with contextlib.suppress(Exception):
                     await asyncio.to_thread(
                         lambda: provenance.write_manifest(
-                            self.session_id,
+                            self.canonical_id,
                             servers=self.servers,
                             model_name=settings.OLLAMA_MODEL,
                         )
@@ -1439,7 +1444,7 @@ class _ChatConnection:
                         with contextlib.suppress(Exception):
                             await asyncio.to_thread(
                                 lambda: provenance.record_tool_event(
-                                    self.session_id,
+                                    self.canonical_id,
                                     tc_id,
                                     event_info,
                                     [str(s["name"]) for s in self.servers],
@@ -1578,7 +1583,7 @@ class _ChatConnection:
 
         def _mirror() -> None:
             if settings.load_provenance_enabled():
-                provenance.log_permission(self.session_id, title=str(title), decision=decision)
+                provenance.log_permission(self.canonical_id, title=str(title), decision=decision)
 
         with contextlib.suppress(Exception):
             await asyncio.to_thread(_mirror)
@@ -1588,17 +1593,58 @@ class _ChatConnection:
 # ── Sessions API ───────────────────────────────────────────
 
 
+def _chain_root(sid: str, parents: dict[str, str], listed: set[str]) -> str:
+    """Walk ``parent_session_id`` backlinks up to the topmost *listed* ancestor."""
+    seen: set[str] = set()
+    cur = sid
+    while cur in parents and cur not in seen:
+        seen.add(cur)
+        parent = parents[cur]
+        if parent not in listed:
+            break
+        cur = parent
+    return cur
+
+
 def _merge_session_registry(raw: list[JsonDict]) -> list[JsonDict]:
     """Overlay UI metadata (title override, archived, provenance) onto vibe's list.
 
-    Runs off the event loop: it reads the registry file and stats a provenance
-    directory per session.
+    Compaction rolls a chat over to a fresh session dir, so vibe lists one chat
+    as several sessions. Continuations — entries whose ``parent_session_id``
+    chain reaches another listed session — are folded into their root: hidden
+    from the list, with the root carrying the newest ``updatedAt`` of the chain.
+    An entry with a UI-registry record is never folded (registry entries mean
+    the user sees that chat as its own — e.g. a deliberate fork — while pure
+    continuations never acquire one).
+
+    Runs off the event loop: it reads the registry file, scans session metas,
+    and stats a provenance directory per session.
     """
     registry = sessions.load_registry()
+    parents = provenance.vibe_session_parents()
+    ids = {
+        sid
+        for s in raw
+        if isinstance(sid := (s.get("sessionId") or s.get("session_id")), str) and sid
+    }
+    # First pass: fold continuations into their roots, keeping the newest stamp.
+    newest_updated: dict[str, str] = {}
+    hidden: set[str] = set()
+    for s in raw:
+        sid = s.get("sessionId") or s.get("session_id")
+        if not (isinstance(sid, str) and sid) or sid in registry:
+            continue
+        root = _chain_root(sid, parents, ids)
+        if root == sid:
+            continue
+        hidden.add(sid)
+        updated = s.get("updatedAt") or s.get("updated_at")
+        if isinstance(updated, str) and updated > newest_updated.get(root, ""):
+            newest_updated[root] = updated
     out: list[JsonDict] = []
     for s in raw:
         sid = s.get("sessionId") or s.get("session_id")
-        if not (isinstance(sid, str) and sid):
+        if not (isinstance(sid, str) and sid) or sid in hidden:
             continue
         entry = registry.get(sid, {})
         override = entry.get("title")
@@ -1607,11 +1653,15 @@ def _merge_session_registry(raw: list[JsonDict]) -> list[JsonDict]:
         else:
             raw_title = s.get("title")
             title = _strip_workspace_note(str(raw_title)) if raw_title else ""
+        updated = s.get("updatedAt") or s.get("updated_at")
+        folded = newest_updated.get(sid)
+        if folded is not None and (not isinstance(updated, str) or folded > updated):
+            updated = folded
         out.append(
             {
                 "id": sid,
                 "title": title or None,
-                "updatedAt": s.get("updatedAt") or s.get("updated_at"),
+                "updatedAt": updated,
                 "archived": bool(entry.get("archived")),
                 "hasProvenance": provenance.provenance_dir(sid).is_dir(),
             }
@@ -1649,13 +1699,15 @@ async def rename_session(session_id: str, payload: RenameSessionPayload) -> Json
     await asyncio.to_thread(sessions.set_title, session_id, payload.title)
     # Write the title through to vibe's own session metadata (ext method, vibe
     # ≥2.23; ACP extension methods are underscore-prefixed on the wire) so it
-    # also shows up wherever vibe surfaces the session. Best-effort: the registry
-    # override above is what the UI reads, and vibe may not be running (it
-    # starts lazily with the first chat socket).
+    # also shows up wherever vibe surfaces the session. Targets the chain tip —
+    # that is the session vibe has live/attached after a compaction. Best-effort:
+    # the registry override above is what the UI reads, and vibe may not be
+    # running (it starts lazily with the first chat socket).
     title = payload.title.strip()
     if title:
         with contextlib.suppress(Exception):
-            await _client.request("_session/set_title", {"sessionId": session_id, "title": title})
+            tip = await asyncio.to_thread(provenance.vibe_chain_tip, session_id)
+            await _client.request("_session/set_title", {"sessionId": tip, "title": title})
     return {"ok": True}
 
 
@@ -1676,11 +1728,13 @@ async def archive_session(session_id: str, payload: ArchiveSessionPayload) -> Js
 async def delete_session(session_id: str) -> JsonDict:
     """Delete a session for good: its transcript, provenance, and UI metadata."""
     # Let vibe drop the session first (ext method, vibe ≥2.23: closes a live
-    # attachment and deletes its stored copy) so a running agent's session list
-    # doesn't go stale. Best-effort — the purge below sweeps whatever remains on
-    # disk (provenance plus any compaction continuations) either way.
+    # attachment and deletes its stored copy). Targets the chain tip — after a
+    # compaction that is the id vibe holds live. Best-effort — the purge below
+    # sweeps whatever remains on disk (provenance plus the whole transcript
+    # chain) either way.
     with contextlib.suppress(Exception):
-        await _client.request("_session/delete", {"sessionId": session_id})
+        tip = await asyncio.to_thread(provenance.vibe_chain_tip, session_id)
+        await _client.request("_session/delete", {"sessionId": tip})
 
     def _delete() -> None:
         provenance.purge_session(session_id)
@@ -1737,18 +1791,26 @@ async def ws_chat(ws: WebSocket, resume: str | None = None) -> None:
         # a fresh session if the id is gone/unloadable.
         replayed = False
         session_id = ""
+        canonical_id: str | None = None
         queue: asyncio.Queue[JsonDict] | None = None
         if resume:
-            queue = _client.register_session(resume)
+            # Resume the chain *tip*, not the requested root: after a compaction
+            # the root dir only holds the pre-compaction prefix, while the tip
+            # carries the summary plus everything since. The browser keeps the
+            # root id (canonical) — ready reports it, provenance keys on it —
+            # and only the vibe RPC target is the tip.
+            tip = await asyncio.to_thread(provenance.vibe_chain_tip, resume)
+            queue = _client.register_session(tip)
             load = await _client.request(
                 "session/load",
-                {"cwd": str(WORKSPACE_ROOT), "mcpServers": [], "sessionId": resume},
+                {"cwd": str(WORKSPACE_ROOT), "mcpServers": [], "sessionId": tip},
             )
             if "error" in load:
-                _client.unregister_session(resume)
+                _client.unregister_session(tip)
                 queue = None
             else:
-                session_id = resume
+                session_id = tip
+                canonical_id = resume
                 replayed = True
         if not session_id:
             session_id = await _new_session()
@@ -1759,10 +1821,12 @@ async def ws_chat(ws: WebSocket, resume: str | None = None) -> None:
             queue = _client.register_session(session_id)
 
         assert queue is not None
-        conn = _ChatConnection(ws, session_id, queue, servers, resumed=replayed)
+        conn = _ChatConnection(
+            ws, session_id, queue, servers, resumed=replayed, canonical_id=canonical_id
+        )
         _connections.add(conn)
         await ws.send_json(
-            {"type": "ready", "sessionId": session_id, "model": settings.OLLAMA_MODEL}
+            {"type": "ready", "sessionId": conn.canonical_id, "model": settings.OLLAMA_MODEL}
         )
         if replayed:
             await conn.replay_history()

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -260,6 +260,32 @@ def test_find_vibe_session_dirs_unknown_session(tmp_path: Path) -> None:
         assert provenance.find_vibe_session_dirs(SESSION_ID) == []
 
 
+def test_vibe_session_parents_maps_backlinks(tmp_path: Path) -> None:
+    """Only sessions with a parent_session_id appear, mapped child -> parent."""
+    _make_vibe_session(tmp_path, "20260101_000000", SESSION_ID)
+    _make_vibe_session(tmp_path, "20260101_010000", CONT_ID, parent_id=SESSION_ID)
+    _make_vibe_session(tmp_path, "20260101_020000", CONT2_ID, parent_id=CONT_ID)
+    with patch.object(provenance, "VIBE_HOME", tmp_path):
+        assert provenance.vibe_session_parents() == {CONT_ID: SESSION_ID, CONT2_ID: CONT_ID}
+
+
+def test_vibe_chain_tip_follows_to_newest_link(tmp_path: Path) -> None:
+    """The tip of a compaction chain is the newest continuation's id."""
+    _make_vibe_session(tmp_path, "20260101_000000", SESSION_ID)
+    _make_vibe_session(tmp_path, "20260101_010000", CONT_ID, parent_id=SESSION_ID)
+    _make_vibe_session(tmp_path, "20260101_020000", CONT2_ID, parent_id=CONT_ID)
+    with patch.object(provenance, "VIBE_HOME", tmp_path):
+        assert provenance.vibe_chain_tip(SESSION_ID) == CONT2_ID
+
+
+def test_vibe_chain_tip_without_chain_is_identity(tmp_path: Path) -> None:
+    """A session with no continuation (or unknown) maps to itself."""
+    _make_vibe_session(tmp_path, "20260101_000000", SESSION_ID)
+    with patch.object(provenance, "VIBE_HOME", tmp_path):
+        assert provenance.vibe_chain_tip(SESSION_ID) == SESSION_ID
+        assert provenance.vibe_chain_tip("99999999-x") == "99999999-x"
+
+
 def test_purge_session_removes_compaction_continuations(tmp_path: Path) -> None:
     """Purging a chat also deletes the transcript dirs compaction rolled over to."""
     original = _make_vibe_session(tmp_path, "20260101_000000", SESSION_ID)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -9,7 +9,7 @@ exercisable without a live vibe-acp subprocess.
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from pathlib import Path
 from typing import Any, cast
 
@@ -533,6 +533,15 @@ class TestVisiblePermissionOptions:
         assert server._visible_permission_options(options) == options
 
 
+def _prov_dir_in(tmp_path: Path) -> Callable[[str], Path]:
+    """Return a provenance_dir substitute rooted at *tmp_path*."""
+
+    def _prov_dir(session_id: str) -> Path:
+        return tmp_path / session_id
+
+    return _prov_dir
+
+
 class TestSessionsApi:
     """GET /api/sessions maps vibe-acp's session/list to the UI shape."""
 
@@ -623,6 +632,94 @@ class TestSessionsApi:
         assert rows["s2"]["title"] == "kept"
         assert rows["s2"]["archived"] is True
         assert rows["s2"]["hasProvenance"] is False
+
+    def test_folds_compaction_continuations(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A continuation is hidden; its root carries the chain's newest updatedAt."""
+        self._stub_client(
+            monkeypatch,
+            {
+                "result": {
+                    "sessions": [
+                        {"sessionId": "root", "title": "Chat", "updatedAt": "t1"},
+                        {"sessionId": "cont", "title": None, "updatedAt": "t9"},
+                        {"sessionId": "other", "title": "Other", "updatedAt": "t2"},
+                    ]
+                }
+            },
+        )
+        monkeypatch.setattr(sessions, "load_registry", dict)
+        monkeypatch.setattr(provenance, "vibe_session_parents", lambda: {"cont": "root"})
+        monkeypatch.setattr(provenance, "provenance_dir", _prov_dir_in(tmp_path))
+        client = TestClient(server.app)
+        rows = client.get("/api/sessions").json()["sessions"]
+        assert [s["id"] for s in rows] == ["root", "other"]
+        assert rows[0]["updatedAt"] == "t9"
+        assert rows[1]["updatedAt"] == "t2"
+
+    def test_multi_hop_chain_folds_to_root(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Several compactions still collapse into the one root entry."""
+        self._stub_client(
+            monkeypatch,
+            {
+                "result": {
+                    "sessions": [
+                        {"sessionId": "root", "title": "Chat", "updatedAt": "t1"},
+                        {"sessionId": "c1", "title": None, "updatedAt": "t5"},
+                        {"sessionId": "c2", "title": None, "updatedAt": "t9"},
+                    ]
+                }
+            },
+        )
+        monkeypatch.setattr(sessions, "load_registry", dict)
+        monkeypatch.setattr(provenance, "vibe_session_parents", lambda: {"c1": "root", "c2": "c1"})
+        monkeypatch.setattr(provenance, "provenance_dir", _prov_dir_in(tmp_path))
+        client = TestClient(server.app)
+        rows = client.get("/api/sessions").json()["sessions"]
+        assert [s["id"] for s in rows] == ["root"]
+        assert rows[0]["updatedAt"] == "t9"
+
+    def test_registry_entry_is_never_folded(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A child the user can see (registry record — e.g. a fork) stays listed."""
+        self._stub_client(
+            monkeypatch,
+            {
+                "result": {
+                    "sessions": [
+                        {"sessionId": "root", "title": "Chat", "updatedAt": "t1"},
+                        {"sessionId": "fork", "title": None, "updatedAt": "t9"},
+                    ]
+                }
+            },
+        )
+        monkeypatch.setattr(sessions, "load_registry", lambda: {"fork": {"title": "My branch"}})
+        monkeypatch.setattr(provenance, "vibe_session_parents", lambda: {"fork": "root"})
+        monkeypatch.setattr(provenance, "provenance_dir", _prov_dir_in(tmp_path))
+        client = TestClient(server.app)
+        rows = client.get("/api/sessions").json()["sessions"]
+        assert [s["id"] for s in rows] == ["root", "fork"]
+        assert rows[0]["updatedAt"] == "t1"  # nothing folded into the root
+        assert rows[1]["title"] == "My branch"
+
+    def test_child_of_unlisted_parent_stays(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A backlink to a session outside this workspace's list does not hide it."""
+        self._stub_client(
+            monkeypatch,
+            {"result": {"sessions": [{"sessionId": "c1", "title": "Solo", "updatedAt": "t1"}]}},
+        )
+        monkeypatch.setattr(sessions, "load_registry", dict)
+        monkeypatch.setattr(provenance, "vibe_session_parents", lambda: {"c1": "elsewhere"})
+        monkeypatch.setattr(provenance, "provenance_dir", _prov_dir_in(tmp_path))
+        client = TestClient(server.app)
+        rows = client.get("/api/sessions").json()["sessions"]
+        assert [s["id"] for s in rows] == ["c1"]
 
     def test_rename_sets_title(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """POST …/rename forwards to the registry's set_title."""


### PR DESCRIPTION
## Summary
Adds an "undo from here" affordance to the chat: hovering a replayed user turn reveals a rewind button; the flow previews which workspace files a rewind would restore, asks for explicit confirmation, then performs vibe 2.23's **in-place** rewind (`_rewind/to` ext method) and reconnects the socket so the history replay rebuilds the truncated transcript.

Replaces #91, which GitHub locked closed when #90's base branch was deleted on merge (squash-merged stacks don't auto-retarget); identical content, now based on `main` (which contains #90).

## Test plan
- [x] `just check` green (308 passed), `npm run lint` + `npm run build` green
- [x] Live test against a running workspace: replayed turns carry messageIds, preview returns the restorable paths, the rewind truncates in place (returning the rewound message text), and the next replay shows only the pre-rewind transcript (8/8 checks)
- [x] Headless-chromium screenshot of the workspace with the new bundle — no visual regression (the button itself is hover-revealed)
- [ ] Manual hover/click pass in a real browser (the confirm card and hover affordance)

## Screenshots
The rewind button is hover-revealed on replayed user turns; static capture shows no layout change.

## Security & data handling
- Rewind restores workspace files (`restoreFiles`, default true) — a mutation, so the UI always previews and asks for explicit confirmation first, and every rewind is written to the `medmcp.audit` log.
- The endpoint only works on live (open) chats — vibe refuses others; errors map to 409.

## Notes
- Live turns sent in the current connection don't carry a messageId (vibe generates it internally); after any reconnect the replay provides ids for all turns. The button therefore appears on replayed turns only — v1 scope.
- The rewound message text is returned by vibe; refilling the input box with it is a possible follow-up nicety.