### PR TITLE
Tighten approvals, simplify the viewer, and scope workflows to replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ Notable, user-visible changes to MedMCP. Format follows
   file explorer onto the image. The dropdown of every volume in the workspace is
   gone, and the bar above the image appears only once something is overlaid —
   showing that volume's name, its opacity, and a button to remove it (#99).
+- Provenance recording is treated as always-on: its off switch moved out of the
+  settings drawer's General list into a collapsed **Advanced** section at the
+  bottom, so a chat's audit trail is no longer one stray click from stopping
+  (#100).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,9 +47,10 @@ Notable, user-visible changes to MedMCP. Format follows
 - Every bash command the agent runs now requires interactive approval: the
   read-only allowlist was removed after finding that an output redirect from an
   allowlisted command (e.g. `echo "" > file`) wrote files without a prompt (#89).
-- The permission dialog no longer offers the durable "Always allow" option
-  vibe 2.23 introduced (it would persist an auto-approval into the config) —
-  per-session approval remains (#89).
+- The permission dialog no longer offers any way to approve more than the call
+  in front of you: both "Always allow" (which persisted an auto-approval into
+  the config) and "Allow for remainder of this session" are gone, leaving
+  **Allow** and **Deny**. Every tool call is approved on its own (#89, #98).
 - The agent's built-in `skill-creator` skill is disabled: workflow distillation
   stays the single, reviewable skill-authoring path (#89).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,11 @@ Notable, user-visible changes to MedMCP. Format follows
 
 ### Fixed
 
+- The approval dialog shows the tool call's arguments again. The agent announces
+  a call before it has finished writing its arguments, so they arrived a moment
+  later and were dropped — leaving you to approve an action with only its name
+  visible. Tool-call cards fill in the same way, and provenance records the
+  arguments again (so those sessions distill into working workflows) (#102).
 - Sent messages no longer appear twice (the agent runtime echoes live prompts
   since vibe 2.23; the echo is now merged into the already-rendered bubble) —
   as a side effect, messages sent in the current session become rewindable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ Notable, user-visible changes to MedMCP. Format follows
   `num_ctx`), not the model family's nominal maximum (#89).
 - Replayed chats show the user's message text without the internal
   `[workspace context: …]` viewer note, natively (#89).
+- Overlaying a segmentation is now drag-and-drop only: drag the volume from the
+  file explorer onto the image. The dropdown of every volume in the workspace is
+  gone, and the bar above the image appears only once something is overlaid —
+  showing that volume's name, its opacity, and a button to remove it (#99).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ Notable, user-visible changes to MedMCP. Format follows
   settings drawer's General list into a collapsed **Advanced** section at the
   bottom, so a chat's audit trail is no longer one stray click from stopping
   (#100).
+- Saved workflows now belong to the replay engine alone. The agent can no longer
+  invoke one as a skill — a workflow runs from the workflow panel, replaying its
+  recorded tool calls exactly, or it does not run. Promoting a draft now just
+  marks it reviewed and worth keeping. The settings drawer's "Personal
+  workflows" master switch and per-workflow switches are gone with the skill
+  loading they controlled (#101).
 
 ### Fixed
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -118,7 +118,7 @@ export default function App() {
             </Panel>
             <Separator className="sep sep-v" />
             <Panel minSize="30%">
-              <Viewer path={openPath} refreshSignal={fsVersion} isResizing={resizing} />
+              <Viewer path={openPath} isResizing={resizing} />
             </Panel>
           </Group>
         </Panel>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -81,15 +81,13 @@ export async function fetchSettings(): Promise<SettingsState> {
 
 /** Persist the full settings state; returns whether the agent was restarted. */
 export async function saveSettings(state: SettingsState): Promise<boolean> {
-  // Send the full known lists (not just the active names) so the server
-  // can preserve entries this drawer never saw (created after it fetched).
+  // Send the full known list (not just the active names) so the server can
+  // preserve stacks this drawer never saw (installed after it fetched).
   const res = await sendJson('PUT', '/api/settings', {
     explain_tools: state.explain_tools,
     record_provenance: state.record_provenance,
-    workflows_enabled: state.workflows_enabled,
     gpu: state.gpu,
     stacks: state.stacks.map((s) => ({ name: s.name, active: s.active })),
-    workflows: state.workflows.map((w) => ({ name: w.name, active: w.active })),
   })
   const body = (await res.json()) as { restarted: boolean }
   return body.restarted
@@ -175,12 +173,9 @@ export async function deleteSession(id: string): Promise<void> {
 
 // ── Workflows ────────────────────────────────────────────────
 
-export async function fetchWorkflows(): Promise<{
-  enabled: boolean
-  workflows: WorkflowListEntry[]
-}> {
+export async function fetchWorkflows(): Promise<WorkflowListEntry[]> {
   const res = await check(await fetch('/api/workflows'))
-  return (await res.json()) as { enabled: boolean; workflows: WorkflowListEntry[] }
+  return ((await res.json()) as { workflows: WorkflowListEntry[] }).workflows
 }
 
 export async function fetchWorkflowDetail(name: string): Promise<WorkflowDetail> {

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -415,6 +415,9 @@ export const Chat = memo(function Chat({
                 ...tc,
                 status: frame.status ?? tc.status,
                 output: frame.output ?? tc.output,
+                // Sent again once the model finished streaming the arguments;
+                // the opening frame's copy can be empty or partial.
+                rawInput: frame.rawInput ?? tc.rawInput,
               },
             }
           })

--- a/frontend/src/components/SettingsDrawer.tsx
+++ b/frontend/src/components/SettingsDrawer.tsx
@@ -8,7 +8,7 @@ import {
   uninstallStack,
 } from '../api'
 import type { CatalogEntry, GpuInfo, InstalledStack, SettingsState } from '../types'
-import { XIcon } from './icons'
+import { ChevronRightIcon, XIcon } from './icons'
 
 interface SettingsDrawerProps {
   open: boolean
@@ -91,6 +91,7 @@ export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
   const [error, setError] = useState<string | null>(null)
   const [notice, setNotice] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
+  const [advanced, setAdvanced] = useState(false)
 
   useEffect(() => {
     if (!open) return
@@ -218,12 +219,6 @@ export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
                 hint="Adds a plain-language explanation and risk tags to each permission prompt."
                 checked={state.explain_tools}
                 onChange={(v) => apply({ ...state, explain_tools: v })}
-              />
-              <Row
-                label="Record provenance"
-                hint="Keeps a replayable record of what each chat did (manifest, tool log, permissions)."
-                checked={state.record_provenance}
-                onChange={(v) => apply({ ...state, record_provenance: v })}
               />
               <Row
                 label="Personal workflows"
@@ -372,6 +367,29 @@ export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
                     />
                   ))}
                 </>
+              )}
+
+              {/* Provenance is on, and meant to stay on — it is the record of what
+                  the agent did to the data. The switch survives for the rare case
+                  that needs it, one disclosure away from being reached by accident. */}
+              <button
+                type="button"
+                className="settings-advanced-toggle"
+                onClick={() => setAdvanced((v) => !v)}
+              >
+                <ChevronRightIcon
+                  size={12}
+                  className={advanced ? 'settings-chevron open' : 'settings-chevron'}
+                />
+                Advanced
+              </button>
+              {advanced && (
+                <Row
+                  label="Record provenance"
+                  hint="Keeps a replayable record of what each chat did (manifest, tool log, permissions). Turning this off means a chat leaves no audit trail and cannot be distilled into a workflow."
+                  checked={state.record_provenance}
+                  onChange={(v) => apply({ ...state, record_provenance: v })}
+                />
               )}
 
               <div className="drawer-footnote">

--- a/frontend/src/components/SettingsDrawer.tsx
+++ b/frontend/src/components/SettingsDrawer.tsx
@@ -75,9 +75,8 @@ function Row({
 
 /**
  * Right-side drawer with the chat control panels: feature toggles, MCP stack
- * switches, and personal-workflow switches. Every change is saved
- * immediately; stack/workflow changes restart the agent (the chat reconnects
- * into a fresh session).
+ * switches, and the stack GPU. Every change is saved immediately; stack and GPU
+ * changes restart the agent (the chat reconnects into a fresh session).
  */
 export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
   const [state, setState] = useState<SettingsState | null>(null)
@@ -220,12 +219,6 @@ export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
                 checked={state.explain_tools}
                 onChange={(v) => apply({ ...state, explain_tools: v })}
               />
-              <Row
-                label="Personal workflows"
-                hint="Master switch for distilled workflows; off hides and unloads all of them."
-                checked={state.workflows_enabled}
-                onChange={(v) => apply({ ...state, workflows_enabled: v })}
-              />
               <div className="settings-row">
                 <div className="settings-row-text">
                   <div className="settings-row-label">GPU</div>
@@ -344,31 +337,6 @@ export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
                 <InstallProgress line={installProgress} />
               )}
 
-              {state.workflows_enabled && (
-                <>
-                  <div className="settings-section">Workflows</div>
-                  {state.workflows.length === 0 && (
-                    <div className="settings-row-hint">No workflows saved yet.</div>
-                  )}
-                  {state.workflows.map((w) => (
-                    <Row
-                      key={w.name}
-                      label={w.name}
-                      hint={w.description || (w.kind === 'draft' ? 'draft' : undefined)}
-                      checked={w.active}
-                      onChange={(v) =>
-                        apply({
-                          ...state,
-                          workflows: state.workflows.map((x) =>
-                            x.name === w.name ? { ...x, active: v } : x,
-                          ),
-                        })
-                      }
-                    />
-                  ))}
-                </>
-              )}
-
               {/* Provenance is on, and meant to stay on — it is the record of what
                   the agent did to the data. The switch survives for the rare case
                   that needs it, one disclosure away from being reached by accident. */}
@@ -393,8 +361,8 @@ export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
               )}
 
               <div className="drawer-footnote">
-                Stack and workflow changes restart the agent; open chats reconnect into a fresh
-                session.{saving ? ' Saving…' : ''}
+                Stack and GPU changes restart the agent; open chats reconnect into a fresh session.
+                {saving ? ' Saving…' : ''}
               </div>
             </>
           )}

--- a/frontend/src/components/Viewer.tsx
+++ b/frontend/src/components/Viewer.tsx
@@ -1,8 +1,8 @@
 import { memo, useCallback, useEffect, useRef, useState } from 'react'
 import { Niivue, SHOW_RENDER, SLICE_TYPE } from '@niivue/niivue'
-import { fetchTree, rawUrl } from '../api'
+import { rawUrl } from '../api'
 import { getDraggedFilePath } from '../dragState'
-import { DRAG_PATH_MIME, type TreeNode } from '../types'
+import { DRAG_PATH_MIME } from '../types'
 import { DownloadIcon, GearIcon, XIcon } from './icons'
 import { ViewerSettingsPanel } from './ViewerSettings'
 
@@ -165,29 +165,15 @@ function classify(path: string): FileKind {
   return 'other'
 }
 
-/** Flatten the explorer tree into the workspace-relative paths of all volumes. */
-function collectVolumePaths(nodes: TreeNode[], out: string[] = []): string[] {
-  for (const node of nodes) {
-    if (node.children) {
-      collectVolumePaths(node.children, out)
-    } else if (VOLUME_EXT.test(node.name.toLowerCase())) {
-      out.push(node.id)
-    }
-  }
-  return out
-}
-
 /**
  * Niivue-backed volume view: multiplanar slices + 3D render, wheel scrolls
- * slices. A second volume (e.g. a segmentation mask) can be overlaid — picked
- * from the dropdown or dragged from the file explorer onto the image. The
- * overlay is rendered with a label colormap (distinct color per integer label)
- * and adjustable opacity.
+ * slices. A second volume (e.g. a segmentation mask) is overlaid by dragging it
+ * from the file explorer onto the image; it renders with a label colormap
+ * (distinct color per integer label) and adjustable opacity.
  */
 function VolumeView({
   path,
   settings,
-  refreshSignal,
   isResizing,
   overlayPath,
   overlayOpacity,
@@ -196,7 +182,6 @@ function VolumeView({
 }: {
   path: string
   settings: ViewerSettings
-  refreshSignal?: number
   isResizing?: boolean
   overlayPath: string
   overlayOpacity: number
@@ -210,7 +195,6 @@ function VolumeView({
   const nvRef = useRef<Niivue | null>(null)
   const [loadError, setLoadError] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
-  const [volumePaths, setVolumePaths] = useState<string[]>([])
   const [dragOver, setDragOver] = useState(false)
   // Read inside the url-keyed load effect (constructor seeding + post-load) and
   // the live-settings effect without making settings a dependency of the load
@@ -353,19 +337,6 @@ function VolumeView({
     }
   }, [url])
 
-  // Candidate overlays: every other volume in the workspace. refreshSignal
-  // picks up volumes the agent or a replay just produced; the trailing
-  // debounce collapses a turn's burst of signals into one tree fetch
-  // (matching FileExplorer's reload).
-  useEffect(() => {
-    const timer = window.setTimeout(() => {
-      fetchTree()
-        .then((tree) => setVolumePaths(collectVolumePaths(tree).filter((p) => p !== path)))
-        .catch(() => setVolumePaths([]))
-    }, 300)
-    return () => window.clearTimeout(timer)
-  }, [path, refreshSignal])
-
   // Apply live setting changes to the open volume. `antialias` and
   // `renderScale` are excluded here — both are creation-time, so changing them
   // remounts this view via its key (see Viewer). The guard skips the initial
@@ -448,40 +419,30 @@ function VolumeView({
 
   return (
     <div className="volume-view">
-      <div className="overlay-bar">
-        <span className="overlay-label">Overlay</span>
-        <select
-          className="overlay-select"
-          value={overlayPath}
-          title="Pick a volume, or drag one from the file explorer onto the image"
-          onChange={(e) => setOverlay(e.target.value)}
-        >
-          <option value="">none — or drag a file here</option>
-          {volumePaths.map((p) => (
-            <option key={p} value={p}>
-              {p}
-            </option>
-          ))}
-        </select>
-        {overlayPath && (
-          <>
-            <span className="overlay-opacity-label">Opacity</span>
-            <input
-              className="overlay-opacity"
-              type="range"
-              min={0}
-              max={1}
-              step={0.05}
-              value={overlayOpacity}
-              title={`Opacity ${Math.round(overlayOpacity * 100)}%`}
-              onChange={(e) => setOpacity(Number(e.target.value))}
-            />
-            <button className="btn-icon" title="Remove overlay" onClick={() => setOverlay('')}>
-              <XIcon size={13} />
-            </button>
-          </>
-        )}
-      </div>
+      {/* Only rendered once something is actually overlaid: with drag-and-drop
+          as the only way in, an always-present bar would be a permanent strip of
+          controls for a state the viewer is usually not in. */}
+      {overlayPath && (
+        <div className="overlay-bar">
+          <span className="overlay-label" title={overlayPath}>
+            {overlayPath.split('/').pop()}
+          </span>
+          <span className="overlay-opacity-label">Opacity</span>
+          <input
+            className="overlay-opacity"
+            type="range"
+            min={0}
+            max={1}
+            step={0.05}
+            value={overlayOpacity}
+            title={`Opacity ${Math.round(overlayOpacity * 100)}%`}
+            onChange={(e) => setOpacity(Number(e.target.value))}
+          />
+          <button className="btn-icon" title="Remove overlay" onClick={() => setOverlay('')}>
+            <XIcon size={13} />
+          </button>
+        </div>
+      )}
       {loadError && <div className="panel-error">{loadError}</div>}
       <div className="niivue-sizer" ref={sizerRef}>
         <div
@@ -525,16 +486,13 @@ function TextView({ url }: { url: string }) {
 
 /** Routes the selected file to the right renderer (volume / PDF / image / text). */
 // Memoized so a separator drag doesn't re-render the viewer (and its WebGL/React
-// subtree) every frame; props from App are stable except when the open file or
-// fs version actually changes.
+// subtree) every frame; props from App are stable except when the open file
+// actually changes.
 export const Viewer = memo(function Viewer({
   path,
-  refreshSignal,
   isResizing,
 }: {
   path: string | null
-  /** Bumped when the workspace may have changed; refreshes the overlay list. */
-  refreshSignal?: number
   /** True while a separator is being dragged; freezes the volume canvas size. */
   isResizing?: boolean
 }) {
@@ -642,7 +600,6 @@ export const Viewer = memo(function Viewer({
               key={`${path}#${resizeGen}#${settings.antialias ? 'aa' : 'noaa'}#${settings.renderScale}`}
               path={path}
               settings={settings}
-              refreshSignal={refreshSignal}
               isResizing={isResizing}
               overlayPath={overlayPath}
               overlayOpacity={overlayOpacity}

--- a/frontend/src/components/WorkflowPanel.tsx
+++ b/frontend/src/components/WorkflowPanel.tsx
@@ -410,7 +410,6 @@ export const WorkflowPanel = memo(function WorkflowPanel({
   selectedPaths?: string[]
 }) {
   const [workflows, setWorkflows] = useState<WorkflowListEntry[] | null>(null)
-  const [enabled, setEnabled] = useState(true)
   const [expanded, setExpanded] = useState<string | null>(null)
   const [detail, setDetail] = useState<WorkflowDetail | null>(null)
   const [mode, setMode] = useState<Mode>({ kind: 'view' })
@@ -425,9 +424,8 @@ export const WorkflowPanel = memo(function WorkflowPanel({
   const reload = useCallback(
     () =>
       fetchWorkflows()
-        .then((res) => {
-          setEnabled(res.enabled)
-          setWorkflows(res.workflows)
+        .then((list) => {
+          setWorkflows(list)
           setError(null)
         })
         .catch((e: unknown) => setError(e instanceof Error ? e.message : String(e))),
@@ -893,7 +891,7 @@ export const WorkflowPanel = memo(function WorkflowPanel({
               <>
                 <button
                   className="btn-plain"
-                  title="Keep permanently; loads as a skill in new chat sessions"
+                  title="Mark as reviewed and keep permanently"
                   onClick={() => void promote(d.name)}
                 >
                   Promote
@@ -1309,11 +1307,6 @@ export const WorkflowPanel = memo(function WorkflowPanel({
         </span>
       </div>
       <div className="panel-body wf-body">
-        {!enabled && (
-          <div className="viewer-message">
-            Personal workflows are turned off — enable them in Settings.
-          </div>
-        )}
         {error && <div className="panel-error">{error}</div>}
         {busy && (
           <div className="wf-busy">
@@ -1328,14 +1321,13 @@ export const WorkflowPanel = memo(function WorkflowPanel({
             {mode.kind === 'running' ? renderRunning(mode) : renderDone(mode)}
           </div>
         )}
-        {enabled && workflows !== null && workflows.length === 0 && !busy && (
+        {workflows !== null && workflows.length === 0 && !busy && (
           <div className="viewer-message">
             No saved workflows yet. Run an analysis in the chat, then click{' '}
             <BookmarkPlusIcon size={12} /> to turn it into a reusable, replayable workflow.
           </div>
         )}
-        {enabled &&
-          workflows?.map((w) => (
+        {workflows?.map((w) => (
             <div key={w.name} className="wf-item">
               <button className="wf-row" onClick={() => void openDetail(w.name)}>
                 <ChevronRightIcon

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -440,29 +440,17 @@ button:hover {
   flex-shrink: 0;
 }
 
+/* The overlaid volume's filename. Takes the free space and truncates, so a long
+   name pushes the opacity control off the bar instead of wrapping it. */
 .overlay-label {
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: var(--muted);
-}
-
-.overlay-select {
-  background: var(--card);
-  color: var(--text);
-  border: 1px solid var(--border2);
-  border-radius: 6px;
-  padding: 3px 8px;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   font-family: var(--mono);
   font-size: 11.5px;
-  max-width: 280px;
-  min-width: 0;
-}
-
-.overlay-select:focus {
-  outline: none;
-  border-color: rgba(127, 168, 245, 0.4);
+  color: var(--text);
 }
 
 /* Viewer settings: gear in the panel header opens a popover. Positioned within

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1380,6 +1380,40 @@ button:hover {
   margin: 20px 0 4px;
 }
 
+/* Disclosure for settings that should be reachable but not browsed past. Mirrors
+   the viewer settings popover's own Advanced row (.vs-advanced-toggle). */
+.settings-advanced-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  margin-top: 20px;
+  padding: 10px 0 4px;
+  background: none;
+  border: none;
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.settings-advanced-toggle:hover {
+  /* Neutralize the global button:hover fade, as .vs-advanced-toggle does: on a
+     full-width, border-top-only row it reads as a shimmer. */
+  background: none;
+  border-color: var(--border);
+  color: var(--text);
+}
+
+.settings-chevron {
+  transition: transform 0.12s ease;
+}
+
+.settings-chevron.open {
+  transform: rotate(90deg);
+}
+
 .settings-row {
   display: flex;
   align-items: center;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -76,23 +76,14 @@ export interface CatalogEntry {
   installed: boolean
 }
 
-export interface WorkflowInfo {
-  name: string
-  description: string
-  kind: 'active' | 'draft'
-  active: boolean
-}
-
 export interface SettingsState {
   explain_tools: boolean
   record_provenance: boolean
-  workflows_enabled: boolean
   /** Selected GPU (CDI device id) for container stacks; "all" = every GPU. */
   gpu: string
   /** GPU the LLM container was created with (deploy-time; read-only here). */
   llm_gpu: string
   stacks: StackInfo[]
-  workflows: WorkflowInfo[]
 }
 
 /** One GPU from GET /api/gpus (best-effort enumeration). */

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -198,7 +198,14 @@ export type ServerFrame =
       kind?: string | null
       rawInput?: unknown
     }
-  | { type: 'tool_call_update'; toolCallId: string; status?: string | null; output?: string | null }
+  | {
+      type: 'tool_call_update'
+      toolCallId: string
+      status?: string | null
+      output?: string | null
+      /** Completed arguments, re-sent once the model finished streaming them. */
+      rawInput?: unknown
+    }
   | { type: 'usage'; used: number; size?: number }
   | {
       type: 'permission_request'

--- a/src/medmcp/distill.py
+++ b/src/medmcp/distill.py
@@ -6,9 +6,9 @@ calls, and lifts concrete file paths into named placeholders to produce a
 :class:`~medmcp.workflow.Recipe`. The recipe is emitted two ways from one
 distillation (Option C):
 
-- ``recipe.yaml`` — machine-readable + replayable.
-- ``SKILL.md``    — frontmatter + ``## Steps`` / ``## Gotchas``, droppable into a
-  ``skill_paths`` directory so it plugs into the existing skill system.
+- ``recipe.yaml`` — machine-readable + replayable; what the replay engine runs.
+- ``SKILL.md``    — frontmatter + ``## Steps`` / ``## Gotchas``: the human-facing
+  description of the workflow, shown in the UI and carried by an export.
 
 The prose (workflow name, description, narrative steps, gotchas) is written by a
 hybrid pass: the step sequence is extracted deterministically, then the local
@@ -16,8 +16,10 @@ Ollama model is asked to write the human-facing narrative. If the model is
 unavailable the narrative falls back to a mechanical rendering so distillation
 never hard-fails.
 
-Output lands in ``.vibe/workflows/draft/<name>/`` for human review; promotion to
-an active ``skill_paths`` location is a separate, deliberate step.
+Output lands in ``.vibe/workflows/draft/<name>/`` for human review; promoting it
+to ``active/`` — marking it reviewed and worth keeping — is a separate,
+deliberate step. Neither directory is ever loaded as a skill: a workflow runs
+through :mod:`medmcp.replay`, never by the agent deciding to invoke it.
 """
 
 from __future__ import annotations
@@ -714,8 +716,9 @@ def distill_session(
 def promote_draft(name: str, *, workflows_root: Path | None = None) -> Path:
     """Move draft workflow *name* into ``active/`` and return the new path.
 
-    Promotion makes the workflow discoverable as a skill (the active directory is
-    added to ``skill_paths``). Raises ``FileNotFoundError`` if no such draft exists.
+    Promotion marks the workflow as reviewed and worth keeping; both directories
+    are replayable, and neither is loaded as a skill. Raises ``FileNotFoundError``
+    if no such draft exists.
     """
     src = _draft_dir(name, workflows_root)
     if not (src / "SKILL.md").exists():

--- a/src/medmcp/provcli.py
+++ b/src/medmcp/provcli.py
@@ -62,19 +62,19 @@ def _distill(session_id: str, *, use_llm: bool) -> int:
         print(f"error: {exc}", file=sys.stderr)
         return 1
     print(f"Draft workflow written to: {draft_dir}")
-    print("Review and edit, then promote it into a skill_paths directory to reuse it.")
+    print("Review and edit it, then promote it to keep it.")
     return 0
 
 
 def _promote(name: str) -> int:
-    """Move a reviewed draft workflow into ``active/`` so it loads as a skill."""
+    """Move a reviewed draft workflow into ``active/``."""
     try:
         dst = distill.promote_draft(name)
     except FileNotFoundError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
     print(f"Promoted workflow to: {dst}")
-    print("Restart the UI to pick it up; it will be available via the skill system.")
+    print("Run it from the workspace UI's workflow panel.")
     return 0
 
 

--- a/src/medmcp/server.py
+++ b/src/medmcp/server.py
@@ -965,7 +965,7 @@ async def ws_replay(ws: WebSocket) -> None:
 #     {"type": "tool_call", "toolCallId": str, "title": str, "status": str,
 #      "kind": str | None, "rawInput": object}
 #     {"type": "tool_call_update", "toolCallId": str, "status": str | None,
-#      "output": str | None}
+#      "output": str | None, "rawInput": object | None}
 #     {"type": "usage", "used": int}
 #     {"type": "permission_request", "requestId": int, "toolCall": {...},
 #      "options": [{"optionId": str, "name": str, "kind": str}],
@@ -1421,10 +1421,19 @@ class _ChatConnection:
                 if not output and raw_output is not None:
                     output = str(raw_output)
                 status = update.get("status")
+                # A tool call is announced before the model has finished streaming
+                # its arguments, so the opening `tool_call` frame can carry an empty
+                # or partial rawInput; vibe re-sends the completed arguments on the
+                # first update whose detail changed. Overwrite (not set-if-absent)
+                # or the placeholder sticks — which leaves the approval box with no
+                # arguments to show and the provenance event with no `arguments`.
+                raw_input = update.get("rawInput")
                 info = self._tool_calls.get(tc_id)
                 if info is not None:
                     if isinstance(status, str):
                         info["status"] = status
+                    if raw_input is not None:
+                        info["rawInput"] = raw_input
                     if raw_output is not None:
                         info["rawOutput"] = raw_output
                     elif output:
@@ -1435,6 +1444,7 @@ class _ChatConnection:
                         "toolCallId": tc_id,
                         "status": status,
                         "output": output[:2000] if output else None,
+                        "rawInput": raw_input,
                     }
                 )
                 if status in ("completed", "failed") and info is not None:

--- a/src/medmcp/server.py
+++ b/src/medmcp/server.py
@@ -295,52 +295,37 @@ class ToggleEntry(BaseModel):
 class SettingsPayload(BaseModel):
     """Full settings state as submitted by the UI's settings drawer.
 
-    ``stacks``/``workflows`` carry every entry the drawer knew about (name +
-    active), so the server can tell "deactivated" apart from "unknown to this
-    drawer" and preserve the state of entries created after the drawer
-    fetched (e.g. a draft distilled while it was open).
+    ``stacks`` carries every entry the drawer knew about (name + active), so the
+    server can tell "deactivated" apart from "unknown to this drawer" and
+    preserve the state of stacks installed after the drawer fetched.
     """
 
     explain_tools: bool
     record_provenance: bool
-    workflows_enabled: bool
     # Selected GPU (CDI device id) for container stacks; "" = leave unchanged.
     gpu: str = ""
     stacks: list[ToggleEntry]
-    workflows: list[ToggleEntry]
 
 
 def _settings_state() -> JsonDict:
     """Assemble the current settings state (runs blocking discovery)."""
     stacks = settings.load_mcp_servers()
     active = settings.load_active_server_names()
-    workflows = settings.discover_workflows()
-    active_wf = settings.load_active_workflow_names()
     return {
         "explain_tools": settings.load_explain_enabled(),
         "record_provenance": settings.load_provenance_enabled(),
-        "workflows_enabled": settings.load_workflows_enabled(),
         "gpu": settings.load_gpu_selection(),
         "llm_gpu": settings.LLM_GPU,
         "stacks": [
             {"name": s["name"], "version": s.get("version"), "active": s["name"] in active}
             for s in stacks
         ],
-        "workflows": [
-            {
-                "name": w["name"],
-                "description": w["description"],
-                "kind": w["kind"],
-                "active": w["name"] in active_wf,
-            }
-            for w in workflows
-        ],
     }
 
 
 @app.get("/api/settings")
 async def get_settings() -> JsonDict:
-    """Return toggles plus the discovered stacks/workflows with active state."""
+    """Return toggles plus the discovered stacks with active state."""
     return await asyncio.to_thread(_settings_state)
 
 
@@ -348,15 +333,13 @@ async def get_settings() -> JsonDict:
 async def put_settings(payload: SettingsPayload) -> JsonDict:
     """Persist settings; restart vibe-acp when its config inputs changed.
 
-    Stack and workflow changes are baked into ``.vibe/config.toml`` at session
-    start, so applying them requires a fresh vibe-acp process. All live chat
-    sockets are closed; each client auto-reconnects into a new session.
+    Stack changes are baked into ``.vibe/config.toml`` at session start, so
+    applying them requires a fresh vibe-acp process. All live chat sockets are
+    closed; each client auto-reconnects into a new session.
     """
 
     def _apply() -> tuple[bool, set[str], set[str]]:
         old_stacks = settings.load_active_server_names()
-        old_workflows = settings.load_active_workflow_names()
-        old_wf_enabled = settings.load_workflows_enabled()
 
         # An empty gpu means "leave unchanged"; a new value re-pins stack containers.
         gpu_changed = bool(payload.gpu) and payload.gpu != settings.load_gpu_selection()
@@ -365,24 +348,13 @@ async def put_settings(payload: SettingsPayload) -> JsonDict:
 
         settings.save_explain_enabled(payload.explain_tools)
         settings.save_provenance_enabled(payload.record_provenance)
-        settings.save_workflows_enabled(payload.workflows_enabled)
         # Merge instead of overwrite: entries the drawer never saw keep their
         # current active state instead of being silently deactivated.
         known_stacks = {t.name for t in payload.stacks}
         new_stacks = {t.name for t in payload.stacks if t.active} | (old_stacks - known_stacks)
-        known_workflows = {t.name for t in payload.workflows}
-        new_workflows = {t.name for t in payload.workflows if t.active} | (
-            old_workflows - known_workflows
-        )
         settings.save_active_server_names(new_stacks)
-        settings.save_active_workflow_names(new_workflows)
 
-        restart = (
-            new_stacks != old_stacks
-            or new_workflows != old_workflows
-            or payload.workflows_enabled != old_wf_enabled
-            or gpu_changed
-        )
+        restart = new_stacks != old_stacks or gpu_changed
         if restart:
             settings.sync_servers_to_vibe_config(settings.active_servers())
         return restart, new_stacks - old_stacks, old_stacks - new_stacks
@@ -617,15 +589,8 @@ def _workflow_detail(name: str) -> JsonDict:
 
 @app.get("/api/workflows")
 async def get_workflows() -> JsonDict:
-    """List personal workflows plus the master-toggle state."""
-
-    def _state() -> JsonDict:
-        return {
-            "enabled": settings.load_workflows_enabled(),
-            "workflows": settings.discover_workflows(),
-        }
-
-    return await asyncio.to_thread(_state)
+    """List the personal workflows available to the replay engine."""
+    return {"workflows": await asyncio.to_thread(settings.discover_workflows)}
 
 
 class DistillPayload(BaseModel):

--- a/src/medmcp/server.py
+++ b/src/medmcp/server.py
@@ -1080,16 +1080,35 @@ def _usage_window(update: JsonDict) -> int:
     return settings.cached_context_window()
 
 
-def _visible_permission_options(options: list[JsonDict]) -> list[JsonDict]:
-    """Drop permission options that would create a durable auto-approval.
+# Permission options that approve more than the call being asked about:
+# ``allow_always`` ("Allow for remainder of this session") auto-approves every
+# later call of that tool in the session, and ``allow_always_permanent``
+# ("Always allow") persists the approval into ``.vibe/config.toml`` so it
+# outlives the session entirely. Both are auto-approval paths, which medmcp
+# does not offer — every tool call is gated on its own.
+_AUTO_APPROVE_OPTIONS = frozenset({"allow_always", "allow_always_permanent"})
 
-    vibe ≥2.23 offers ``allow_always_permanent`` ("Always allow"), which
-    persists the approval into ``.vibe/config.toml`` — every future call of
-    that tool would then bypass the permission flow entirely. medmcp's posture
-    is interactive gating only, so the option is never shown to the browser
-    (per-session "allow always" remains available).
+
+def _visible_permission_options(options: list[JsonDict]) -> list[JsonDict]:
+    """Reduce vibe's permission options to a per-call allow/deny pair.
+
+    Every option that would auto-approve anything beyond the call in hand is
+    dropped (see :data:`_AUTO_APPROVE_OPTIONS`), leaving ``allow_once`` and
+    ``reject_once``. With no "always" variant left to contrast against,
+    "Allow once" is relabelled to plain **"Allow"** — the scope is no longer a
+    choice the user makes, so naming it only invites the question.
+
+    Renaming here rather than in the browser keeps one source for the label:
+    the frontend renders whatever ``name`` the frame carries.
     """
-    return [o for o in options if o.get("optionId") != "allow_always_permanent"]
+    visible: list[JsonDict] = []
+    for option in options:
+        if option.get("optionId") in _AUTO_APPROVE_OPTIONS:
+            continue
+        if option.get("optionId") == "allow_once":
+            option = {**option, "name": "Allow"}
+        visible.append(option)
+    return visible
 
 
 def _workspace_note(viewed_path: str) -> str:

--- a/src/medmcp/settings.py
+++ b/src/medmcp/settings.py
@@ -123,12 +123,8 @@ def fetched_context_window() -> int | None:
 
 # Tracks which discovered stacks are enabled; defaults to all when absent.
 ACTIVE_STACKS_PATH: Path = VIBE_HOME / "active_stacks.json"
-# Tracks which personal workflows are enabled (loaded as skills); all when absent.
-ACTIVE_WORKFLOWS_PATH: Path = VIBE_HOME / "active_workflows.json"
 # Persists the provenance-capture on/off preference; defaults to on when absent.
 PROVENANCE_ENABLED_PATH: Path = VIBE_HOME / "provenance_enabled.json"
-# Master on/off for the personal-workflows feature; defaults to on when absent.
-WORKFLOWS_ENABLED_PATH: Path = VIBE_HOME / "workflows_enabled.json"
 # Persists the explain-tool-calls on/off preference; defaults to on when absent.
 EXPLAIN_ENABLED_PATH: Path = VIBE_HOME / "explain_enabled.json"
 
@@ -955,27 +951,6 @@ def discover_workflows() -> list[JsonDict]:
     return list(found.values())
 
 
-def load_active_workflow_names() -> set[str]:
-    """Return the set of workflow names currently enabled (loaded as skills).
-
-    When ``.vibe/active_workflows.json`` is absent every discovered workflow is
-    active, so a freshly distilled/promoted workflow is on by default.
-    """
-    all_names = {w["name"] for w in discover_workflows()}
-    if not ACTIVE_WORKFLOWS_PATH.exists():
-        return all_names
-    try:
-        data = cast("dict[str, Any]", json.loads(ACTIVE_WORKFLOWS_PATH.read_text()))
-        return set(cast("list[str]", data.get("active", list(all_names))))
-    except (json.JSONDecodeError, OSError):
-        return all_names
-
-
-def save_active_workflow_names(names: set[str]) -> None:
-    """Persist the active workflow set to ``.vibe/active_workflows.json``."""
-    _atomic_write_json(ACTIVE_WORKFLOWS_PATH, {"active": sorted(names)})
-
-
 def _load_flag(path: Path) -> bool:
     """Read an ``{"enabled": bool}`` preference file (default ``True`` when unset)."""
     if not path.exists():
@@ -1000,20 +975,6 @@ def load_provenance_enabled() -> bool:
 def save_provenance_enabled(enabled: bool) -> None:
     """Persist the provenance-capture on/off preference to disk."""
     _save_flag(PROVENANCE_ENABLED_PATH, enabled)
-
-
-def load_workflows_enabled() -> bool:
-    """Return whether the personal-workflows feature is enabled (default ``True``).
-
-    The master switch: when off, no personal workflow is loaded as a skill and
-    the UIs hide their workflow controls (see ``sync_servers_to_vibe_config``).
-    """
-    return _load_flag(WORKFLOWS_ENABLED_PATH)
-
-
-def save_workflows_enabled(enabled: bool) -> None:
-    """Persist the personal-workflows master on/off preference to disk."""
-    _save_flag(WORKFLOWS_ENABLED_PATH, enabled)
 
 
 def load_explain_enabled() -> bool:
@@ -1197,36 +1158,22 @@ def _sync_servers_to_vibe_config_locked(servers: list[JsonDict]) -> None:
 
     # Collect skills_path values from discovered servers and write them to
     # skill_paths so vibe-acp loads the bundled skill docs automatically.
-    skill_paths = [srv["skills_path"] for srv in servers if srv.get("skills_path")]
-    # The personal-workflows feature can be turned off entirely by the master
-    # toggle; when off, no workflow dir is added to skill_paths and every workflow
-    # is listed in disabled_skills, so nothing personal is loaded.
-    workflows_enabled = load_workflows_enabled()
-    if workflows_enabled:
-        # Promoted, reusable workflows live here as <name>/SKILL.md; include the
-        # directory so distilled workflows are discoverable as skills (Tier 3).
-        workflows_active = VIBE_HOME / "workflows" / "active"
-        if workflows_active.is_dir():
-            skill_paths.append(str(workflows_active))
-        # Draft workflows are loaded too, so a draft can be tested (invoked as
-        # `/<name>`) before it is promoted. Promotion just moves the draft into
-        # active/ to keep it permanently; both dirs hold <name>/SKILL.md entries.
-        workflows_draft = VIBE_HOME / "workflows" / "draft"
-        if workflows_draft.is_dir():
-            skill_paths.append(str(workflows_draft))
-    cfg["skill_paths"] = skill_paths
+    #
+    # Personal workflows are deliberately NOT here. A distilled workflow is a
+    # recorded sequence of tool calls, replayed verbatim by replay.py on new
+    # inputs — its value is that it does exactly what it did last time. Exposing
+    # it as a skill handed it back to the agent as prose to reinterpret, which is
+    # the opposite guarantee, and put a second, unreviewed path to the same tools
+    # next to the deterministic one. The replay engine is the only way to run one.
+    cfg["skill_paths"] = [srv["skills_path"] for srv in servers if srv.get("skills_path")]
 
-    # Personal workflows toggled off in the gear are disabled by name so vibe-acp
-    # skips loading them, without removing them from disk. With the master toggle
-    # off, all of them are disabled. Non-workflow entries in disabled_skills (if
-    # any were set manually) are preserved.
-    all_workflows = {w["name"] for w in discover_workflows()}
-    deactivated = (
-        all_workflows if not workflows_enabled else (all_workflows - load_active_workflow_names())
-    )
+    # Workflow names were listed in disabled_skills to keep deactivated ones from
+    # loading. With no workflow dir in skill_paths there is nothing to disable, so
+    # drop those entries — but preserve the rest (e.g. vibe's own skill-creator,
+    # disabled so distillation stays the single skill-authoring path).
+    workflow_names = {w["name"] for w in discover_workflows()}
     existing_disabled = cast("list[str]", cfg.get("disabled_skills", []))
-    preserved = [s for s in existing_disabled if s not in all_workflows]
-    cfg["disabled_skills"] = sorted(set(preserved) | deactivated)
+    cfg["disabled_skills"] = sorted(s for s in existing_disabled if s not in workflow_names)
 
     config_path.parent.mkdir(parents=True, exist_ok=True)
     # A unique temp name (not a fixed .tmp path) so a concurrent writer in

--- a/tests/test_active_servers.py
+++ b/tests/test_active_servers.py
@@ -14,10 +14,8 @@ from medmcp.settings import (
     load_active_server_names,
     load_mcp_servers,
     load_provenance_enabled,
-    load_workflows_enabled,
     save_active_server_names,
     save_provenance_enabled,
-    save_workflows_enabled,
     sync_servers_to_vibe_config,
 )
 
@@ -147,71 +145,43 @@ class TestProvenanceEnabled:
             assert load_provenance_enabled() is True
 
 
-# ── personal-workflows master toggle ──────────────────────────────────────────
+# ── personal workflows are never loaded as skills ─────────────────────────────
 
 
-class TestWorkflowsEnabled:
-    """_load/save_workflows_enabled round-trip and default to on."""
+class TestWorkflowsAreNotSkills:
+    """Workflows belong to the replay engine; vibe-acp never sees them."""
 
-    def test_defaults_to_true_when_absent(self, tmp_path: Path) -> None:
-        """Without the file, the workflows feature is enabled by default."""
-        with patch("medmcp.settings.WORKFLOWS_ENABLED_PATH", tmp_path / "workflows_enabled.json"):
-            assert load_workflows_enabled() is True
-
-    def test_round_trip_false(self, tmp_path: Path) -> None:
-        """A saved disabled preference reads back as False."""
-        path = tmp_path / "workflows_enabled.json"
-        with patch("medmcp.settings.WORKFLOWS_ENABLED_PATH", path):
-            save_workflows_enabled(False)
-            assert load_workflows_enabled() is False
-        assert json.loads(path.read_text()) == {"enabled": False}
-
-    def test_corrupt_file_defaults_to_true(self, tmp_path: Path) -> None:
-        """A corrupt preference file falls back to enabled."""
-        path = tmp_path / "workflows_enabled.json"
-        path.write_text("not json{{{")
-        with patch("medmcp.settings.WORKFLOWS_ENABLED_PATH", path):
-            assert load_workflows_enabled() is True
-
-
-class TestWorkflowSkillPathsGating:
-    """sync_servers_to_vibe_config honors the workflows master toggle."""
-
-    def test_enabled_adds_skill_paths(self, tmp_path: Path) -> None:
-        """With the feature on, workflow dirs are added to skill_paths."""
+    def test_workflow_dirs_are_never_added_to_skill_paths(self, tmp_path: Path) -> None:
+        """Neither draft/ nor active/ reaches skill_paths, promoted or not."""
         _make_workflow(tmp_path, "active", "wf-promoted")
         _make_workflow(tmp_path, "draft", "wf-draft")
         cfg_path = tmp_path / "config.toml"
-        with (
-            patch("medmcp.settings.VIBE_HOME", tmp_path),
-            patch("medmcp.settings.WORKFLOWS_ENABLED_PATH", tmp_path / "workflows_enabled.json"),
-            patch("medmcp.settings.ACTIVE_WORKFLOWS_PATH", tmp_path / "active_workflows.json"),
-        ):
+        with patch("medmcp.settings.VIBE_HOME", tmp_path):
             sync_servers_to_vibe_config([])
         cfg = tomllib.loads(cfg_path.read_text())
-        skill_paths = cfg["skill_paths"]
-        assert str(tmp_path / "workflows" / "active") in skill_paths
-        assert str(tmp_path / "workflows" / "draft") in skill_paths
-        # All discovered workflows are active by default, so none disabled.
-        assert cfg["disabled_skills"] == []
+        assert cfg["skill_paths"] == []
 
-    def test_disabled_drops_skill_paths_and_disables_all(self, tmp_path: Path) -> None:
-        """With the feature off, no workflow dir loads and all are disabled."""
+    def test_stack_skill_paths_still_load(self, tmp_path: Path) -> None:
+        """A stack's own bundled skills are unaffected — only workflows are excluded."""
         _make_workflow(tmp_path, "active", "wf-promoted")
+        cfg_path = tmp_path / "config.toml"
+        with patch("medmcp.settings.VIBE_HOME", tmp_path):
+            sync_servers_to_vibe_config(
+                [{"name": "neuro", "command": "/bin/neuro", "skills_path": "/opt/neuro/skills"}]
+            )
+        cfg = tomllib.loads(cfg_path.read_text())
+        assert cfg["skill_paths"] == ["/opt/neuro/skills"]
+
+    def test_stale_workflow_names_are_dropped_from_disabled_skills(self, tmp_path: Path) -> None:
+        """Names left in disabled_skills by the old gating are cleaned up."""
         _make_workflow(tmp_path, "draft", "wf-draft")
         cfg_path = tmp_path / "config.toml"
-        with (
-            patch("medmcp.settings.VIBE_HOME", tmp_path),
-            patch("medmcp.settings.WORKFLOWS_ENABLED_PATH", tmp_path / "workflows_enabled.json"),
-            patch("medmcp.settings.ACTIVE_WORKFLOWS_PATH", tmp_path / "active_workflows.json"),
-        ):
-            save_workflows_enabled(False)
+        cfg_path.write_text('disabled_skills = ["wf-draft", "skill-creator"]\n')
+        with patch("medmcp.settings.VIBE_HOME", tmp_path):
             sync_servers_to_vibe_config([])
         cfg = tomllib.loads(cfg_path.read_text())
-        skill_paths = cfg["skill_paths"]
-        assert str(tmp_path / "workflows" / "active") not in skill_paths
-        assert str(tmp_path / "workflows" / "draft") not in skill_paths
-        assert cfg["disabled_skills"] == ["wf-draft", "wf-promoted"]
+        # The workflow goes; the deliberately-disabled builtin stays.
+        assert cfg["disabled_skills"] == ["skill-creator"]
 
 
 # ── active_servers ───────────────────────────────────────────────────────────
@@ -393,28 +363,6 @@ class TestSyncServersToVibeConfig:
 
         assert result.get("skill_paths") == []
 
-    def test_active_workflows_dir_added_to_skill_paths(self, tmp_path: Path) -> None:
-        """A promoted-workflows active/ dir is included in skill_paths."""
-        (tmp_path / "workflows" / "active").mkdir(parents=True)
-        with patch("medmcp.settings.VIBE_HOME", tmp_path):
-            sync_servers_to_vibe_config(_TWO_SERVERS)
-
-        with (tmp_path / "config.toml").open("rb") as f:
-            result = tomllib.load(f)
-
-        assert str(tmp_path / "workflows" / "active") in result["skill_paths"]
-
-    def test_draft_workflows_dir_added_to_skill_paths(self, tmp_path: Path) -> None:
-        """The draft/ dir is included in skill_paths so drafts can be tested."""
-        (tmp_path / "workflows" / "draft").mkdir(parents=True)
-        with patch("medmcp.settings.VIBE_HOME", tmp_path):
-            sync_servers_to_vibe_config(_TWO_SERVERS)
-
-        with (tmp_path / "config.toml").open("rb") as f:
-            result = tomllib.load(f)
-
-        assert str(tmp_path / "workflows" / "draft") in result["skill_paths"]
-
     def test_skill_paths_updated_when_partial_deactivation(self, tmp_path: Path) -> None:
         """skill_paths reflects only the active servers after partial deactivation."""
         cfg_path = tmp_path / "config.toml"
@@ -470,55 +418,3 @@ class TestDiscoverWorkflows:
             found = [w for w in discover_workflows() if w["name"] == "dup"]
         assert len(found) == 1
         assert found[0]["kind"] == "active"
-
-
-class TestWorkflowDisabledSkills:
-    """Deactivated workflows are written to disabled_skills on config sync."""
-
-    def test_deactivated_workflow_disabled(self, tmp_path: Path) -> None:
-        """A workflow not in the active set is written to disabled_skills."""
-        _make_workflow(tmp_path, "active", "keep-me")
-        _make_workflow(tmp_path, "active", "turn-off")
-        active_path = tmp_path / "active_workflows.json"
-        active_path.write_text(json.dumps({"active": ["keep-me"]}))
-
-        with (
-            patch("medmcp.settings.VIBE_HOME", tmp_path),
-            patch("medmcp.settings.ACTIVE_WORKFLOWS_PATH", active_path),
-        ):
-            sync_servers_to_vibe_config([])
-
-        with (tmp_path / "config.toml").open("rb") as f:
-            result = tomllib.load(f)
-        assert result["disabled_skills"] == ["turn-off"]
-
-    def test_all_active_means_none_disabled(self, tmp_path: Path) -> None:
-        """With no active_workflows.json, every workflow is active (none disabled)."""
-        _make_workflow(tmp_path, "active", "a")
-        _make_workflow(tmp_path, "draft", "b")
-        with (
-            patch("medmcp.settings.VIBE_HOME", tmp_path),
-            patch("medmcp.settings.ACTIVE_WORKFLOWS_PATH", tmp_path / "active_workflows.json"),
-        ):
-            sync_servers_to_vibe_config([])
-        with (tmp_path / "config.toml").open("rb") as f:
-            result = tomllib.load(f)
-        assert result["disabled_skills"] == []
-
-    def test_preserves_non_workflow_disabled_skills(self, tmp_path: Path) -> None:
-        """A manually-disabled non-workflow skill survives the sync."""
-        _make_workflow(tmp_path, "active", "wf-a")
-        cfg = tmp_path / "config.toml"
-        cfg.write_text('disabled_skills = ["some-builtin"]\n')
-        active_path = tmp_path / "active_workflows.json"
-        active_path.write_text(json.dumps({"active": []}))  # wf-a deactivated
-
-        with (
-            patch("medmcp.settings.VIBE_HOME", tmp_path),
-            patch("medmcp.settings.ACTIVE_WORKFLOWS_PATH", active_path),
-        ):
-            sync_servers_to_vibe_config([])
-
-        with cfg.open("rb") as f:
-            result = tomllib.load(f)
-        assert set(result["disabled_skills"]) == {"some-builtin", "wf-a"}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -514,22 +514,37 @@ class TestUsageWindow:
 
 
 class TestVisiblePermissionOptions:
-    """The durable auto-approval option is never offered to the browser."""
+    """No auto-approval option is ever offered to the browser."""
 
-    def test_drops_allow_always_permanent(self) -> None:
-        """``allow_always_permanent`` is filtered; the interactive options stay."""
-        options = [
+    @staticmethod
+    def _vibe_options() -> list[dict[str, object]]:
+        """The four options vibe-acp offers on every permission request."""
+        return [
             {"optionId": "allow_once", "name": "Allow once"},
             {"optionId": "allow_always", "name": "Allow for remainder of this session"},
             {"optionId": "allow_always_permanent", "name": "Always allow"},
             {"optionId": "reject_once", "name": "Deny"},
         ]
-        visible = server._visible_permission_options(options)
-        assert [o["optionId"] for o in visible] == ["allow_once", "allow_always", "reject_once"]
+
+    def test_drops_both_auto_approve_options(self) -> None:
+        """Session-scoped and permanent "always" both go; allow/deny remain."""
+        visible = server._visible_permission_options(self._vibe_options())
+        assert [o["optionId"] for o in visible] == ["allow_once", "reject_once"]
+
+    def test_relabels_allow_once(self) -> None:
+        """With no "always" variant to contrast against, the scope drops from the label."""
+        visible = server._visible_permission_options(self._vibe_options())
+        assert [o["name"] for o in visible] == ["Allow", "Deny"]
+
+    def test_does_not_mutate_input(self) -> None:
+        """The relabel copies — the caller's option dicts are left untouched."""
+        options = self._vibe_options()
+        server._visible_permission_options(options)
+        assert options[0]["name"] == "Allow once"
 
     def test_passes_unknown_options_through(self) -> None:
-        """Only the durable option is dropped — future option ids are relayed."""
-        options = [{"optionId": "allow_once"}, {"optionId": "something_new"}]
+        """Only the auto-approve ids are dropped — future option ids are relayed."""
+        options = [{"optionId": "reject_once"}, {"optionId": "something_new"}]
         assert server._visible_permission_options(options) == options
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -471,6 +471,88 @@ class TestIdlePump:
         assert queue.qsize() == 1
 
 
+class TestToolCallRawInput:
+    """Arguments streamed in after the call is announced still reach the UI.
+
+    vibe announces a tool call before the model has finished streaming its
+    arguments, so the opening ``tool_call`` frame can carry an empty rawInput and
+    the completed one arrives on a later ``tool_call_update``. Missing that
+    second copy leaves the approval box with no arguments to show and the
+    provenance event with no ``arguments`` — see ``_effect_progress_updates`` in
+    vibe's session_updates (rawInput is re-sent only when the detail changed).
+    """
+
+    @staticmethod
+    def _update(payload: dict[str, object]) -> dict[str, object]:
+        return {"method": "session/update", "params": {"update": payload}}
+
+    @pytest.mark.asyncio
+    async def test_late_arguments_overwrite_the_partial_placeholder(self) -> None:
+        """The completed rawInput replaces the empty one from the opening frame."""
+        queue: asyncio.Queue[dict[str, object]] = asyncio.Queue()
+        conn = server._ChatConnection(cast("Any", _StubWs()), "sid", cast("Any", queue), [])
+        await queue.put(
+            self._update(
+                {
+                    "sessionUpdate": "tool_call",
+                    "toolCallId": "call_1",
+                    "title": "medmcp-neuro-core_skull_strip",
+                    "status": "pending",
+                    "rawInput": {},
+                }
+            )
+        )
+        await queue.put(
+            self._update(
+                {
+                    "sessionUpdate": "tool_call_update",
+                    "toolCallId": "call_1",
+                    "status": "in_progress",
+                    "rawInput": {"image": "/data/T1.nii.gz"},
+                }
+            )
+        )
+        conn.start_idle_pump()
+        await asyncio.sleep(0.05)
+        await conn._stop_idle_pump()
+
+        assert conn._tool_calls["call_1"]["rawInput"] == {"image": "/data/T1.nii.gz"}
+        sent = cast("_StubWs", conn.ws).sent
+        update_frame = next(m for m in sent if m.get("type") == "tool_call_update")
+        assert update_frame["rawInput"] == {"image": "/data/T1.nii.gz"}
+
+    @pytest.mark.asyncio
+    async def test_update_without_arguments_keeps_the_known_ones(self) -> None:
+        """A status-only update (vibe sends rawInput only when detail changed)."""
+        queue: asyncio.Queue[dict[str, object]] = asyncio.Queue()
+        conn = server._ChatConnection(cast("Any", _StubWs()), "sid", cast("Any", queue), [])
+        await queue.put(
+            self._update(
+                {
+                    "sessionUpdate": "tool_call",
+                    "toolCallId": "call_1",
+                    "title": "bash",
+                    "status": "pending",
+                    "rawInput": {"command": "ls"},
+                }
+            )
+        )
+        await queue.put(
+            self._update(
+                {
+                    "sessionUpdate": "tool_call_update",
+                    "toolCallId": "call_1",
+                    "status": "in_progress",
+                }
+            )
+        )
+        conn.start_idle_pump()
+        await asyncio.sleep(0.05)
+        await conn._stop_idle_pump()
+
+        assert conn._tool_calls["call_1"]["rawInput"] == {"command": "ls"}
+
+
 class TestUsageWindow:
     """The context meter denominator: Ollama's num_ctx wins over vibe's registry figure."""
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -200,31 +200,27 @@ class TestWorkspaceNote:
 
 
 class TestSettingsMerge:
-    """The settings PUT merges the drawer's known lists with the current state.
+    """The settings PUT merges the drawer's known stack list with the current state.
 
-    The drawer submits every entry it knew about (name + active). Entries it
-    never saw (e.g. a workflow distilled while the drawer was open) must keep
-    their current active state rather than being dropped.
+    The drawer submits every stack it knew about (name + active). Stacks it never
+    saw (e.g. one installed while the drawer was open) must keep their current
+    active state rather than being dropped.
     """
 
     @pytest.fixture
     def harness(self, monkeypatch: pytest.MonkeyPatch) -> dict[str, set[str]]:
         """Stub settings persistence and the vibe restart; capture what's saved.
 
-        ``old`` seeds the current active sets; ``saved`` records the merged sets
-        the endpoint persists. The vibe-acp restart and config sync are stubbed
-        so the endpoint can run without a subprocess.
+        ``old_stacks`` seeds the current active set; ``saved`` records the merged
+        set the endpoint persists. The vibe-acp restart and config sync are
+        stubbed so the endpoint can run without a subprocess.
         """
         old_stacks = {"alpha", "beta"}
-        old_workflows = {"wf-keep"}
         saved: dict[str, set[str]] = {}
 
         # Strict pyright rejects untyped lambdas, so the stubs are typed defs.
         def _save_stacks(names: Iterable[str]) -> None:
             saved["stacks"] = set(names)
-
-        def _save_workflows(names: Iterable[str]) -> None:
-            saved["workflows"] = set(names)
 
         def _noop_bool(_value: bool) -> None:
             return None
@@ -239,13 +235,9 @@ class TestSettingsMerge:
             return None
 
         monkeypatch.setattr(settings, "load_active_server_names", lambda: set(old_stacks))
-        monkeypatch.setattr(settings, "load_active_workflow_names", lambda: set(old_workflows))
-        monkeypatch.setattr(settings, "load_workflows_enabled", lambda: True)
         monkeypatch.setattr(settings, "save_explain_enabled", _noop_bool)
         monkeypatch.setattr(settings, "save_provenance_enabled", _noop_bool)
-        monkeypatch.setattr(settings, "save_workflows_enabled", _noop_bool)
         monkeypatch.setattr(settings, "save_active_server_names", _save_stacks)
-        monkeypatch.setattr(settings, "save_active_workflow_names", _save_workflows)
         monkeypatch.setattr(settings, "sync_servers_to_vibe_config", _noop_sync)
         monkeypatch.setattr(settings, "active_servers", _active_servers)
         monkeypatch.setattr(server, "_restart_vibe", _no_restart)
@@ -256,9 +248,7 @@ class TestSettingsMerge:
         body: dict[str, object] = {
             "explain_tools": True,
             "record_provenance": False,
-            "workflows_enabled": True,
             "stacks": [],
-            "workflows": [],
         }
         body.update(overrides)
         resp = client.put("/api/settings", json=body)
@@ -283,27 +273,14 @@ class TestSettingsMerge:
         assert harness["stacks"] == {"beta"}
         assert result["restarted"] is True
 
-    def test_workflows_master_toggle_triggers_restart(self, harness: dict[str, set[str]]) -> None:
-        """Flipping the workflows master switch restarts vibe even if sets match."""
-        client = TestClient(server.app)
-        result = self._put(
-            client,
-            workflows_enabled=False,
-            stacks=[{"name": "alpha", "active": True}, {"name": "beta", "active": True}],
-            workflows=[{"name": "wf-keep", "active": True}],
-        )
-        assert result["restarted"] is True
-
     def test_no_restart_when_nothing_changes(self, harness: dict[str, set[str]]) -> None:
         """Re-submitting the current state is a no-op restart-wise."""
         client = TestClient(server.app)
         result = self._put(
             client,
             stacks=[{"name": "alpha", "active": True}, {"name": "beta", "active": True}],
-            workflows=[{"name": "wf-keep", "active": True}],
         )
         assert harness["stacks"] == {"alpha", "beta"}
-        assert harness["workflows"] == {"wf-keep"}
         assert result["restarted"] is False
 
 

--- a/tests/test_server_pool.py
+++ b/tests/test_server_pool.py
@@ -78,8 +78,6 @@ async def test_lifespan_enabled_starts_and_stops_broker(
     monkeypatch.setenv("MEDMCP_STACK_POOL", "1")
     monkeypatch.setenv("MEDMCP_WORKSPACE", str(tmp_path))
     monkeypatch.setattr(settings, "VIBE_HOME", tmp_path)
-    monkeypatch.setattr(settings, "WORKFLOWS_ENABLED_PATH", tmp_path / "workflows_enabled.json")
-    monkeypatch.setattr(settings, "ACTIVE_WORKFLOWS_PATH", tmp_path / "active_workflows.json")
     monkeypatch.setattr(settings, "get_uv_tool_dir", lambda: None)
     settings.load_mcp_servers.cache_clear()
     monkeypatch.setattr(server, "_pool", None)

--- a/tests/test_stack_pool_sync.py
+++ b/tests/test_stack_pool_sync.py
@@ -32,8 +32,6 @@ _DICOM: JsonDict = {
 
 def _isolate(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, *, pool: bool) -> None:
     monkeypatch.setattr(settings, "VIBE_HOME", tmp_path)
-    monkeypatch.setattr(settings, "WORKFLOWS_ENABLED_PATH", tmp_path / "workflows_enabled.json")
-    monkeypatch.setattr(settings, "ACTIVE_WORKFLOWS_PATH", tmp_path / "active_workflows.json")
     if pool:
         monkeypatch.setenv("MEDMCP_STACK_POOL", "1")
     else:


### PR DESCRIPTION
## Summary
Four changes to what the agent is allowed to do without asking and what the UI puts in front of you when it does ask: the permission dialog loses both approve-more-than-this-call options, the viewer's overlay becomes drag-and-drop only, provenance's off switch moves out of easy reach, and personal workflows stop being loadable as agent skills. Plus one bug fix found while verifying the rest — tool-call arguments had stopped reaching the approval dialog entirely.

## Related issue
N/A

## Test plan
- [x] `just check` — 315 tests, ruff lint + format, pyright strict: all pass
- [x] `npm run lint` + `npm run build` (tsc strict): clean, no eslint findings
- [x] New unit tests: `_visible_permission_options` (drops both auto-approve ids, relabels, doesn't mutate its input); `sync_servers_to_vibe_config` (workflow dirs never in `skill_paths`, stack skills unaffected, stale workflow names dropped from `disabled_skills` while `skill-creator`/`vibe` survive); tool-call `rawInput` arriving late vs. a status-only update
- [x] Built the core image and ran the full stack (`docker-compose.ghcr.yml` + `docker-compose.localtest.yml`), verified against the running instance:
  - `GET /api/settings` no longer returns `workflows_enabled` / `workflows`
  - `GET /api/workflows` no longer returns `enabled`; still lists workflows
  - in-container `config.toml`: `skill_paths` holds only the stack's own skills; `disabled_skills` is down to `skill-creator` + `vibe`
  - an existing promoted workflow still lists and stays replayable
- [x] Manual: approval dialog shows **Allow** / **Deny** only, with arguments
- [x] Manual: drag a volume from the explorer onto an open image to overlay it

## Screenshots
N/A

## Security & data handling

This PR narrows what runs without an explicit, per-call decision.

- **No auto-approval remains in the dialog.** vibe offers four options per call; two of them approve beyond the call in hand — `allow_always` (rest of session) and `allow_always_permanent` (persisted into `config.toml`). Both are now filtered, leaving allow/deny. This is not hypothetical: the working `.vibe/config.toml` on the dev host had grown `[tools.bash] allowlist = ["find"]` from a single "Always allow" click, which is exactly the redirect bypass class we removed the bash allowlist for in #89. Entries already written into a host's config are not retracted by this change.
- **The agent can no longer invoke a personal workflow.** Distilled workflows were published into `skill_paths`, giving the model a second, unreviewed route to the same stack tools alongside the deterministic replay engine — and which one ran depended on whether the user opened the workflow panel or typed the name in chat. No workflow directory is published now; the replay engine (which still requires the resolved-step preview and explicit confirmation) is the only way to run one. Non-workflow `disabled_skills` entries are preserved, so `skill-creator` stays disabled.
- **Provenance is harder to switch off.** Its toggle moves behind an Advanced disclosure and the hint now states the cost (no audit trail, not distillable). Default is unchanged (on).
- **The approval dialog shows the arguments again.** Tool-call arguments had stopped reaching it, so approval decisions were being made on a tool name alone. Same fix restores `arguments` in the provenance record.

No new tool surface, no new network calls, no new file-write paths, no change to the `_safe_path` workspace boundary or the `127.0.0.1` bind.
