### PR TITLE
fix: recover agent turns lost to Ollama's Glimmer tool-call parser

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,8 +28,8 @@ MEDMCP_WORKSPACE=/abs/path/to/workspace
 # Base image the core/stack builds derive from (default: medmcp-base:dev).
 # MEDMCP_BASE_IMAGE=ghcr.io/medmcp/base:dev
 
-# Route the agent's model traffic through the tool-call repair shim. Ollama's
-# Glimmer parser drops many tool calls and ends the stream without an error, so
-# the chat answers nothing at all; the shim repairs and retries those turns.
-# Set to 1 to enable.
-# MEDMCP_LLM_SHIM=1
+# Tool-call repair shim between the agent and the model server. On by default,
+# because Ollama's Glimmer parser drops many tool calls and ends the stream
+# without an error — the chat simply never answers. Set to 0 to disable and talk
+# to the model server directly.
+# MEDMCP_LLM_SHIM=0

--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,9 @@ MEDMCP_WORKSPACE=/abs/path/to/workspace
 
 # Base image the core/stack builds derive from (default: medmcp-base:dev).
 # MEDMCP_BASE_IMAGE=ghcr.io/medmcp/base:dev
+
+# Route the agent's model traffic through the tool-call repair shim. Ollama's
+# Glimmer parser drops many tool calls and ends the stream without an error, so
+# the chat answers nothing at all; the shim repairs and retries those turns.
+# Set to 1 to enable.
+# MEDMCP_LLM_SHIM=1

--- a/.vibe/config.toml
+++ b/.vibe/config.toml
@@ -38,7 +38,11 @@ api_base = "http://localhost:11434/v1"
 api_key_env_var = ""
 api_style = "openai"
 backend = "generic"
-reasoning_field_name = "reasoning_content"
+# Ollama names the reasoning channel differently per mode: "reasoning_content" when
+# non-streaming, "reasoning" in stream deltas. vibe streams, so this must be
+# "reasoning" — otherwise the key never matches and the model's entire answer is
+# dropped (LLMMessage ignores extras), leaving turns visibly empty.
+reasoning_field_name = "reasoning"
 project_id = ""
 region = ""
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,9 @@ Notable, user-visible changes to MedMCP. Format follows
   the model server and repairs the tool-call failures above: it works around the
   name collision that triggers them, retries turns that are cut short, and
   neutralises malformed tool arguments that would otherwise leave a chat
-  permanently unable to reply. Off by default; enable it by pointing the model
-  provider's `api_base` at it.
+  permanently unable to reply. **On by default** — the failure it prevents is
+  silent, so there is nothing for you to notice or search for when it happens.
+  Set `MEDMCP_LLM_SHIM=0` to disable it and talk to the model server directly.
 
 ## 0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,26 @@ Notable, user-visible changes to MedMCP. Format follows
 
 ## Unreleased
 
-_Nothing yet._
+### Fixed
+
+- **The agent no longer goes silent on multi-step requests.** Asking for a
+  multi-step imaging workflow could leave the chat with no reply at all — no text,
+  no error, nothing to retry. The local model server was failing to read the
+  model's tool calls and closing the connection without reporting it, so roughly
+  half of all tool-using turns were lost. Affected turns now complete, and a turn
+  that genuinely cannot be recovered says so instead of hanging.
+- **Agent replies are no longer discarded.** Responses from the model were being
+  dropped before they reached the chat because the reasoning output was read from
+  the wrong field.
+
+### Added
+
+- **`medmcp-llm-shim`** — an optional local proxy that sits between the agent and
+  the model server and repairs the tool-call failures above: it works around the
+  name collision that triggers them, retries turns that are cut short, and
+  neutralises malformed tool arguments that would otherwise leave a chat
+  permanently unable to reply. Off by default; enable it by pointing the model
+  provider's `api_base` at it.
 
 ## 0.1.0
 

--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -113,6 +113,11 @@ services:
       # warm across calls and hides pool-machinery tools (warmup) from the model.
       # 1/true to enable; empty = off (legacy per-call spawn).
       MEDMCP_STACK_POOL: "${MEDMCP_STACK_POOL:-}"
+      # Tool-call repair shim between vibe and Ollama. On by default: without it
+      # Ollama's Glimmer parser silently drops roughly half of all tool-using
+      # turns, and the failure is invisible — no error, just a chat that never
+      # answers. Set to 0 to talk to Ollama directly.
+      MEDMCP_LLM_SHIM: "${MEDMCP_LLM_SHIM:-1}"
     healthcheck:
       test:
         - CMD

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,11 +102,11 @@ services:
       # warm across calls and hides pool-machinery tools (warmup) from the model.
       # 1/true to enable; empty = off (legacy per-call spawn).
       MEDMCP_STACK_POOL: "${MEDMCP_STACK_POOL:-}"
