### PR TITLE
fix: scale the stack task limit to the host instead of a fixed 512

### DIFF
--- a/src/medmcp/settings.py
+++ b/src/medmcp/settings.py
@@ -259,51 +259,95 @@ def call_entry_point(python: Path, module: str, attr: str) -> object:
     return json.loads(result.stdout)
 
 
-# Isolation applied to every container-stack launch. Stacks bake their weights at
-# build time and are offline at runtime (verified: all shipped stacks initialise and
-# register their tools under `--network none`), so egress is denied by default — the
-# safety model assumes the local model can be steered by prompt injection, and a tool
-# call must not become a data-exfiltration path. A stack that genuinely needs egress
-# sets "network": true in its org.medmcp.stack label, which writes an explicit
-# `--network bridge` at install time; that is detected and preserved here.
-#
-# The MCP server inside a stack is a plain Python process over stdio: it needs no
-# capabilities, no privilege escalation, and no unbounded process count.
-# DAC_OVERRIDE is added back deliberately. The workspace is bind-mounted from the
-# host, where its files are owned by the invoking user, while the stack runs as root
-# inside the container. Root normally bypasses the permission check via
-# CAP_DAC_OVERRIDE; dropping it makes every tool fail to write its results into a
-# host-owned directory ("cannot open output file ..."), which drops all of ALL's
-# other capabilities while keeping the stack functional. The proper fix is to run
-# stacks as the invoking uid, which removes the need for this entirely — see the
-# non-root work tracked separately.
-_STACK_RUN_HARDENING: tuple[tuple[str, tuple[str, ...]], ...] = (
-    ("--network", ("--network", "none")),
-    ("--cap-drop", ("--cap-drop", "ALL")),
-    ("--cap-add", ("--cap-add", "DAC_OVERRIDE")),
-    ("--security-opt", ("--security-opt", "no-new-privileges")),
-    ("--pids-limit", ("--pids-limit", "512")),
-)
+def _stack_pids_limit() -> int:
+    """Return the per-stack task limit, scaled to this host's CPU count.
+
+    ``pids.max`` counts *threads*, not just processes, and the imaging stacks are
+    deliberately parallel: nnUNet-style inference forks a pool of preprocessing
+    workers, and each worker then opens an OpenMP/BLAS pool sized to the core
+    count. The peak is therefore roughly quadratic in cores, so any fixed number
+    is wrong somewhere — 512 was comfortable on a laptop and throttled a 20-core
+    DGX Spark, where a single LST-AI run peaked at 629 tasks and died with
+    ``pthread_create() is 11`` (EAGAIN). nnUNet reports that as "Background
+    workers died ... your RAM was full", which sends you looking at memory.
+
+    256 per core keeps ~6x headroom over that measured peak while still bounding
+    a runaway fork loop far below the kernel's ``pid_max``; the floor covers hosts
+    that report very few cores (containers with a small ``cpuset``) where the
+    stack can still be asked to process a full-resolution volume.
+    """
+    return max(4096, (os.cpu_count() or 8) * 256)
+
+
+# Flags whose *value* is a floor rather than a fixed setting: an existing lower
+# value is raised, an existing higher one is left alone. Everything else in
+# _STACK_RUN_HARDENING is presence-checked only, so a deliberate opt-out (a stack
+# that sets "network": true and installs with `--network bridge`) survives.
+_STACK_RUN_MINIMUMS: tuple[str, ...] = ("--pids-limit",)
+
+
+def _stack_run_hardening() -> tuple[tuple[str, tuple[str, ...]], ...]:
+    """Container-isolation flags applied to every container-stack launch.
+
+    Stacks bake their weights at build time and are offline at runtime (verified:
+    all shipped stacks initialise and register their tools under ``--network
+    none``), so egress is denied by default — the safety model assumes the local
+    model can be steered by prompt injection, and a tool call must not become a
+    data-exfiltration path.
+
+    The MCP server inside a stack is a plain Python process over stdio: it needs no
+    capabilities and no privilege escalation. DAC_OVERRIDE is added back
+    deliberately. The workspace is bind-mounted from the host, where its files are
+    owned by the invoking user, while the stack runs as root inside the container.
+    Root normally bypasses the permission check via CAP_DAC_OVERRIDE; dropping it
+    makes every tool fail to write its results into a host-owned directory
+    ("cannot open output file ..."), which drops all of ALL's other capabilities
+    while keeping the stack functional. The proper fix is to run stacks as the
+    invoking uid, which removes the need for this entirely — see the non-root work
+    tracked separately.
+    """
+    return (
+        ("--network", ("--network", "none")),
+        ("--cap-drop", ("--cap-drop", "ALL")),
+        ("--cap-add", ("--cap-add", "DAC_OVERRIDE")),
+        ("--security-opt", ("--security-opt", "no-new-privileges")),
+        ("--pids-limit", ("--pids-limit", str(_stack_pids_limit()))),
+    )
 
 
 def _harden_stack_run_args(args: list[str]) -> list[str]:
     """Insert container-isolation flags into a ``docker run`` argument list.
 
     Idempotent — a flag already present (written by a newer install, or by a stack
-    that opted into egress) is left untouched. Flags are inserted directly after
-    ``run`` so they precede the image reference and anything after it.
+    that opted into egress) is left untouched, except for the value floors in
+    :data:`_STACK_RUN_MINIMUMS`, which are raised in place. Flags are inserted
+    directly after ``run`` so they precede the image reference and anything after
+    it.
 
     This runs at manifest *load* time as well as install time, so stacks installed
     before this existed are hardened without requiring a reinstall. ``stacks.d``
     manifests are the launch recipe and are written once at install; without the
-    load-time pass, an upgrade would silently leave existing stacks unisolated.
+    load-time pass, an upgrade would silently leave existing stacks unisolated —
+    and, for the floors, would pin them to whatever value was correct on the day
+    they were installed.
     """
     if not args or args[0] != "run":
         return args
