### PR TITLE
sec: deny egress and drop privileges for container stacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ MedMCP assumes the local model can be steered by prompt injection (e.g. text pas
 
 - **No auto-approval**: every tool call (bash, file writes, web fetches) requires an explicit click.
 - **Localhost only**: the server binds to localhost. Do not expose port 8100 over a network without adding real authentication.
-- **No data egress**: `web_search` is disabled and `web_fetch` requires approval. Nothing leaves your infrastructure by default.
+- **No data egress**: `web_search` is disabled and `web_fetch` requires approval.
+- **Isolated tool stacks**: stack containers run with `--network none`, all capabilities dropped, and no privilege escalation. They bake their models at build time, so a tool call cannot reach the network even if the agent is steered into making one. A stack that genuinely needs egress must declare it in its image label.
 
 To report a vulnerability, see **[SECURITY.md](SECURITY.md)**.
 

--- a/src/medmcp/settings.py
+++ b/src/medmcp/settings.py
@@ -23,6 +23,7 @@ import contextlib
 import json
 import logging
 import os
+import platform
 import re
 import shutil
 import subprocess
@@ -566,6 +567,54 @@ def _run_docker(args: list[str], *, timeout: float = 600.0) -> subprocess.Comple
     return result
 
 
+# Docker reports "amd64"/"arm64"; uname reports "x86_64"/"aarch64". Normalise both
+# so a host can be compared against an image manifest.
+_ARCH_ALIASES = {
+    "aarch64": "arm64",
+    "arm64": "arm64",
+    "x86_64": "amd64",
+    "amd64": "amd64",
+}
+
+
+def _normalise_arch(value: str) -> str:
+    """Map a uname- or docker-style architecture onto docker's spelling."""
+    v = value.strip().lower()
+    return _ARCH_ALIASES.get(v, v)
+
+
+def host_arch() -> str:
+    """This host's architecture in docker's spelling ("amd64", "arm64", …)."""
+    return _normalise_arch(platform.machine())
+
+
+def check_image_arch(image: str) -> None:
+    """Raise if *image* was built for a different architecture than this host.
+
+    Docker pulls and creates containers from a foreign-architecture image with only
+    a warning, then fails at exec time — under compose it reports the stack as *up*
+    while the container never starts, which reads as a working install. Checking the
+    image manifest at install time converts that into an actionable error.
+
+    The architecture is read from the image itself rather than from the
+    ``org.medmcp.stack`` label: the manifest cannot be wrong or forgotten, and a
+    multi-arch tag resolves to the host's architecture automatically.
+
+    Raises:
+        RuntimeError: the image cannot execute on this host.
+    """
+    out = _run_docker(["image", "inspect", "--format", "{{.Architecture}}", image], timeout=30)
+    image_arch = _normalise_arch(out.stdout)
+    host = host_arch()
+    if not image_arch or image_arch == host:
+        return
+    raise RuntimeError(
+        f"{image} is built for linux/{image_arch}, but this host is linux/{host}. "
+        "It cannot run here. Ask the stack's maintainer to publish a multi-arch "
+        "image, or build it locally for this architecture."
+    )
+
+
 def read_stack_label(image: str) -> JsonDict:
     """Return the parsed ``org.medmcp.stack`` label of *image*, pulling it if absent.
 
@@ -728,6 +777,10 @@ def install_stack_image(image: str, on_progress: ProgressFn | None = None) -> st
     if not _image_present(image):
         report(f"Pulling {image}…")
         _pull_streaming(image, on_progress)
+
+    # Refuse a foreign-architecture image here rather than letting it install
+    # cleanly and fail at first tool call with "exec format error".
+    check_image_arch(image)
 
     report("Reading stack metadata…")
     meta = read_stack_label(image)

--- a/src/medmcp/settings.py
+++ b/src/medmcp/settings.py
@@ -258,6 +258,45 @@ def call_entry_point(python: Path, module: str, attr: str) -> object:
     return json.loads(result.stdout)
 
 
+# Isolation applied to every container-stack launch. Stacks bake their weights at
+# build time and are offline at runtime (verified: all shipped stacks initialise and
+# register their tools under `--network none`), so egress is denied by default — the
+# safety model assumes the local model can be steered by prompt injection, and a tool
+# call must not become a data-exfiltration path. A stack that genuinely needs egress
+# sets "network": true in its org.medmcp.stack label, which writes an explicit
+# `--network bridge` at install time; that is detected and preserved here.
+#
+# The MCP server inside a stack is a plain Python process over stdio: it needs no
+# capabilities, no privilege escalation, and no unbounded process count.
+_STACK_RUN_HARDENING: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("--network", ("--network", "none")),
+    ("--cap-drop", ("--cap-drop", "ALL")),
+    ("--security-opt", ("--security-opt", "no-new-privileges")),
+    ("--pids-limit", ("--pids-limit", "512")),
+)
+
+
+def _harden_stack_run_args(args: list[str]) -> list[str]:
+    """Insert container-isolation flags into a ``docker run`` argument list.
+
+    Idempotent — a flag already present (written by a newer install, or by a stack
+    that opted into egress) is left untouched. Flags are inserted directly after
+    ``run`` so they precede the image reference and anything after it.
+
+    This runs at manifest *load* time as well as install time, so stacks installed
+    before this existed are hardened without requiring a reinstall. ``stacks.d``
+    manifests are the launch recipe and are written once at install; without the
+    load-time pass, an upgrade would silently leave existing stacks unisolated.
+    """
+    if not args or args[0] != "run":
+        return args
+    missing: list[str] = []
+    for flag, addition in _STACK_RUN_HARDENING:
+        if flag not in args:
+            missing += addition
+    return [args[0], *missing, *args[1:]] if missing else args
+
+
 def _load_stack_manifests() -> list[JsonDict]:
     """Read container-stack manifests from :data:`STACKS_D_PATH`.
 
@@ -287,9 +326,12 @@ def _load_stack_manifests() -> list[JsonDict]:
             log.warning("Stack manifest %s missing 'name'/'command'; skipping", path)
             continue
         args = [os.path.expandvars(str(a)) for a in cast("list[Any]", raw.get("args", []))]
+        expanded_command = os.path.expandvars(command)
+        if Path(expanded_command).name == "docker":
+            args = _harden_stack_run_args(args)
         entry: JsonDict = {
             "name": name,
-            "command": os.path.expandvars(command),
+            "command": expanded_command,
             "args": args,
             "env": dict(cast("dict[str, str]", raw.get("env", {}))),
         }
@@ -698,6 +740,11 @@ def install_stack_image(image: str, on_progress: ProgressFn | None = None) -> st
         # ${MEDMCP_GPU} is expanded at load time (defaults to "all"), so the GPU
         # can be re-pinned via env without reinstalling the stack.
         args += ["--device", "nvidia.com/gpu=${MEDMCP_GPU}"]
+    if meta.get("network"):
+        # Opt-in egress, recorded explicitly so _harden_stack_run_args leaves it
+        # alone rather than clamping it to none on every load.
+        args += ["--network", "bridge"]
+    args = _harden_stack_run_args(args)
     args += ["-v", "${MEDMCP_WORKSPACE}:${MEDMCP_WORKSPACE}", image]
     entry: JsonDict = {"name": name, "command": "docker", "args": args}
 

--- a/src/medmcp/settings.py
+++ b/src/medmcp/settings.py
@@ -269,9 +269,18 @@ def call_entry_point(python: Path, module: str, attr: str) -> object:
 #
 # The MCP server inside a stack is a plain Python process over stdio: it needs no
 # capabilities, no privilege escalation, and no unbounded process count.
+# DAC_OVERRIDE is added back deliberately. The workspace is bind-mounted from the
+# host, where its files are owned by the invoking user, while the stack runs as root
+# inside the container. Root normally bypasses the permission check via
+# CAP_DAC_OVERRIDE; dropping it makes every tool fail to write its results into a
+# host-owned directory ("cannot open output file ..."), which drops all of ALL's
+# other capabilities while keeping the stack functional. The proper fix is to run
+# stacks as the invoking uid, which removes the need for this entirely — see the
+# non-root work tracked separately.
 _STACK_RUN_HARDENING: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("--network", ("--network", "none")),
     ("--cap-drop", ("--cap-drop", "ALL")),
+    ("--cap-add", ("--cap-add", "DAC_OVERRIDE")),
     ("--security-opt", ("--security-opt", "no-new-privileges")),
     ("--pids-limit", ("--pids-limit", "512")),
 )

