### PR TITLE
fix: live-echo duplicates and fork/chain confusion (vibe 2.23 follow-ups)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog
+
+Notable, user-visible changes to MedMCP. Format follows
+[Keep a Changelog](https://keepachangelog.com/); entries land under
+**Unreleased** as PRs merge and move under a version heading at release time.
+
+## Unreleased
+
+### Added
+
+- **Rewind**: hover a user message in a resumed chat to rewind the conversation
+  to before it — previews which workspace files would be restored, asks for
+  confirmation, then truncates in place (#93).
+- **Branch a chat**: a git-branch icon on the open chat's row in the Chats menu
+  duplicates its full history into a new session, for trying a second analysis
+  path on the same context; branches inherit the source's title (#92).
+- Stack connection failures now surface as a chat message on session start
+  ("The following MCP servers failed to connect: …") instead of tools being
+  silently missing (#89).
+
+### Changed
+
+- One chat, one entry: context compaction no longer splits a chat into multiple
+  sessions in the Chats menu, and reopening a compacted chat restores the full
+  post-compaction context — including after an agent restart (#90).
+- Deleting a chat now removes everything it produced: the whole transcript
+  chain, the provenance record, and the agent's own stored copy (#89, #90).
+- Renaming a chat writes the title into the agent's session metadata too (#89).
+- The context meter reports the model's actually-served window (Ollama
+  `num_ctx`), not the model family's nominal maximum (#89).
+- Replayed chats show the user's message text without the internal
+  `[workspace context: …]` viewer note, natively (#89).
+
+### Fixed
+
+- Sent messages no longer appear twice (the agent runtime echoes live prompts
+  since vibe 2.23; the echo is now merged into the already-rendered bubble) —
+  as a side effect, messages sent in the current session become rewindable
+  immediately instead of after a reload (#94).
+- A branched chat and its original are now truly independent: opening the
+  original no longer attaches to the branch, deleting the original no longer
+  deletes the branch, and workflow distillation no longer mixes the two (#94).
+- Workflow distillation covers tool calls made after a context compaction (#89).
+
+### Security
+
+- Every bash command the agent runs now requires interactive approval: the
+  read-only allowlist was removed after finding that an output redirect from an
+  allowlisted command (e.g. `echo "" > file`) wrote files without a prompt (#89).
+- The permission dialog no longer offers the durable "Always allow" option
+  vibe 2.23 introduced (it would persist an auto-approval into the config) —
+  per-session approval remains (#89).
+- The agent's built-in `skill-creator` skill is disabled: workflow distillation
+  stays the single, reviewable skill-authoring path (#89).
+
+### Dependencies
+
+- mistral-vibe 2.17 → 2.23.3, fastapi 0.141, ruff 0.16 (#84, #88, #89).

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -451,12 +451,24 @@ export const Chat = memo(function Chat({
           setItems((prev) => [...prev, { kind: 'error', text: frame.message }])
           break
         case 'user':
-          // A replayed user turn from a resumed session (live sends are added
-          // locally in send(), so this only fires during history replay).
-          setItems((prev) => [
-            ...prev,
-            { kind: 'user', text: frame.text, messageId: frame.messageId },
-          ])
+          // Two sources: history replay on resume, and vibe ≥2.23's echo of a
+          // *live* prompt. Live sends are already rendered locally in send(),
+          // so when the echo matches the newest id-less user bubble, merge its
+          // messageId into that bubble instead of appending a duplicate — this
+          // is also what gives live turns a rewind anchor without a reload.
+          setItems((prev) => {
+            for (let j = prev.length - 1; j >= 0; j--) {
+              const it = prev[j]
+              if (it.kind !== 'user') continue
+              if (!it.messageId && it.text === frame.text) {
+                const next = prev.slice()
+                next[j] = { ...it, messageId: frame.messageId }
+                return next
+              }
+              break // newest user turn differs — a genuine replayed frame
+            }
+            return [...prev, { kind: 'user', text: frame.text, messageId: frame.messageId }]
+          })
           break
         case 'ready':
           // (Re)connect: the server is the transcript's source of truth — a

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -196,8 +196,8 @@ export interface RewindResult {
 export type ServerFrame =
   | { type: 'ready'; sessionId: string; model?: string }
   | { type: 'chunk'; text: string }
-  // Replayed user turn from a resumed session (session/load); live prompts are
-  // rendered locally on send and are not echoed by the server.
+  // A user turn: replayed from a resumed session (session/load), or vibe's
+  // echo of a live prompt (merged into the locally-rendered bubble by id).
   | { type: 'user'; text: string; messageId?: string }
   | {
       type: 'tool_call'

--- a/src/medmcp/distill.py
+++ b/src/medmcp/distill.py
@@ -26,6 +26,7 @@ import json
 import os
 import re
 import shutil
+from collections.abc import Collection
 from pathlib import Path
 from typing import Any, cast
 
@@ -660,19 +661,21 @@ def distill_session(
     *,
     use_llm: bool = True,
     workflows_root: Path | None = None,
+    chain_stop_ids: Collection[str] = (),
 ) -> Path:
     """Distill *session_id* into a draft workflow directory and return its path.
 
     Reads the session's ``messages.jsonl`` — concatenated across the session's
     compaction chain (vibe rolls a compacted conversation over to a new dir;
     see :func:`provenance.find_vibe_session_dirs`), so tool calls made after a
-    compaction distill too — builds a parameterized recipe, adds a (hybrid)
+    compaction distill too — ``chain_stop_ids`` keeps the walk out of forks
+    (pass the UI session registry's ids) — builds a parameterized recipe, adds a (hybrid)
     prose narrative, and writes ``recipe.yaml`` + ``SKILL.md`` into
     ``<workflows_root>/draft/<name>/`` for human review.
 
     Raises ``FileNotFoundError`` if the session's raw log cannot be located.
     """
-    session_dirs = provenance.find_vibe_session_dirs(session_id)
+    session_dirs = provenance.find_vibe_session_dirs(session_id, stop_ids=chain_stop_ids)
     if not session_dirs:
         raise FileNotFoundError(f"no vibe session log found for session {session_id!r}")
     message_paths = [d / "messages.jsonl" for d in session_dirs if (d / "messages.jsonl").exists()]

--- a/src/medmcp/provenance.py
+++ b/src/medmcp/provenance.py
@@ -30,6 +30,7 @@ import subprocess
 import sys
 import time
 import tomllib
+from collections.abc import Collection
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, cast
@@ -340,7 +341,7 @@ def find_vibe_session_dir(session_id: str) -> Path | None:
     return candidates[0] if candidates else None
 
 
-def find_vibe_session_dirs(session_id: str) -> list[Path]:
+def find_vibe_session_dirs(session_id: str, *, stop_ids: Collection[str] = ()) -> list[Path]:
     """Locate *session_id*'s log dir plus its compaction continuations, in order.
 
     On context compaction vibe rolls the conversation over to a fresh session id
@@ -348,6 +349,14 @@ def find_vibe_session_dirs(session_id: str) -> list[Path]:
     ``meta.json``. Following those backlinks (vibe ≥2.21 writes them) yields the
     whole chain — original first, then each continuation in creation order — so
     purge and distillation see one chat, not just its pre-compaction prefix.
+
+    ``stop_ids`` marks children that are chats in their own right and must not
+    be walked into: a **fork** carries the same ``parent_session_id`` backlink
+    as a compaction continuation, so without the stop set a branched chat would
+    be treated as its source's continuation (resume would land in the fork,
+    purge would delete it, distillation would mix it in). Callers pass the UI
+    session registry's ids — a fork is registered there at creation, while a
+    pure continuation never is. *session_id* itself is never a stop.
     """
     root = find_vibe_session_dir(session_id)
     if root is None:
@@ -365,13 +374,14 @@ def find_vibe_session_dirs(session_id: str) -> list[Path]:
         parent_id = data.get("parent_session_id")
         if isinstance(child_id, str) and isinstance(parent_id, str) and parent_id:
             children.setdefault(parent_id, []).append((candidate, child_id))
+    stop = set(stop_ids) - {session_id}
     chain: list[Path] = [root]
     queue: list[str] = [session_id]
     seen: set[str] = {session_id}
     while queue:
         for child_dir, child_id in children.get(queue.pop(0), []):
-            if child_id in seen:  # defensive: malformed metas must not loop
-                continue
+            if child_id in seen or child_id in stop:
+                continue  # already walked, or another chat (fork) — not ours
             seen.add(child_id)
             chain.append(child_dir)
             queue.append(child_id)
@@ -403,16 +413,17 @@ def vibe_session_parents() -> dict[str, str]:
     return parents
 
 
-def vibe_chain_tip(session_id: str) -> str:
+def vibe_chain_tip(session_id: str, *, stop_ids: Collection[str] = ()) -> str:
     """Follow compaction continuations from *session_id* to the newest link.
 
     Returns *session_id* itself when it has no continuation (or is unknown).
     Resuming the tip instead of the root restores the post-compaction context;
-    the root dir only holds the pre-compaction prefix. With several children
-    (defensive — pure compaction rolls over to at most one) the newest dir in
-    the chain wins.
+    the root dir only holds the pre-compaction prefix. ``stop_ids`` keeps the
+    walk out of forks (see :func:`find_vibe_session_dirs`). With several
+    children (defensive — pure compaction rolls over to at most one) the
+    newest dir in the chain wins.
     """
-    dirs = find_vibe_session_dirs(session_id)
+    dirs = find_vibe_session_dirs(session_id, stop_ids=stop_ids)
     if len(dirs) < 2:
         return session_id
     data = _read_session_meta(dirs[-1])
@@ -455,18 +466,19 @@ def purge_orphans(referenced_ids: set[str]) -> list[str]:
     return purged
 
 
-def purge_session(session_id: str) -> None:
+def purge_session(session_id: str, *, stop_ids: Collection[str] = ()) -> None:
     """Delete all on-disk logs for *session_id*.
 
     Removes the provenance directory and every vibe transcript dir in the
     session's chain (the original plus compaction continuations, see
-    :func:`find_vibe_session_dirs`), so deleting a chat leaves nothing orphaned
-    on disk. Best-effort: missing paths are ignored.
+    :func:`find_vibe_session_dirs` — ``stop_ids`` keeps forks alive), so
+    deleting a chat leaves nothing orphaned on disk. Best-effort: missing
+    paths are ignored.
     """
     pdir = provenance_dir(session_id)
     if pdir.exists():
         shutil.rmtree(pdir, ignore_errors=True)
-    for vibe_dir in find_vibe_session_dirs(session_id):
+    for vibe_dir in find_vibe_session_dirs(session_id, stop_ids=stop_ids):
         shutil.rmtree(vibe_dir, ignore_errors=True)
 
 

--- a/src/medmcp/server.py
+++ b/src/medmcp/server.py
@@ -642,7 +642,11 @@ async def post_distill(payload: DistillPayload) -> JsonDict:
     while; distillation itself never hard-fails on a model outage.
     """
     try:
-        draft_dir = await asyncio.to_thread(distill.distill_session, payload.session_id)
+        draft_dir = await asyncio.to_thread(
+            lambda: distill.distill_session(
+                payload.session_id, chain_stop_ids=_chain_stop_ids(payload.session_id)
+            )
+        )
     except FileNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     _audit.info("workflow distilled: %s", draft_dir.name)
@@ -1193,7 +1197,11 @@ class _ChatConnection:
         _client.unregister_session(self.session_id)
         if not self._prompted and not self._resumed:
             with contextlib.suppress(Exception):
-                await asyncio.to_thread(provenance.purge_session, self.canonical_id)
+                await asyncio.to_thread(
+                    lambda: provenance.purge_session(
+                        self.canonical_id, stop_ids=_chain_stop_ids(self.canonical_id)
+                    )
+                )
 
     async def _cancel_prompt(self) -> None:
         """Cancel the running prompt task and tell vibe-acp to abort its loop."""
@@ -1600,6 +1608,18 @@ class _ChatConnection:
 # ── Sessions API ───────────────────────────────────────────
 
 
+def _chain_stop_ids(session_id: str) -> set[str]:
+    """Registry ids that end a chain walk from *session_id* (reads a file).
+
+    A fork carries the same ``parent_session_id`` backlink as a compaction
+    continuation; its registry entry (created at fork time) marks it as its
+    own chat, so the resume tip-mapping, purge, and distillation must not
+    walk into it. The walked session's own entry (e.g. a renamed root) never
+    stops its own chain. File I/O — call via ``asyncio.to_thread``.
+    """
+    return set(sessions.load_registry()) - {session_id}
+
+
 def _chain_root(sid: str, parents: dict[str, str], listed: set[str]) -> str:
     """Walk ``parent_session_id`` backlinks up to the topmost *listed* ancestor."""
     seen: set[str] = set()
@@ -1713,7 +1733,9 @@ async def rename_session(session_id: str, payload: RenameSessionPayload) -> Json
     title = payload.title.strip()
     if title:
         with contextlib.suppress(Exception):
-            tip = await asyncio.to_thread(provenance.vibe_chain_tip, session_id)
+            tip = await asyncio.to_thread(
+                lambda: provenance.vibe_chain_tip(session_id, stop_ids=_chain_stop_ids(session_id))
+            )
             await _client.request("_session/set_title", {"sessionId": tip, "title": title})
     return {"ok": True}
 
@@ -1731,7 +1753,9 @@ async def fork_session(session_id: str) -> JsonDict:
     live sessions); targets the chain tip, the id vibe holds live.
     """
     await _client.ensure_started()
-    tip = await asyncio.to_thread(provenance.vibe_chain_tip, session_id)
+    tip = await asyncio.to_thread(
+        lambda: provenance.vibe_chain_tip(session_id, stop_ids=_chain_stop_ids(session_id))
+    )
     resp = await _client.request(
         "session/fork", {"sessionId": tip, "cwd": str(WORKSPACE_ROOT), "mcpServers": []}
     )
@@ -1778,7 +1802,9 @@ async def rewind_session(session_id: str, payload: RewindPayload) -> JsonDict:
     it truncates conversation history and rewrites workspace files.
     """
     await _client.ensure_started()
-    tip = await asyncio.to_thread(provenance.vibe_chain_tip, session_id)
+    tip = await asyncio.to_thread(
+        lambda: provenance.vibe_chain_tip(session_id, stop_ids=_chain_stop_ids(session_id))
+    )
     if payload.preview:
         method = "_rewind/preview"
         params: JsonDict = {"sessionId": tip, "messageId": payload.message_id}
@@ -1821,11 +1847,13 @@ async def delete_session(session_id: str) -> JsonDict:
     # sweeps whatever remains on disk (provenance plus the whole transcript
     # chain) either way.
     with contextlib.suppress(Exception):
-        tip = await asyncio.to_thread(provenance.vibe_chain_tip, session_id)
+        tip = await asyncio.to_thread(
+            lambda: provenance.vibe_chain_tip(session_id, stop_ids=_chain_stop_ids(session_id))
+        )
         await _client.request("_session/delete", {"sessionId": tip})
 
     def _delete() -> None:
-        provenance.purge_session(session_id)
+        provenance.purge_session(session_id, stop_ids=_chain_stop_ids(session_id))
         sessions.remove(session_id)
 
     await asyncio.to_thread(_delete)
@@ -1887,7 +1915,9 @@ async def ws_chat(ws: WebSocket, resume: str | None = None) -> None:
             # carries the summary plus everything since. The browser keeps the
             # root id (canonical) — ready reports it, provenance keys on it —
             # and only the vibe RPC target is the tip.
-            tip = await asyncio.to_thread(provenance.vibe_chain_tip, resume)
+            tip = await asyncio.to_thread(
+                lambda: provenance.vibe_chain_tip(resume, stop_ids=_chain_stop_ids(resume))
+            )
             queue = _client.register_session(tip)
             load = await _client.request(
                 "session/load",

--- a/src/medmcp/server.py
+++ b/src/medmcp/server.py
@@ -1392,7 +1392,9 @@ class _ChatConnection:
                     if visible:
                         await self._send({"type": "chunk", "text": visible})
             elif update_type == "user_message_chunk":
-                # Replayed user turns (session/load); live prompts are not echoed.
+                # Replayed user turns (session/load) — and, since vibe 2.23, an
+                # echo of the *live* prompt carrying its messageId; the browser
+                # merges that echo into the locally-rendered bubble.
                 text = _replayed_user_text(update)
                 if text:
                     frame: JsonDict = {"type": "user", "text": text}

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -286,6 +286,38 @@ def test_vibe_chain_tip_without_chain_is_identity(tmp_path: Path) -> None:
         assert provenance.vibe_chain_tip("99999999-x") == "99999999-x"
 
 
+def test_chain_walk_stops_at_forks(tmp_path: Path) -> None:
+    """A fork (stop id) is not treated as its source's continuation.
+
+    Forks carry the same parent_session_id backlink as compaction
+    continuations; without the stop set, resuming the source would land in
+    the fork and purging the source would delete it.
+    """
+    original = _make_vibe_session(tmp_path, "20260101_000000", SESSION_ID)
+    fork = _make_vibe_session(tmp_path, "20260101_010000", CONT_ID, parent_id=SESSION_ID)
+    with patch.object(provenance, "VIBE_HOME", tmp_path):
+        assert provenance.find_vibe_session_dirs(SESSION_ID, stop_ids={CONT_ID}) == [original]
+        assert provenance.vibe_chain_tip(SESSION_ID, stop_ids={CONT_ID}) == SESSION_ID
+        # The fork's own chain still walks (its own id never stops itself).
+        assert provenance.find_vibe_session_dirs(CONT_ID, stop_ids={CONT_ID}) == [fork]
+
+        provenance.purge_session(SESSION_ID, stop_ids={CONT_ID})
+
+        assert not original.exists()
+        assert fork.exists()  # the branched chat survives its source's deletion
+
+
+def test_chain_walk_stops_only_at_fork_boundary(tmp_path: Path) -> None:
+    """A compaction continuation *behind* a fork boundary is still excluded."""
+    _make_vibe_session(tmp_path, "20260101_000000", SESSION_ID)
+    _make_vibe_session(tmp_path, "20260101_010000", CONT_ID, parent_id=SESSION_ID)
+    # CONT2 continues the fork (e.g. the fork later compacted) — not ours.
+    _make_vibe_session(tmp_path, "20260101_020000", CONT2_ID, parent_id=CONT_ID)
+    with patch.object(provenance, "VIBE_HOME", tmp_path):
+        dirs = provenance.find_vibe_session_dirs(SESSION_ID, stop_ids={CONT_ID})
+        assert [d.name.split("_")[-1] for d in dirs] == [SESSION_ID[:8]]
+
+
 def test_purge_session_removes_compaction_continuations(tmp_path: Path) -> None:
     """Purging a chat also deletes the transcript dirs compaction rolled over to."""
     original = _make_vibe_session(tmp_path, "20260101_000000", SESSION_ID)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -751,7 +751,8 @@ class TestSessionsApi:
         """DELETE …/{id} purges the transcript/provenance and drops the registry entry."""
         calls: list[tuple[str, str]] = []
 
-        def _purge(session_id: str) -> None:
+        def _purge(session_id: str, *, stop_ids: Iterable[str] = ()) -> None:
+            del stop_ids
             calls.append(("purge", session_id))
 
         def _remove(session_id: str) -> None:


### PR DESCRIPTION
## Summary
Sent messages appeared twice: vibe ≥2.23 echoes every live prompt back as a `user_message_chunk` (latent since the vibe bump in #88 — pre-2.23 never echoed), the relay forwards it, and the browser had already rendered the text locally on send. Rather than suppressing the echo, the frontend merges its `messageId` into the newest id-less matching user bubble — the duplicate is gone, and live turns gain a **rewind anchor immediately** (closing the v1 limitation noted in #93, where only replayed turns had one).

## Test plan
- [x] Reproduced at the protocol level first: a live prompt yields exactly one `user` frame echo carrying a messageId (no viewer file needed)
- [x] `just check` green (308 passed), `npm run lint` + `npm run build` green
- [x] Real-UI check over CDP (3/3): typed and sent through the actual chat input — exactly one user bubble after the turn, the live turn shows the hover rewind button, throwaway session deleted
- [x] Quick manual send in your own browser after merging (reload to pick up the bundle)

## Second fix: fork/chain confusion (user-reported)
A branched chat and its original showed the same content, and new messages appeared in "both": forks carry the same `parent_session_id` backlink as compaction continuations, so #90's chain walks treated the fork as its source's tail — resuming the original attached to the fork (one live session behind two menu entries). Latent worse cases: deleting the original would purge the fork; distilling it would mix the fork's tool calls in. All chain walks (`find_vibe_session_dirs`/`vibe_chain_tip`/`purge_session`/`distill_session`) now take a stop set — the UI registry's ids, the same discriminator the menu folding already used (a fork is registered at creation; a pure continuation never is).

- [x] 310 tests green (4 new: fork survives source deletion, walks stop exactly at the fork boundary, chain-tip identity with stops, delete-endpoint signature)
- [x] Live fork-isolation test (11/11): shared turn → branch → divergent turn in the original only → each resumes as itself with the right content, no bleed → deleting the original spares the fork

## Also in this PR
- **CHANGELOG.md introduced** (there was none): Keep-a-Changelog format, seeded with an Unreleased section covering the whole vibe 2.23 program (#84–#94) — features, fixes, and the security hardening — so the next release has its notes ready.

## Notes
- Replay behavior is unchanged: a replayed `user` frame that doesn't match the newest id-less bubble is appended as before (resume clears items first, so replays never collide with the merge path).
- If the user sends twice quickly, the first turn's echo is drained server-side with the cancelled turn; its bubble simply keeps no rewind anchor — cosmetic only.