+    args = list(args)
     missing: list[str] = []
-    for flag, addition in _STACK_RUN_HARDENING:
+    for flag, addition in _stack_run_hardening():
         if flag not in args:
             missing += addition
+            continue
+        if flag not in _STACK_RUN_MINIMUMS:
+            continue
+        # Raise a stale or hand-lowered value to the current floor. A malformed
+        # value is left alone: docker will reject it with a clearer message than
+        # anything guessed here.
+        index = args.index(flag) + 1
+        if index < len(args):
+            with contextlib.suppress(ValueError):
+                args[index] = str(max(int(args[index]), int(addition[1])))
     return [args[0], *missing, *args[1:]] if missing else args
 
 

--- a/tests/test_stacks_install.py
+++ b/tests/test_stacks_install.py
@@ -290,6 +290,53 @@ class TestStackIsolation:
         assert "--cap-drop" in args
         assert args[-1] == "img:tag"
 
+    def test_pids_limit_scales_with_cpu_count(self) -> None:
+        """The task limit tracks core count instead of being a fixed number.
+
+        Peak task usage is roughly quadratic in cores (a pool of workers, each
+        opening a pool of threads), so a value that fits a laptop throttles a
+        many-core host: 512 killed LST-AI mid-run on a 20-core box at 629 tasks.
+        """
+        with patch("medmcp.settings.os.cpu_count", return_value=128):
+            assert settings._stack_pids_limit() == 128 * 256  # pyright: ignore[reportPrivateUsage]  # testing an internal on purpose
+        # Floor applies where the host reports very few cores (small cpuset), which
+        # does not make a full-resolution volume any less demanding.
+        with patch("medmcp.settings.os.cpu_count", return_value=2):
+            assert settings._stack_pids_limit() == 4096  # pyright: ignore[reportPrivateUsage]  # testing an internal on purpose
+        # cpu_count() returns None on hosts it cannot determine; must not crash.
+        with patch("medmcp.settings.os.cpu_count", return_value=None):
+            assert settings._stack_pids_limit() == 4096  # pyright: ignore[reportPrivateUsage]  # testing an internal on purpose
+
+    def test_stale_pids_limit_is_raised_on_load(self, stacks_dir: Path) -> None:
+        """An already-installed manifest gets its too-low task limit raised.
+
+        The presence check alone is not enough here: every stack installed before
+        this fix carries `--pids-limit 512`, so without raising the value in place
+        they would keep the limit that killed them until someone reinstalled.
+        """
+        stacks_dir.mkdir(parents=True, exist_ok=True)
+        (stacks_dir / "medmcp-stale.toml").write_text(
+            'name = "medmcp-stale"\n'
+            'command = "docker"\n'
+            'args = ["run", "--pids-limit", "512", "--rm", "-i", "img:tag"]\n'
+        )
+        loaded = settings._load_stack_manifests()  # pyright: ignore[reportPrivateUsage]  # testing an internal on purpose
+        entry = next(m for m in loaded if m["name"] == "medmcp-stale")
+        args = entry["args"]
+        assert int(args[args.index("--pids-limit") + 1]) == settings._stack_pids_limit()  # pyright: ignore[reportPrivateUsage]  # testing an internal on purpose
+        assert args.count("--pids-limit") == 1
+
+    def test_higher_pids_limit_is_preserved(self) -> None:
+        """A deliberately raised limit is a floor, not a target — it is not lowered."""
+        raised = str(settings._stack_pids_limit() * 4)  # pyright: ignore[reportPrivateUsage]  # testing an internal on purpose
+        args = settings._harden_stack_run_args(["run", "--pids-limit", raised, "img:tag"])  # pyright: ignore[reportPrivateUsage]  # testing an internal on purpose
+        assert args[args.index("--pids-limit") + 1] == raised
+
+    def test_malformed_pids_limit_is_left_alone(self) -> None:
+        """A non-numeric value is passed through for docker to reject clearly."""
+        args = settings._harden_stack_run_args(["run", "--pids-limit", "lots", "img:tag"])  # pyright: ignore[reportPrivateUsage]  # testing an internal on purpose
+        assert args[args.index("--pids-limit") + 1] == "lots"
+
     def test_hardening_is_idempotent(self) -> None:
         """Re-applying the hardening does not duplicate flags."""
         once = settings._harden_stack_run_args(["run", "--rm", "-i"])  # pyright: ignore[reportPrivateUsage]  # testing an internal on purpose