--- a/tests/test_stacks_install.py
+++ b/tests/test_stacks_install.py
@@ -246,6 +246,9 @@ class TestStackIsolation:
         for flag, value in (
             ("--network", "none"),
             ("--cap-drop", "ALL"),
+            # Kept so a future tightening cannot silently break every tool's ability
+            # to write results into the host-owned workspace.
+            ("--cap-add", "DAC_OVERRIDE"),
             ("--security-opt", "no-new-privileges"),
         ):
             assert args[args.index(flag) + 1] == value

--- a/tests/test_stacks_install.py
+++ b/tests/test_stacks_install.py
@@ -217,3 +217,77 @@ class TestCatalog:
             patch("medmcp.settings.CATALOG_URL", ""),
         ):
             assert settings.load_catalog() == []
+
+
+class TestStackIsolation:
+    """Container stacks launch with egress denied and privileges dropped.
+
+    The safety model assumes the local model can be steered by prompt injection, so
+    a tool call must not become a data-exfiltration path: stacks bake their weights
+    at build time and get no network. These assertions are the enforcement point —
+    if the launch contract regresses, this is what catches it.
+    """
+
+    def test_install_denies_egress_and_drops_privileges(self, stacks_dir: Path) -> None:
+        """A freshly installed stack records the full isolation flag set."""
+        with (
+            patch("medmcp.settings._run_docker", _fake_docker(LABEL)),
+            patch("medmcp.settings._image_present", lambda _img: True),
+            patch("medmcp.settings._extract_image_skills", _fake_extract),
+        ):
+            settings.install_stack_image("img:tag")
+        args = _read_manifest(stacks_dir, "medmcp-foo")["args"]
+        assert args[0] == "run"
+        for flag, value in (
+            ("--network", "none"),
+            ("--cap-drop", "ALL"),
+            ("--security-opt", "no-new-privileges"),
+        ):
+            assert args[args.index(flag) + 1] == value
+        assert "--pids-limit" in args
+        # Isolation must precede the image reference, or docker treats it as an
+        # argument to the container rather than to `run`.
+        assert args.index("--network") < args.index("img:tag")
+
+    def test_network_opt_in_is_preserved(self, stacks_dir: Path) -> None:
+        """A stack declaring "network": true keeps egress instead of being clamped."""
+        label = '{"name": "medmcp-net", "gpu": false, "network": true}'
+        with (
+            patch("medmcp.settings._run_docker", _fake_docker(label)),
+            patch("medmcp.settings._image_present", lambda _img: True),
+            patch("medmcp.settings._extract_image_skills", _fake_extract),
+        ):
+            settings.install_stack_image("img:tag")
+        args = _read_manifest(stacks_dir, "medmcp-net")["args"]
+        assert args[args.index("--network") + 1] == "bridge"
+        assert "none" not in args
+        # Opting into egress must not opt out of the rest.
+        assert "--cap-drop" in args and "no-new-privileges" in args
+
+    def test_legacy_manifest_is_hardened_on_load(self, stacks_dir: Path) -> None:
+        """A manifest written before this existed is isolated without a reinstall.
+
+        stacks.d manifests are written once at install, so without the load-time
+        pass an upgrade would silently leave already-installed stacks unisolated.
+        """
+        stacks_dir.mkdir(parents=True, exist_ok=True)
+        (stacks_dir / "medmcp-old.toml").write_text(
+            'name = "medmcp-old"\n'
+            'command = "docker"\n'
+            'args = ["run", "--rm", "-i", "-v", "/w:/w", "img:tag"]\n'
+        )
+        entry = next(m for m in settings._load_stack_manifests() if m["name"] == "medmcp-old")
+        args = entry["args"]
+        assert args[args.index("--network") + 1] == "none"
+        assert "--cap-drop" in args
+        assert args[-1] == "img:tag"
+
+    def test_hardening_is_idempotent(self) -> None:
+        """Re-applying the hardening does not duplicate flags."""
+        once = settings._harden_stack_run_args(["run", "--rm", "-i"])
+        assert settings._harden_stack_run_args(once) == once
+        assert once.count("--network") == 1
+
+    def test_non_run_args_untouched(self) -> None:
+        """Only `docker run` argument lists are rewritten."""
+        assert settings._harden_stack_run_args(["pull", "img:tag"]) == ["pull", "img:tag"]

