### PR TITLE
feat: show the model's reasoning, and raise the thinking budget

### DIFF
--- a/docker/config.toml
+++ b/docker/config.toml
@@ -118,7 +118,11 @@ api_base = "http://llm:11434/v1"
 api_key_env_var = ""
 api_style = "openai"
 backend = "generic"
-reasoning_field_name = "reasoning_content"
+# Ollama returns this model's chain of thought in `reasoning`, not the
+# `reasoning_content` other providers use. Point vibe at the right field or it
+# finds nothing and emits no thought chunks — the reasoning is produced and
+# billed either way, just discarded.
+reasoning_field_name = "reasoning"
 project_id = ""
 region = ""
 
@@ -132,7 +136,9 @@ alias = "local"
 temperature = 1.0
 input_price = 0.0
 output_price = 0.0
-thinking = "medium"
+# Reasoning is surfaced in the chat as a collapsed "Thinking" block, so a higher
+# budget buys visible working-out rather than hidden latency.
+thinking = "high"
 
 [project_context]
 max_chars = 40000

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -137,6 +137,27 @@ const ToolCard = memo(function ToolCard({ tc }: { tc: ToolCallState }) {
   )
 })
 
+/**
+ * The model's reasoning for the turn that follows.
+ *
+ * Collapsed by default and rendered as plain text, not markdown: it is
+ * working-out rather than an answer, and giving it the same weight as the reply
+ * would bury the reply. Available when you want to know why the agent did
+ * something — worth being able to inspect in a clinical tool — and out of the
+ * way when you do not.
+ */
+const ThoughtBlock = memo(function ThoughtBlock({ text }: { text: string }) {
+  return (
+    <details className="thought-block">
+      <summary>
+        <span className="thought-label">Thinking</span>
+        <span className="thought-hint">{text.length.toLocaleString()} chars</span>
+      </summary>
+      <div className="thought-body">{text}</div>
+    </details>
+  )
+})
+
 /** Render a token count compactly, e.g. 131072 → "131k". */
 function fmtTokens(n: number): string {
   if (n < 1000) return String(n)
@@ -468,6 +489,7 @@ export const Chat = memo(function Chat({
     // short timer so a long answer doesn't trigger thousands of re-renders
     // (each re-parsing the accumulated markdown).
     let chunkBuffer = ''
+    let thoughtBuffer = ''
     let flushTimer: number | null = null
     const flushChunks = () => {
       if (flushTimer != null) {
@@ -485,12 +507,40 @@ export const Chat = memo(function Chat({
         return [...prev, { kind: 'assistant', text }]
       })
     }
+    // Reasoning streams token-by-token like the answer, so it is buffered on the
+    // same timer; without that a long chain of thought re-renders the transcript
+    // once per token.
+    const flushThoughts = () => {
+      if (!thoughtBuffer) return
+      const text = thoughtBuffer
+      thoughtBuffer = ''
+      setItems((prev) => {
+        const last = prev[prev.length - 1]
+        if (last && last.kind === 'thought') {
+          return [...prev.slice(0, -1), { kind: 'thought', text: last.text + text }]
+        }
+        return [...prev, { kind: 'thought', text }]
+      })
+    }
     const onFrame = (frame: ServerFrame) => {
-      // Any non-chunk frame that appends to the transcript must flush first,
-      // or buffered text would land after the item it preceded.
-      if (frame.type !== 'chunk') flushChunks()
+      // Any streaming frame that appends to the transcript must flush first, or
+      // buffered text would land after the item it preceded.
+      if (frame.type !== 'chunk' && frame.type !== 'thought') {
+        flushChunks()
+        flushThoughts()
+      }
       switch (frame.type) {
+        case 'thought':
+          // Reasoning precedes the reply it produced, so settle any pending
+          // answer text before starting a thought block.
+          flushChunks()
+          thoughtBuffer += frame.text
+          if (flushTimer == null) {
+            flushTimer = window.setTimeout(flushThoughts, 50)
+          }
+          break
         case 'chunk':
+          flushThoughts()
           chunkBuffer += frame.text
           if (flushTimer == null) {
             flushTimer = window.setTimeout(flushChunks, 50)
@@ -725,6 +775,9 @@ export const Chat = memo(function Chat({
           <div className="viewer-message">Ask the MedMCP agent anything about your workspace.</div>
         )}
         {items.map((item, i) => {
+          if (item.kind === 'thought') {
+            return <ThoughtBlock key={i} text={item.text} />
+          }
           if (item.kind === 'tool') {
             const tc = toolCalls[item.toolCallId]
             return tc ? <ToolCard key={i} tc={tc} /> : null

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2732,3 +2732,73 @@ textarea.wf-input {
   opacity: 0.6;
   text-decoration: line-through;
 }
+
+/* ── Model reasoning ── */
+
+/* Deliberately quieter than a message: reasoning is working-out, and giving it
+   the visual weight of an answer would bury the answer. Collapsed by default,
+   one line when shut. */
+.thought-block {
+  align-self: stretch;
+  max-width: none;
+  border-left: 2px solid var(--border2);
+  padding-left: 10px;
+  margin: 1px 0;
+}
+
+.thought-block > summary {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  cursor: pointer;
+  list-style: none;
+  font-size: 11.5px;
+  color: var(--muted);
+  padding: 1px 0;
+}
+
+.thought-block > summary::-webkit-details-marker {
+  display: none;
+}
+
+/* A rotating caret rather than the native marker, so the affordance matches the
+   disclosure triangles used elsewhere in the transcript. */
+.thought-block > summary::before {
+  content: '›';
+  display: inline-block;
+  transition: transform 0.15s;
+  font-size: 13px;
+  line-height: 1;
+}
+
+.thought-block[open] > summary::before {
+  transform: rotate(90deg);
+}
+
+.thought-block > summary:hover {
+  color: var(--muted2);
+}
+
+.thought-label {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.thought-hint {
+  font-family: var(--mono);
+  font-size: 10px;
+  opacity: 0.7;
+}
+
+/* Preserves the model's own line breaks; scrolls rather than growing without
+   bound, since a long chain of thought can run to thousands of characters. */
+.thought-body {
+  margin-top: 5px;
+  max-height: 320px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--muted);
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -211,6 +211,9 @@ export type ChatItem =
   // messageId (replayed turns only) anchors per-turn actions like rewind.
   | { kind: 'user'; text: string; messageId?: string }
   | { kind: 'assistant'; text: string }
+  // The model's reasoning for the turn that follows, kept separate from the
+  // answer and collapsed by default.
+  | { kind: 'thought'; text: string }
   | { kind: 'tool'; toolCallId: string }
   | { kind: 'error'; text: string }
 
@@ -226,6 +229,7 @@ export interface RewindResult {
 export type ServerFrame =
   | { type: 'ready'; sessionId: string; model?: string }
   | { type: 'chunk'; text: string }
+  | { type: 'thought'; text: string }
   // A user turn: replayed from a resumed session (session/load), or vibe's
   // echo of a live prompt (merged into the locally-rendered bubble by id).
   | { type: 'user'; text: string; messageId?: string }

--- a/src/medmcp/server.py
+++ b/src/medmcp/server.py
@@ -965,6 +965,7 @@ async def ws_replay(ws: WebSocket) -> None:
 #   server → client
 #     {"type": "ready", "sessionId": str, "model": str}
 #     {"type": "chunk", "text": str}
+#     {"type": "thought", "text": str}   (the model's reasoning, if any)
 #     {"type": "tool_call", "toolCallId": str, "title": str, "status": str,
 #      "kind": str | None, "rawInput": object}
 #     {"type": "tool_call_update", "toolCallId": str, "status": str | None,
@@ -1414,6 +1415,17 @@ class _ChatConnection:
                     visible = self._thoughts.feed(str(content.get("text") or ""))
                     if visible:
                         await self._send({"type": "chunk", "text": visible})
+            elif update_type == "agent_thought_chunk":
+                # The model's reasoning, which vibe keeps in its own channel
+                # rather than mixing into the answer. Relayed as its own frame so
+                # the browser can offer it without it ever being mistaken for the
+                # reply — it was previously dropped here, so the work the model
+                # did to reach an answer was invisible.
+                content = cast("JsonDict", update.get("content") or {})
+                if content.get("type") == "text":
+                    text = str(content.get("text") or "")
+                    if text:
+                        await self._send({"type": "thought", "text": text})
             elif update_type == "user_message_chunk":
                 # Replayed user turns (session/load) — and, since vibe 2.23, an
                 # echo of the *live* prompt carrying its messageId; the browser


### PR DESCRIPTION
## Summary

- The model reasons on every turn and **none of it was reachable**. Two things were in the way, and both are fixed here.
- The chat now shows it as a collapsed **Thinking** disclosure above the reply.
- `thinking` is raised from `medium` to `high`, which is worth more now the output is visible rather than invisible latency.

## Related issue

N/A.

## What was wrong

**The provider config named the wrong field.** Ollama returns this model's chain of thought in `reasoning`; the config said `reasoning_content`, which other providers use. vibe looked somewhere empty, so it emitted no thought events — while the reasoning was still generated and paid for on every turn, then discarded. Measured directly against the endpoint: ~2,000–3,000 characters per turn at this budget.

**The server dropped the events anyway.** vibe sends reasoning as `agent_thought_chunk` — its own channel, so it never mixes into the answer — and `_handle_update` had no branch for it. It now relays a `thought` frame.

Both were needed; fixing either alone changes nothing.

## Design

Reasoning is **working-out, not an answer**, so it is deliberately quieter than a message: collapsed by default, plain text rather than markdown, dimmed, and scrolling past ~320px. Giving it the visual weight of a reply would bury the reply. But in a clinical tool, being able to ask *why* the agent chose a transform or a file is worth having available.

Thought chunks are buffered on the same 50 ms timer as answer text — a 3,000-character chain of thought would otherwise re-render the transcript once per token. Answer text is flushed before a thought block begins and vice versa, so the two cannot interleave out of order.

## Test plan

- [x] `just check` — 407 passed, 2 skipped; ruff, ruff format, pyright strict clean
- [x] `npm run build` / `npm run lint` — pass
- [x] **Verified end to end on a live turn**: 1,951 characters of reasoning reached the browser as `thought` frames alongside a 496-character answer. Before the fix the same turn produced 0.
- [x] Confirmed at the source that Ollama streams `reasoning` deltas (2,441 chars in one turn) and that `reasoning_content` is always empty for this model — the field name was the actual defect, not a missing capability

No new automated tests: the frame relay needs a live vibe-acp, and the frontend has no test infrastructure. Both exercised manually against the running stack.

## Screenshots

Worth a look — the Thinking disclosure is a new surface, and its collapsed height and contrast are the sort of thing that reads differently at your font size than in markup.

## Security & data handling

No change to tool surface, network calls, file-write paths, or the approval flow. Reasoning was already being generated and sent over the same connection; this stops discarding it and puts it behind a disclosure.

Worth noting for anyone reviewing the privacy posture: reasoning is model output, so it stays on-premise like everything else, and it is **not** persisted anywhere new — it lives in the transcript vibe already keeps.

## Notes

- `reasoning_field_name` is provider-specific. Swapping the model or the serving stack may need it changed again; the comment at the site says so.
- Raising `thinking` costs latency and completion tokens on every turn. `high` was chosen because the reasoning is now visible and useful; `medium` or `low` are one-line changes if turns feel slow.
- Reasoning tokens count toward the model's context. I have not measured whether they are included in the context meter — if they are not, the meter under-reports at this budget.