-      # Tool-call repair shim between vibe and Ollama. Works around Ollama's
-      # Glimmer parser dropping tool calls and truncating the stream silently,
-      # which shows up as a chat that answers nothing. 1/true to enable;
-      # empty = off (vibe talks to Ollama directly).
-      MEDMCP_LLM_SHIM: "${MEDMCP_LLM_SHIM:-}"
+      # Tool-call repair shim between vibe and Ollama. On by default: without it
+      # Ollama's Glimmer parser silently drops roughly half of all tool-using
+      # turns, and the failure is invisible — no error, just a chat that never
+      # answers. Set to 0 to talk to Ollama directly.
+      MEDMCP_LLM_SHIM: "${MEDMCP_LLM_SHIM:-1}"
     healthcheck:
       test:
         - CMD

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,6 +102,11 @@ services:
       # warm across calls and hides pool-machinery tools (warmup) from the model.
       # 1/true to enable; empty = off (legacy per-call spawn).
       MEDMCP_STACK_POOL: "${MEDMCP_STACK_POOL:-}"
+      # Tool-call repair shim between vibe and Ollama. Works around Ollama's
+      # Glimmer parser dropping tool calls and truncating the stream silently,
+      # which shows up as a chat that answers nothing. 1/true to enable;
+      # empty = off (vibe talks to Ollama directly).
+      MEDMCP_LLM_SHIM: "${MEDMCP_LLM_SHIM:-}"
     healthcheck:
       test:
         - CMD

--- a/docker/config.toml
+++ b/docker/config.toml
@@ -118,7 +118,11 @@ api_base = "http://llm:11434/v1"
 api_key_env_var = ""
 api_style = "openai"
 backend = "generic"
-reasoning_field_name = "reasoning_content"
+# Ollama names the reasoning channel differently per mode: "reasoning_content" when
+# non-streaming, "reasoning" in stream deltas. vibe streams, so this must be
+# "reasoning" — otherwise the key never matches and the model's entire answer is
+# dropped (LLMMessage ignores extras), leaving turns visibly empty.
+reasoning_field_name = "reasoning"
 project_id = ""
 region = ""
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -18,11 +18,49 @@ export DOCKER_HOST="${DOCKER_HOST:-unix:///var/run/docker.sock}"
 
 CONFIG="${VIBE_HOME:-/app/.vibe}/config.toml"
 
-# Rewrite the single [[providers]] api_base from $OLLAMA_BASE_URL. Idempotent —
+# Optionally interpose the tool-call repair shim between vibe and the LLM service.
+# Ollama's Glimmer function-calling parser drops roughly half of all tool calls and
+# truncates the stream with no finish_reason and no error — HTTP 200, empty turn,
+# which reads as a frozen chat. The shim renames the colliding tool, retries
+# truncated turns, and sanitizes malformed arguments. Opt-in, so the direct path
+# stays the default; if it fails to come up we fall back rather than strand vibe on
+# a dead port. Only vibe is routed through it: the auxiliary calls (explanations,
+# distillation prose) read OLLAMA_BASE_URL and keep talking to Ollama directly.
+LLM_TARGET_URL="$OLLAMA_BASE_URL"
+if [ -n "${MEDMCP_LLM_SHIM:-}" ] && [ "${MEDMCP_LLM_SHIM}" != "0" ]; then
+    shim_port="${MEDMCP_SHIM_PORT:-11435}"
+    MEDMCP_SHIM_UPSTREAM="$OLLAMA_BASE_URL" \
+    MEDMCP_SHIM_HOST=127.0.0.1 \
+    MEDMCP_SHIM_PORT="$shim_port" \
+        medmcp-llm-shim &
+
+    # vibe-acp starts lazily, but wait anyway so the first prompt cannot race it.
+    shim_ready=""
+    for _ in $(seq 1 50); do
+        if python3 -c "
+import socket, sys
+s = socket.socket(); s.settimeout(0.2)
+sys.exit(0 if s.connect_ex(('127.0.0.1', $shim_port)) == 0 else 1)
+" 2>/dev/null; then
+            shim_ready=1
+            break
+        fi
+        sleep 0.2
+    done
+
+    if [ -n "$shim_ready" ]; then
+        LLM_TARGET_URL="http://127.0.0.1:${shim_port}"
+        echo "medmcp-entrypoint: tool-call shim on :${shim_port} -> ${OLLAMA_BASE_URL}"
+    else
+        echo "medmcp-entrypoint: WARNING: shim did not start; using ${OLLAMA_BASE_URL} directly" >&2
+    fi
+fi
+
+# Rewrite the single [[providers]] api_base from $LLM_TARGET_URL. Idempotent —
 # runs on every start, before sync_servers_to_vibe_config (which leaves providers
 # untouched). Trailing slashes are stripped so we always emit "<base>/v1".
 if [ -f "$CONFIG" ]; then
-    base="${OLLAMA_BASE_URL%/}"
+    base="${LLM_TARGET_URL%/}"
     sed -i -E "s#^api_base = \".*\"#api_base = \"${base}/v1\"#" "$CONFIG"
 
     # Point the single [[models]] entry at $OLLAMA_MODEL for the same reason:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ Homepage = "https://medmcp.ai"
 medmcp = "medmcp.provcli:main"
 medmcp-workspace = "medmcp.server:main"
 medmcp-mcp-proxy = "medmcp.proxy:main"