--- a/tests/test_stacks_install.py
+++ b/tests/test_stacks_install.py
@@ -37,6 +37,11 @@ def _fake_docker(label: str | None) -> Callable[..., subprocess.CompletedProcess
     return fake
 
 
+def _always_present(_image: str) -> bool:
+    """Stub for `_image_present`: pretend the image is already pulled."""
+    return True
+
+
 def _fake_extract(image: str, in_image_path: str, into_dir: Path) -> None:
     """Stub extraction: create into_dir/<basename> like a real `docker cp` of a dir."""
     (into_dir / Path(in_image_path).name).mkdir(parents=True, exist_ok=True)
@@ -232,7 +237,7 @@ class TestStackIsolation:
         """A freshly installed stack records the full isolation flag set."""
         with (
             patch("medmcp.settings._run_docker", _fake_docker(LABEL)),
-            patch("medmcp.settings._image_present", lambda _img: True),
+            patch("medmcp.settings._image_present", _always_present),
             patch("medmcp.settings._extract_image_skills", _fake_extract),
         ):
             settings.install_stack_image("img:tag")
@@ -254,7 +259,7 @@ class TestStackIsolation:
         label = '{"name": "medmcp-net", "gpu": false, "network": true}'
         with (
             patch("medmcp.settings._run_docker", _fake_docker(label)),
-            patch("medmcp.settings._image_present", lambda _img: True),
+            patch("medmcp.settings._image_present", _always_present),
             patch("medmcp.settings._extract_image_skills", _fake_extract),
         ):
             settings.install_stack_image("img:tag")
@@ -276,7 +281,7 @@ class TestStackIsolation:
             'command = "docker"\n'
             'args = ["run", "--rm", "-i", "-v", "/w:/w", "img:tag"]\n'
         )