### PR DESCRIPTION
## What

`--pids-limit 512`, which I added with the container isolation hardening in #95/#97, kills real workloads. Found it running MS lesion segmentation on the PROVAL cohort on the DGX Spark: every `segment_ms_lesions` call failed inside HD-BET.

## Why it happens

`pids.max` counts **threads**, not processes, and the imaging stacks are deliberately parallel — nnUNet-style inference forks a pool of preprocessing workers, and each worker then opens an OpenMP/BLAS pool sized to the core count. Peak task usage is therefore roughly quadratic in cores: comfortable on a laptop, over the line on a 20-core box.

A measured LST-AI run peaks at **629 tasks** against the 512 ceiling and dies with:

```
ERROR; return code from pthread_create() is 11
	Error detail: Resource temporarily unavailable
```

`EAGAIN` from `pthread_create`. nnUNet then reports it as *"Background workers died ... your RAM was full and the worker was killed by the OS"*, which sends you looking at memory — the box had ~120 GB free.

Confirmed by changing that one flag and nothing else: at 512 the tool fails in ~10 s, at 8192 it completes and returns 4552 mm3 across 58 lesions.

This is a core bug, not a stack bug. The flag is defined in exactly one place and core injects it into the `docker run` args of every stack it launches, so no stack repo can opt out. `neuro-ms` surfaces it first only because LST-AI is the most thread-hungry stack in the catalogue; the same ceiling sits under `neuro-cancer` and `monai`.

## The fix

Scale to **256 tasks per core with a 4096 floor** — 5120 on the Spark, ~6x headroom over the measured peak, still far below the kernel's `pid_max` so a runaway fork loop is bounded. The floor covers hosts reporting very few cores (a small `cpuset` does not make a full-resolution volume less demanding), and `os.cpu_count()` returning `None` is handled.

Raising the constant alone would have fixed nothing for anyone already running: every installed stack carries `--pids-limit 512` in its `stacks.d` manifest, and `_harden_stack_run_args` only ever added *missing* flags. So flags in the new `_STACK_RUN_MINIMUMS` set are treated as floors and raised in place at load time. A deliberately higher value is preserved (floor, not target), and a malformed value is left alone for docker to reject with a better message than anything guessed here. Every other hardening flag keeps presence-only semantics, so the `--network bridge` egress opt-in still survives untouched.

## Testing

- New: scaling with cpu count, the floor, the `None` case, stale-manifest upgrade on load, higher-value preservation, malformed-value passthrough.
- Full suite green (323 passed, 2 skipped); ruff + pyright clean.
- End-to-end on hardware: `segment_ms_lesions` on `proval/m000782/20090814` completes on GPU under the new limit.

## Note for reviewers

Same failure mode as the `--cap-drop ALL` bug caught before #97 merged: a hardening flag that passes a startup smoke test and only breaks under a real workload. Worth assuming the remaining flags have the same exposure — the honest test for this class is running an actual pipeline, not checking that the container starts.

## AI Disclosure

This change was drafted with Claude Code. The diagnosis, the measured peak, and the end-to-end verification were carried out on real hardware and reviewed by me.