+medmcp-llm-shim = "medmcp.llmshim:main"
 medmcp-pathguard = "medmcp.pathguard:main"
 
 [dependency-groups]

--- a/src/medmcp/llmshim.py
+++ b/src/medmcp/llmshim.py
@@ -1,0 +1,499 @@
+"""``medmcp-llm-shim`` — a reverse proxy that repairs Ollama's Glimmer tool calls.
+
+Ollama's Muse Glimmer function-calling parser drops tool calls. Measured against
+the real workspace system prompt and tool list, ~50% of streaming requests fail;
+the failure mode differs by transport, and the streaming one is silent:
+
+* **non-streaming** → ``HTTP 500 parse Glimmer call to <tool>: malformed ATEM parameter``
+* **streaming** → the stream is truncated with **no** ``finish_reason``, no ``usage``
+  chunk, and an empty ``model`` on the final chunk. HTTP status is already 200, so
+  no client can tell the turn failed. vibe records an empty assistant message and
+  the chat appears frozen.
+
+This shim sits between vibe and Ollama and applies three repairs:
+
+1. **Tool renaming.** The dominant trigger is the tool literally named ``skill``,
+   which collides in Glimmer's ATEM recipient namespace (hence the sibling error
+   ``Glimmer recipient "skill" does not match ...``). Renaming it on the wire lifts
+   streaming success from ~50% to ~90% — the same as deleting the tool outright, but
+   the capability is kept. Names are restored on the way back, so vibe still sees
+   and executes its own builtin.
+2. **Retry on silent truncation.** A missing ``finish_reason`` is a reliable
+   abnormal-termination signal, so the shim retries instead of passing the empty
+   turn through. vibe's own retry cannot help: a truncated stream is still HTTP 200,
+   so vibe never sees an error.
+3. **Argument sanitising.** Ollama rejects (400 ``invalid tool call arguments``) any
+   assistant ``tool_calls[].function.arguments`` that is not a JSON *object* string.
+   vibe replays whatever the model produced verbatim, so one malformed call poisons
+   the history and every later request 400s — a permanently dead chat. Coercing to
+   ``"{}"`` on the way out breaks that trap.
+
+Reasoning deltas are relayed live so the UI keeps its "thinking" feed; only
+``content`` and ``tool_calls`` are buffered until the turn is known to be healthy.
+If every attempt fails the shim emits an explicit, clearly-labelled error message
+rather than an empty turn — a visible failure beats a silent one.
+
+Inert until ``api_base`` in ``.vibe/config.toml`` points at it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from collections.abc import AsyncIterator, Mapping
+from typing import Any, cast
+
+import httpx
+import uvicorn
+from fastapi import FastAPI, Request, Response
+from fastapi.responses import JSONResponse, StreamingResponse
+
+log: logging.Logger = logging.getLogger(__name__)
+
+JsonDict = dict[str, Any]
+
+# Tool names rewritten on the way to Ollama and restored on the way back. Only the
+# wire name changes; vibe keeps executing its own builtin under the original name.
+DEFAULT_RENAMES: dict[str, str] = {"skill": "load_skill"}
+
+_SSE_PREFIX = "data: "
+_SSE_DONE = "[DONE]"
+
+# Total upstream attempts per client request, including the first.
+DEFAULT_ATTEMPTS: int = 3
+
+_UPSTREAM_ENV = "MEDMCP_SHIM_UPSTREAM"
+_DEFAULT_UPSTREAM = "http://llm:11434"
+
+
+# ── request repair (pure) ──────────────────────────────────
+
+
+def sanitize_arguments(raw: object) -> str:
+    """Coerce a tool call's ``arguments`` into a JSON-object string.
+
+    Ollama unmarshals ``arguments`` as a string and then parses it as a JSON object,
+    rejecting the request outright if either step fails. Anything that would fail —
+    ``None``, ``""``, whitespace, truncated JSON, or a non-object like ``[]`` — is
+    replaced with ``"{}"`` so the request survives. A dict is re-serialised rather
+    than dropped, since its content is still meaningful.
+    """
+    if isinstance(raw, dict):
+        try:
+            return json.dumps(cast("JsonDict", raw))
+        except (TypeError, ValueError):
+            return "{}"
+    if not isinstance(raw, str):
+        return "{}"
+    try:
+        parsed: object = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return "{}"
+    return raw if isinstance(parsed, dict) else "{}"
+
+
+def _rename_tool_calls(message: JsonDict, renames: Mapping[str, str]) -> None:
+    """Rewrite tool-call names and sanitise arguments on one message, in place."""
+    raw_calls = message.get("tool_calls")
+    if not isinstance(raw_calls, list):
+        return
+    for raw_call in cast("list[object]", raw_calls):
+        if not isinstance(raw_call, dict):
+            continue
+        call = cast("JsonDict", raw_call)
+        raw_fn = call.get("function")
+        if not isinstance(raw_fn, dict):
+            continue
+        fn = cast("JsonDict", raw_fn)
+        name = fn.get("name")
+        if isinstance(name, str) and name in renames:
+            fn["name"] = renames[name]
+        fn["arguments"] = sanitize_arguments(fn.get("arguments"))
+
+
+def repair_request(payload: JsonDict, renames: Mapping[str, str]) -> JsonDict:
+    """Return ``payload`` with tools renamed and tool-call arguments sanitised.
+
+    Renames are applied to the advertised ``tools`` list, to assistant ``tool_calls``
+    already in the history, and to the ``name`` on ``tool`` result messages, so the
+    model never sees the two spellings mixed.
+    """
+    out = cast("JsonDict", json.loads(json.dumps(payload)))
+
+    raw_tools = out.get("tools")
+    if isinstance(raw_tools, list):
+        for raw_tool in cast("list[object]", raw_tools):
+            if not isinstance(raw_tool, dict):
+                continue
+            raw_fn = cast("JsonDict", raw_tool).get("function")
+            if not isinstance(raw_fn, dict):
+                continue
+            fn = cast("JsonDict", raw_fn)
+            name = fn.get("name")
+            if isinstance(name, str) and name in renames:
+                fn["name"] = renames[name]
+
+    raw_messages = out.get("messages")
+    if isinstance(raw_messages, list):
+        for raw_message in cast("list[object]", raw_messages):
+            if not isinstance(raw_message, dict):
+                continue
+            message = cast("JsonDict", raw_message)
+            _rename_tool_calls(message, renames)
+            if message.get("role") == "tool":
+                tool_name = message.get("name")
+                if isinstance(tool_name, str) and tool_name in renames:
+                    message["name"] = renames[tool_name]
+
+    return out
+
+
+def restore_response(payload: JsonDict, inverse: Mapping[str, str]) -> JsonDict:
+    """Rewrite renamed tool names in a response back to what the caller expects."""
+    for key in ("choices",):
+        raw_choices = payload.get(key)
+        if not isinstance(raw_choices, list):
+            continue
+        for raw_choice in cast("list[object]", raw_choices):
+            if not isinstance(raw_choice, dict):
+                continue
+            choice = cast("JsonDict", raw_choice)
+            for slot in ("message", "delta"):
+                raw_msg = choice.get(slot)
+                if isinstance(raw_msg, dict):
+                    _restore_names(cast("JsonDict", raw_msg), inverse)
+    return payload
+
+
+def _restore_names(message: JsonDict, inverse: Mapping[str, str]) -> None:
+    raw_calls = message.get("tool_calls")
+    if not isinstance(raw_calls, list):
+        return
+    for raw_call in cast("list[object]", raw_calls):
+        if not isinstance(raw_call, dict):
+            continue
+        raw_fn = cast("JsonDict", raw_call).get("function")
+        if not isinstance(raw_fn, dict):
+            continue
+        fn = cast("JsonDict", raw_fn)
+        name = fn.get("name")
+        if isinstance(name, str) and name in inverse:
+            fn["name"] = inverse[name]
+
+
+# ── stream classification ──────────────────────────────────
+
+
+class StreamOutcome:
+    """Accumulates one upstream SSE stream and judges whether it completed.
+
+    ``content`` and ``tool_calls`` chunks are withheld until the stream is known to
+    be healthy, so a truncated attempt can be retried without the caller having seen
+    a partial answer. Reasoning chunks are released immediately — they are display-only
+    and replaying them across attempts is harmless.
+    """
+
+    def __init__(self) -> None:
+        """Start an empty outcome for one upstream attempt."""
+        self.saw_finish_reason: bool = False
+        self.saw_usable: bool = False
+        self.buffered: list[JsonDict] = []
+        self.tail: list[JsonDict] = []
+
+    @property
+    def healthy(self) -> bool:
+        """Whether the stream terminated normally.
+
+        A missing ``finish_reason`` is the abnormal-termination signal: healthy turns
+        always carry one (``"tool_calls"`` or ``"stop"``), truncated ones never do.
+        """
+        return self.saw_finish_reason
+
+    def feed(self, event: JsonDict) -> JsonDict | None:
+        """Absorb one SSE event; return an event to forward now, or ``None``."""
+        raw_choices = event.get("choices")
+        if not isinstance(raw_choices, list) or not raw_choices:
+            # A usage-only or keepalive frame belongs with the tail, after content.
+            self.tail.append(event)
+            return None
+
+        passthrough = False
+        for raw_choice in cast("list[object]", raw_choices):
+            if not isinstance(raw_choice, dict):
+                continue
+            choice = cast("JsonDict", raw_choice)
+            if choice.get("finish_reason"):
+                self.saw_finish_reason = True
+            raw_delta = choice.get("delta")
+            delta = cast("JsonDict", raw_delta) if isinstance(raw_delta, dict) else {}
+            if delta.get("content") or delta.get("tool_calls"):
+                self.saw_usable = True
+            # Reasoning-only frames stream straight through.
+            reasoning = delta.get("reasoning") or delta.get("reasoning_content")
+            if reasoning and not delta.get("content") and not delta.get("tool_calls"):
+                passthrough = True
+
+        if passthrough:
+            return event
+        self.buffered.append(event)
+        return None
+
+    def release(self) -> list[JsonDict]:
+        """Return the withheld events, in order, once the stream is trusted."""
+        return [*self.buffered, *self.tail]
+
+
+def parse_sse_line(line: str) -> JsonDict | None:
+    """Decode one ``data:`` SSE line into an event, or ``None`` if not an event."""
+    if not line.startswith(_SSE_PREFIX):
+        return None
+    body = line[len(_SSE_PREFIX) :].strip()
+    if not body or body == _SSE_DONE:
+        return None
+    try:
+        parsed: object = json.loads(body)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    return cast("JsonDict", parsed) if isinstance(parsed, dict) else None
+
+
+def _encode(event: JsonDict) -> bytes:
+    return f"{_SSE_PREFIX}{json.dumps(event)}\n\n".encode()
+
+
+def failure_event(model: str, detail: str) -> JsonDict:
+    """Build a terminal chunk that reports an upstream failure in-band.
+
+    Once SSE headers are sent the status code is fixed at 200, so the only way to
+    make the failure visible is a final message. It is explicitly labelled as coming
+    from the shim so it is never mistaken for the model's own words.
+    """
+    return {
+        "id": "medmcp-shim-error",
+        "object": "chat.completion.chunk",
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "delta": {
+                    "role": "assistant",
+                    "content": (
+                        f"[medmcp: the local model server failed to return a usable "
+                        f"response after retries — {detail}. This is an Ollama "
+                        f"tool-call parsing failure, not a model refusal. Try again.]"
+                    ),
+                },
+                "finish_reason": "stop",
+            }
+        ],
+    }
+
+
+# ── proxy app ──────────────────────────────────────────────
+
+
+def _inverse(renames: Mapping[str, str]) -> dict[str, str]:
+    return {v: k for k, v in renames.items()}
+
+
+def create_app(
+    upstream: str,
+    *,
+    renames: Mapping[str, str] | None = None,
+    attempts: int = DEFAULT_ATTEMPTS,
+) -> FastAPI:
+    """Build the shim ASGI app forwarding to ``upstream``."""
+    app = FastAPI(title="medmcp-llm-shim")
+    mapping = dict(DEFAULT_RENAMES if renames is None else renames)
+    inverse = _inverse(mapping)
+    base = upstream.rstrip("/")
+
+    @app.post("/v1/chat/completions")
+    async def chat_completions(request: Request) -> Response:  # pyright: ignore[reportUnusedFunction]
+        try:
+            raw: object = json.loads(await request.body())
+        except (json.JSONDecodeError, ValueError):
+            return JSONResponse({"error": {"message": "invalid JSON"}}, status_code=400)
+        if not isinstance(raw, dict):
+            return JSONResponse({"error": {"message": "invalid payload"}}, status_code=400)
+
+        payload = repair_request(cast("JsonDict", raw), mapping)
+        model = str(payload.get("model") or "")
+        url = f"{base}/v1/chat/completions"
+
+        if payload.get("stream"):
+            return StreamingResponse(
+                _stream_with_retry(url, payload, inverse, attempts, model),
+                media_type="text/event-stream",
+            )
+        return await _complete_with_retry(url, payload, inverse, attempts)
+
+    @app.api_route(  # pyright: ignore[reportUntypedFunctionDecorator]
+        "/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "HEAD"]
+    )
+    async def passthrough(request: Request, path: str) -> Response:  # pyright: ignore[reportUnusedFunction]
+        """Forward every other Ollama route untouched, so the shim is a drop-in."""
+        body = await request.body()
+        headers = {k: v for k, v in request.headers.items() if k.lower() != "host"}
+        async with httpx.AsyncClient(timeout=httpx.Timeout(900.0)) as client:
+            upstream_resp = await client.request(
+                request.method,
+                f"{base}/{path}",
+                content=body,
+                headers=headers,
+                params=request.query_params,
+            )
+        excluded = {"content-encoding", "content-length", "transfer-encoding", "connection"}
+        return Response(
+            content=upstream_resp.content,
+            status_code=upstream_resp.status_code,
+            headers={k: v for k, v in upstream_resp.headers.items() if k.lower() not in excluded},
+        )
+
+    return app
+
+
+async def _complete_with_retry(
+    url: str, payload: JsonDict, inverse: Mapping[str, str], attempts: int
+) -> Response:
+    """Run a non-streaming completion, retrying parse failures and empty turns."""
+    detail = "unknown error"
+    async with httpx.AsyncClient(timeout=httpx.Timeout(900.0)) as client:
+        for attempt in range(1, attempts + 1):
+            resp = await client.post(url, json=payload)
+            if resp.status_code != 200:
+                detail = resp.text[:200]
+                log.warning(
+                    "shim: upstream %s on attempt %d/%d", resp.status_code, attempt, attempts
+                )
+                continue
+            try:
+                parsed: object = resp.json()
+            except (json.JSONDecodeError, ValueError):
+                detail = "upstream returned non-JSON"
+                continue
+            if not isinstance(parsed, dict):
+                detail = "upstream returned a non-object"
+                continue
+            body = restore_response(cast("JsonDict", parsed), inverse)
+            if _has_usable_choice(body):
+                return JSONResponse(body)
+            detail = "upstream returned an empty turn"
+            log.warning("shim: empty turn on attempt %d/%d", attempt, attempts)
+    return JSONResponse(
+        {
+            "error": {
+                "message": f"medmcp-llm-shim: no usable response after {attempts} attempts "
+                f"({detail})",
+                "type": "api_error",
+            }
+        },
+        status_code=502,
+    )
+
+
+def _has_usable_choice(body: JsonDict) -> bool:
+    raw_choices = body.get("choices")
+    if not isinstance(raw_choices, list):
+        return False
+    for raw_choice in cast("list[object]", raw_choices):
+        if not isinstance(raw_choice, dict):
+            continue
+        raw_msg = cast("JsonDict", raw_choice).get("message")
+        if not isinstance(raw_msg, dict):
+            continue
+        msg = cast("JsonDict", raw_msg)
+        content = msg.get("content")
+        if (isinstance(content, str) and content.strip()) or msg.get("tool_calls"):
+            return True
+    return False
+
+
+async def _stream_with_retry(
+    url: str,
+    payload: JsonDict,
+    inverse: Mapping[str, str],
+    attempts: int,
+    model: str,
+) -> AsyncIterator[bytes]:
+    """Relay a streaming completion, retrying attempts that truncate silently."""
+    detail = "unknown error"
+    async with httpx.AsyncClient(timeout=httpx.Timeout(900.0)) as client:
+        for attempt in range(1, attempts + 1):
+            outcome = StreamOutcome()
+            try:
+                async with client.stream("POST", url, json=payload) as resp:
+                    if resp.status_code != 200:
+                        await resp.aread()
+                        detail = f"HTTP {resp.status_code}"
+                        log.warning(
+                            "shim: upstream %s on stream attempt %d/%d",
+                            resp.status_code,
+                            attempt,
+                            attempts,
+                        )
+                        continue
+                    async for line in resp.aiter_lines():
+                        event = parse_sse_line(line)
+                        if event is None:
+                            continue
+                        forward = outcome.feed(restore_response(event, inverse))
+                        if forward is not None:
+                            yield _encode(forward)
+            except httpx.HTTPError as exc:
+                detail = f"{type(exc).__name__}: {exc}"
+                log.warning("shim: stream error on attempt %d/%d: %s", attempt, attempts, exc)
+                continue
+
+            if outcome.healthy:
+                for event in outcome.release():
+                    yield _encode(event)
+                yield f"{_SSE_PREFIX}{_SSE_DONE}\n\n".encode()
+                return
+
+            detail = "stream truncated with no finish_reason"
+            log.warning("shim: silent truncation on attempt %d/%d — retrying", attempt, attempts)
+
+    yield _encode(failure_event(model, detail))
+    yield f"{_SSE_PREFIX}{_SSE_DONE}\n\n".encode()
+
+
+def _renames_from_env() -> dict[str, str]:
+    """Parse ``MEDMCP_SHIM_RENAME`` (``old=new,old2=new2``); empty disables renaming."""
+    spec = os.environ.get("MEDMCP_SHIM_RENAME")
+    if spec is None:
+        return dict(DEFAULT_RENAMES)
+    out: dict[str, str] = {}
+    for part in spec.split(","):
+        if "=" not in part:
+            continue
+        old, new = part.split("=", 1)
+        if old.strip() and new.strip():
+            out[old.strip()] = new.strip()
+    return out
+
+
+def main() -> None:
+    """Run the shim. Configured entirely by environment variables."""
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+    upstream = (
+        os.environ.get(_UPSTREAM_ENV) or os.environ.get("OLLAMA_BASE_URL") or _DEFAULT_UPSTREAM
+    )
+    host = os.environ.get("MEDMCP_SHIM_HOST", "127.0.0.1")
+    port = int(os.environ.get("MEDMCP_SHIM_PORT", "11435"))
+    attempts = int(os.environ.get("MEDMCP_SHIM_ATTEMPTS", str(DEFAULT_ATTEMPTS)))
+    renames = _renames_from_env()
+    log.info(
+        "medmcp-llm-shim -> %s (renames=%s, attempts=%d)", upstream, renames or "none", attempts
+    )
+    uvicorn.run(
+        create_app(upstream, renames=renames, attempts=attempts),
+        host=host,
+        port=port,
+        log_level="warning",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_llmshim.py
+++ b/tests/test_llmshim.py
@@ -1,0 +1,189 @@
+"""Tests for the Ollama Glimmer tool-call shim (``medmcp.llmshim``).
+
+The shapes exercised here are the ones measured against the live model: Ollama
+rejects any ``arguments`` that is not a JSON-object string, and a silently
+truncated stream is identifiable by its missing ``finish_reason``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from medmcp.llmshim import (
+    DEFAULT_RENAMES,
+    StreamOutcome,
+    failure_event,
+    parse_sse_line,
+    repair_request,
+    restore_response,
+    sanitize_arguments,
+)
+
+JsonDict = dict[str, Any]
+
+
+# ── sanitize_arguments ─────────────────────────────────────
+
+
+def test_sanitize_arguments_passes_valid_object_strings_through() -> None:
+    """A well-formed object string is the one shape Ollama accepts; leave it alone."""
+    raw = '{"path": "/data/a.nii.gz"}'
+    assert sanitize_arguments(raw) == raw
+
+
+def test_sanitize_arguments_rejects_every_shape_ollama_400s_on() -> None:
+    """Each of these produced ``400 invalid tool call arguments`` against the model."""
+    for bad in (None, "", "   ", '{"path": "/a', "[]", "null", 42, ["a"]):
+        assert sanitize_arguments(bad) == "{}", f"not neutralised: {bad!r}"
+
+
+def test_sanitize_arguments_reserialises_a_dict_rather_than_dropping_it() -> None:
+    """A dict is still meaningful, so re-serialise instead of discarding its content."""
+    out = sanitize_arguments({"path": "/a"})
+    assert json.loads(out) == {"path": "/a"}
+
+
+# ── repair_request ─────────────────────────────────────────
+
+
+def _payload_with_skill() -> JsonDict:
+    """Build a request carrying the colliding tool name in all three places."""
+    return {
+        "model": "muse-medmcp",
+        "tools": [
+            {"type": "function", "function": {"name": "skill", "parameters": {}}},
+            {"type": "function", "function": {"name": "bash", "parameters": {}}},
+        ],
+        "messages": [
+            {"role": "user", "content": "go"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "c1",
+                        "type": "function",
+                        "function": {"name": "skill", "arguments": ""},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "c1", "name": "skill", "content": "ok"},
+        ],
+    }
+
+
+def test_repair_request_renames_the_colliding_tool_everywhere() -> None:
+    """The rename must reach tools, prior tool calls, and tool results alike."""
+    out = repair_request(_payload_with_skill(), DEFAULT_RENAMES)
+
+    assert [t["function"]["name"] for t in out["tools"]] == ["load_skill", "bash"]
+    assert out["messages"][1]["tool_calls"][0]["function"]["name"] == "load_skill"
+    assert out["messages"][2]["name"] == "load_skill"
+
+
+def test_repair_request_sanitises_arguments_in_history() -> None:
+    """One malformed historical call is enough to 400 every later request."""
+    out = repair_request(_payload_with_skill(), DEFAULT_RENAMES)
+    assert out["messages"][1]["tool_calls"][0]["function"]["arguments"] == "{}"
+
+
+def test_repair_request_does_not_mutate_the_caller_payload() -> None:
+    """Retries re-send the original payload, so repair must not edit it in place."""
+    payload = _payload_with_skill()
+    repair_request(payload, DEFAULT_RENAMES)
+    assert payload["tools"][0]["function"]["name"] == "skill"
+
+
+def test_repair_request_leaves_unmapped_tools_alone() -> None:
+    """An empty rename map disables renaming without disabling sanitising."""
+    out = repair_request(_payload_with_skill(), {})
+    assert [t["function"]["name"] for t in out["tools"]] == ["skill", "bash"]
+
+
+# ── restore_response ───────────────────────────────────────
+
+
+def test_restore_response_renames_back_in_a_non_streaming_message() -> None:
+    """Vibe executes its own builtin, so it must see the original name."""
+    body: JsonDict = {
+        "choices": [{"message": {"tool_calls": [{"function": {"name": "load_skill"}}]}}]
+    }
+    out = restore_response(body, {"load_skill": "skill"})
+    assert out["choices"][0]["message"]["tool_calls"][0]["function"]["name"] == "skill"
+
+
+def test_restore_response_renames_back_in_a_streaming_delta() -> None:
+    """Streaming carries tool calls in ``delta`` rather than ``message``."""
+    event: JsonDict = {
+        "choices": [{"delta": {"tool_calls": [{"function": {"name": "load_skill"}}]}}]
+    }
+    out = restore_response(event, {"load_skill": "skill"})
+    assert out["choices"][0]["delta"]["tool_calls"][0]["function"]["name"] == "skill"
+
+
+# ── parse_sse_line ─────────────────────────────────────────
+
+
+def test_parse_sse_line_decodes_events_and_ignores_framing() -> None:
+    """Only ``data:`` payloads are events; framing and junk decode to nothing."""
+    assert parse_sse_line('data: {"a": 1}') == {"a": 1}
+    assert parse_sse_line("data: [DONE]") is None
+    assert parse_sse_line("") is None
+    assert parse_sse_line(": keepalive") is None
+    assert parse_sse_line("data: not json") is None
+
+
+# ── StreamOutcome ──────────────────────────────────────────
+
+
+def _delta(**kw: object) -> JsonDict:
+    """Build a one-choice streaming chunk carrying the given delta fields."""
+    return {"choices": [{"index": 0, "delta": dict(kw), "finish_reason": None}]}
+
+
+def test_stream_outcome_flags_a_truncated_stream_as_unhealthy() -> None:
+    """The real silent failure: reasoning only, no finish_reason, no usage."""
+    outcome = StreamOutcome()
+    for _ in range(3):
+        outcome.feed(_delta(content="", reasoning="thinking"))
+    assert not outcome.healthy
+
+
+def test_stream_outcome_accepts_a_stream_that_finished() -> None:
+    """A healthy turn always carries a finish_reason; that is the whole signal."""
+    outcome = StreamOutcome()
+    outcome.feed(_delta(content="", reasoning="thinking"))
+    outcome.feed(_delta(tool_calls=[{"function": {"name": "bash"}}]))
+    outcome.feed({"choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}]})
+    assert outcome.healthy
+
+
+def test_stream_outcome_streams_reasoning_but_withholds_the_answer() -> None:
+    """Reasoning is display-only so it flows live; the answer waits until trusted."""
+    outcome = StreamOutcome()
+    assert outcome.feed(_delta(content="", reasoning="thinking")) is not None
+    assert outcome.feed(_delta(content="hello")) is None
+    assert outcome.feed(_delta(tool_calls=[{"function": {"name": "bash"}}])) is None
+
+    assert len(outcome.release()) == 2
+
+
+def test_stream_outcome_orders_usage_frames_after_the_answer() -> None:
+    """Usage arrives on a choice-less frame and must not jump ahead of content."""
+    outcome = StreamOutcome()
+    outcome.feed(_delta(content="hello"))
+    outcome.feed({"usage": {"prompt_tokens": 1}, "choices": []})
+    assert outcome.release()[-1].get("usage") == {"prompt_tokens": 1}
+
+
+# ── failure_event ──────────────────────────────────────────
+
+
+def test_failure_event_is_terminal_and_attributed_to_the_shim() -> None:
+    """A visible error beats the silent empty turn it replaces."""
+    event = failure_event("muse-medmcp", "stream truncated")
+    choice = event["choices"][0]
+    assert choice["finish_reason"] == "stop"
+    assert "medmcp" in choice["delta"]["content"]
+    assert "stream truncated" in choice["delta"]["content"]


### PR DESCRIPTION
## Summary

Multi-step requests frequently ended with no reply at all — no text, no tool call, no error, nothing to retry. Two independent faults stacked up: Ollama's Muse Glimmer parser silently drops tool calls and truncates the stream, and the provider was reading the model's reasoning from a field Ollama only uses when non-streaming. This fixes the second outright and adds an opt-in local proxy that repairs the first.

## Related issue

N/A

## Test plan

- [x] `just check` — 422 passed, 2 skipped; ruff + pyright clean
- [x] 15 new unit tests over the shim's pure logic, covering every `arguments` shape measured to be rejected by Ollama (absent, `""`, whitespace, truncated JSON, `[]`) and the truncated-stream signature
- [x] Raw HTTP against the live model, replaying the real recorded system prompt and tool list: **direct 5/10 → through the shim 10/10**
- [x] Live UI over `/ws/chat` with a real multi-step imaging prompt: 3/4 then 6/6 (**9/10**), with `skill` tool calls succeeding where they previously killed the turn
- [x] Retry path observed firing and recovering in the shim log (`silent truncation on attempt 2/3 — retrying`)
- [x] Failure path forced against a dead upstream: emits the labelled `[medmcp: …]` chunk, and vibe's `OpenAIAdapter.parse_response` parses it back into assistant content
- [x] Entrypoint falls back to the direct Ollama URL when the shim does not come up
- [x] Verified inert with `MEDMCP_LLM_SHIM` unset (`api_base` untouched, no extra process)

## Screenshots

N/A

## Security & data handling

- The shim binds **127.0.0.1** inside the core container only, and is never published. It adds no new external network calls: it forwards to the same `OLLAMA_BASE_URL` the agent already used, and unknown routes pass straight through.
- No new tool surface and no change to the permission flow. Tool **names** are rewritten on the wire and restored before vibe sees them, so approval prompts, provenance, and audit records are unchanged.
- Prompts and tool arguments transit the shim in memory only — nothing is logged. Retry warnings record attempt counts, never payloads.
- No change to what the agent can do without approval.

## Notes

- Root cause is upstream, not ours. Ollama's own v0.32.9 notes say "Handle boundary condition in Muse Glimmer function calling parser" — that patch is already installed here and the bug persists. v0.32.3 fixed the same class of failure for GLM ("tool calls being silently dropped at the end of generation"). Upgrading to 0.32.10 does **not** help; its only change is unrelated. Confirmed by others in ollama/ollama#12557 and worked around the same way (`stream: false`) in openclaw/openclaw#5769 and anomalyco/opencode#20995.
- The argument-sanitising repair fixes a **separate** bug: Ollama 400s on any `tool_calls[].function.arguments` that is not a JSON-object string, and vibe replays the model's value verbatim (`format.py:81`, no `json.dumps`) while reading it leniently. One malformed call therefore poisons the history and every later request 400s — a permanently dead chat. Present in vibe 2.23.3 and 2.24.1 alike.
- Off by default. `MEDMCP_LLM_SHIM=1` enables it; the shim is a no-op for any provider whose tool calls parse correctly, so it can be dropped once upstream fixes the parser.
- A residual ~10% failure rate remains even with the rename (the parser occasionally fails on other tools); the retry covers it. Longer term, moving to the llama.cpp runtime would sidestep the parser entirely.
- `.vibe/config.toml` is skip-worktree; this commit intentionally updates it, so run `just pull-config` after merging.