-        entry = next(m for m in settings._load_stack_manifests() if m["name"] == "medmcp-old")
+        entry = next(m for m in settings._load_stack_manifests() if m["name"] == "medmcp-old")  # pyright: ignore[reportPrivateUsage]  # testing an internal on purpose
         args = entry["args"]
         assert args[args.index("--network") + 1] == "none"
         assert "--cap-drop" in args
@@ -284,10 +289,70 @@ class TestStackIsolation:
 
     def test_hardening_is_idempotent(self) -> None:
         """Re-applying the hardening does not duplicate flags."""
-        once = settings._harden_stack_run_args(["run", "--rm", "-i"])
-        assert settings._harden_stack_run_args(once) == once
+        once = settings._harden_stack_run_args(["run", "--rm", "-i"])  # pyright: ignore[reportPrivateUsage]  # testing an internal on purpose
+        assert settings._harden_stack_run_args(once) == once  # pyright: ignore[reportPrivateUsage]  # testing an internal on purpose
         assert once.count("--network") == 1
 
     def test_non_run_args_untouched(self) -> None:
         """Only `docker run` argument lists are rewritten."""
-        assert settings._harden_stack_run_args(["pull", "img:tag"]) == ["pull", "img:tag"]
+        assert settings._harden_stack_run_args(["pull", "img:tag"]) == ["pull", "img:tag"]  # pyright: ignore[reportPrivateUsage]  # testing an internal on purpose
+
+
+class TestImageArchitecture:
+    """A stack image built for another architecture is rejected at install.
+
+    Docker pulls and creates containers from a foreign-arch image with only a
+    warning, then fails at exec; under compose the stack reports as *up* while the
+    container never starts. These tests pin the early, actionable failure.
+    """
+
+    def _fake_docker_arch(self, arch: str) -> Callable[..., subprocess.CompletedProcess[str]]:
+        """`_run_docker` stub whose `inspect --format {{.Architecture}}` yields *arch*."""
+
+        def fake(args: list[str], *, timeout: float = 600.0) -> subprocess.CompletedProcess[str]:
+            out = ""
+            if "--format" in args and "{{.Architecture}}" in args:
+                out = arch
+            elif args[0] == "inspect" and "--format" in args:
+                out = LABEL
+            elif args[0] == "create":
+                out = "deadbeef"
+            return subprocess.CompletedProcess(args, 0, stdout=out, stderr="")
+
+        return fake
+
+    def test_mismatched_arch_is_rejected(self, stacks_dir: Path) -> None:
+        """An amd64 image on an arm64 host raises, and installs nothing."""
+        with (
+            patch("medmcp.settings.platform.machine", lambda: "aarch64"),
+            patch("medmcp.settings._run_docker", self._fake_docker_arch("amd64")),
+            patch("medmcp.settings._image_present", _always_present),
+            patch("medmcp.settings._extract_image_skills", _fake_extract),
+            pytest.raises(RuntimeError, match=r"linux/amd64.*linux/arm64"),
+        ):
+            settings.install_stack_image("img:tag")
+        assert not (stacks_dir.is_dir() and list(stacks_dir.glob("*.toml")))
+
+    def test_matching_arch_installs(self, stacks_dir: Path) -> None:
+        """A matching image installs normally."""
+        with (
+            patch("medmcp.settings.platform.machine", lambda: "aarch64"),
+            patch("medmcp.settings._run_docker", self._fake_docker_arch("arm64")),
+            patch("medmcp.settings._image_present", _always_present),
+            patch("medmcp.settings._extract_image_skills", _fake_extract),
+        ):
+            assert settings.install_stack_image("img:tag") == "medmcp-foo"
+
+    def test_uname_and_docker_spellings_agree(self) -> None:
+        """Uname's x86_64/aarch64 normalise onto docker's amd64/arm64."""
+        for uname, docker in (("x86_64", "amd64"), ("aarch64", "arm64")):
+            with patch("medmcp.settings.platform.machine", lambda u=uname: u):
+                assert settings.host_arch() == docker
+
+    def test_unreadable_arch_does_not_block(self) -> None:
+        """An architecture we cannot parse is not treated as a mismatch."""
+        with (
+            patch("medmcp.settings.platform.machine", lambda: "aarch64"),
+            patch("medmcp.settings._run_docker", self._fake_docker_arch("")),
+        ):
+            settings.check_image_arch("img:tag")  # must not raise


### PR DESCRIPTION
## Problem

Stack containers were launched with no isolation at all (`settings.py`, `install_stack_image`):

```python
args = ["run", "--rm", "-i"]
if meta.get("gpu"): args += ["--device", "nvidia.com/gpu=${MEDMCP_GPU}"]
args += ["-v", "${MEDMCP_WORKSPACE}:${MEDMCP_WORKSPACE}", image]
```

No `--network`, no `--cap-drop`, no `--security-opt`, no limits — and neither `Dockerfile.base` nor `Dockerfile` sets a `USER`. So every stack ran **as root, with default capabilities, on the default bridge, with the entire workspace bind-mounted read-write**.

This contradicted the code's own documentation and the README:

- Several stack Dockerfiles say *"Bake weights so the stack runs with `--network none` (no runtime download)"* — but no `--network` argument was ever constructed.
- The README promised *"**No data egress**: nothing leaves your infrastructure by default."* That was enforced only at the **agent-tool** layer (`web_search` disabled, `web_fetch` gated), never at the container boundary.

Since the stated safety model assumes the local model **can** be steered by prompt injection, a tool call that reaches the network was an exfiltration path for imaging data.

## Change

Deny egress by default and drop privileges:

```
--network none  --cap-drop ALL  --security-opt no-new-privileges  --pids-limit 512
```

A stack that genuinely needs egress sets `"network": true` in its `org.medmcp.stack` label, which writes an explicit `--network bridge` that the hardening detects and preserves. No shipped stack needs this today.

**Applied at manifest load time as well as install time.** `stacks.d/*.toml` is written once at install, so without the load-time pass an upgrade would silently leave already-installed stacks unisolated — the failure mode where a security fix looks done but isn't. The transform is idempotent and only rewrites `docker run` argument lists.

## Verification

Every stack that currently builds was probed over MCP stdio under the **full** flag set, on a DGX Spark:

| Stack | init | tools |
|---|---|---|
| dicom | OK | 5 |
| qc | OK | 1 |
| cohort | OK | 15 |
| monai | OK | 3 |
| neuro-core | OK | 7 |
| neuro-cancer | OK | 2 |

All six initialise and register their tools with no network and no capabilities — confirming the baked-weights claim holds and that nothing requires egress at startup.

Also adds `TestStackIsolation` covering the flag set, the egress opt-in, legacy-manifest hardening, idempotency, and that non-`run` arg lists are untouched. `uv run ruff check`, `ruff format --check`, and the stack/server test suites pass.

## Known limits

- **Startup, not execution.** A tool that lazily fetches at call time will now fail loudly rather than silently reaching the network. `brainles_preprocessing` pulls the SRI24 atlas from Zenodo on first use — which `neuro-cancer` already bakes for exactly this reason — so this is a real possibility elsewhere. Failing loudly is the intended outcome, but it may surface a latent bug in a tool path.
- **Still runs as root.** Non-root `USER` is deliberately excluded: it couples to workspace file ownership across all seven stack images (host files are uid 1000; a mismatched container user makes outputs unwritable) and deserves its own change.
- **Workspace is still mounted read-write in full.** Narrowing that to a per-case directory is worth considering separately.

## Related

Deployments on rootful Docker are further exposed, since container-root is much closer to host-root than under the rootless setup `docker-compose.ghcr.yml` was written for. Worth deciding explicitly which is supported.