### PR TITLE
fix: give stacks a startup budget a cold start fits into

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Notable, user-visible changes to MedMCP. Format follows
 
 ### Fixed
 
+- **Tool stacks no longer go missing on the first run after installing them.**
+  A stack that takes a moment to start the first time — the usual case, since its
+  image has just been pulled and nothing is cached yet — could be given up on
+  before it answered, leaving that chat with none of its tools. Stacks are now
+  given a startup budget a cold start fits into, and existing installations are
+  repaired automatically — no reinstall needed. Starting a new chat also retries,
+  so a stack that was only slow comes back on its own.
 - **The agent no longer goes silent on multi-step requests.** Asking for a
   multi-step imaging workflow could leave the chat with no reply at all — no text,
   no error, nothing to retry. The local model server was failing to read the

--- a/src/medmcp/settings.py
+++ b/src/medmcp/settings.py
@@ -145,6 +145,16 @@ PROXY_COMMAND: str = "medmcp-mcp-proxy"
 DEFAULT_IDLE_TTL_SEC: float = 120.0
 DEFAULT_STARTUP_TIMEOUT_SEC: float = 60.0
 DEFAULT_TOOL_TIMEOUT_SEC: float = 900.0
+# Startup budget for a stack launched as a container. vibe's own default is 10s,
+# which a stack image cold-starts past on the first run after a pull: the launch
+# has to read the image's Python env off disk before the server answers, and that
+# competes with whatever else is warming at the time (the model being loaded into
+# VRAM, most of all). Warm, these servers answer in under two seconds; the only
+# thing a generous budget costs is how long a genuinely hung server delays
+# warm-up, and an image that is missing or unrunnable still fails immediately
+# rather than waiting this out. Discovery runs once per agent start and a miss
+# silently drops the whole stack, so buy the headroom.
+DEFAULT_STACK_STARTUP_TIMEOUT_SEC: float = 120.0
 # Env keys the proxy layer injects into a stack's [[mcp_servers]] entry — stripped
 # again when the pool is disabled so toggling off leaves no stale routing.
 _POOL_ENV_KEYS: tuple[str, ...] = ("MEDMCP_BROKER_SOCK", "MEDMCP_WORKSPACE")
@@ -389,6 +399,8 @@ def _load_stack_manifests() -> list[JsonDict]:
             entry["skills_path"] = os.path.expandvars(str(raw["skills_path"]))
         if raw.get("tool_timeout_sec") is not None:
             entry["tool_timeout_sec"] = raw["tool_timeout_sec"]
+        if raw.get("startup_timeout_sec") is not None:
+            entry["startup_timeout_sec"] = raw["startup_timeout_sec"]
         if raw.get("idle_ttl_sec") is not None:
             entry["idle_ttl_sec"] = raw["idle_ttl_sec"]
         manifests.append(entry)
@@ -854,6 +866,13 @@ def install_stack_image(image: str, on_progress: ProgressFn | None = None) -> st
     if isinstance(timeout, (int, float)) and not isinstance(timeout, bool):
         entry["tool_timeout_sec"] = float(timeout)
 
+    startup = meta.get("startup_timeout_sec")
+    entry["startup_timeout_sec"] = (
+        float(startup)
+        if isinstance(startup, (int, float)) and not isinstance(startup, bool)
+        else DEFAULT_STACK_STARTUP_TIMEOUT_SEC
+    )
+
     # Skills live inside the image but the agent loads them from the core fs, so
     # extract them next to the manifest and point skills_path there.
     in_image_skills = meta.get("skills_path")
@@ -1193,7 +1212,8 @@ def sync_servers_to_vibe_config(servers: list[JsonDict]) -> None:
     tool permissions, etc.) are left untouched.  For servers already present in
     the file, vibe-acp-specific fields such as ``startup_timeout_sec`` are
     preserved; only ``command`` and ``args`` are updated from the discovery
-    result.
+    result. An entry carrying no ``startup_timeout_sec`` at all is given one —
+    vibe's own 10s default is too tight for a stack that cold-starts a container.
     """
     with _config_write_lock:
         _sync_servers_to_vibe_config_locked(servers)
@@ -1252,6 +1272,21 @@ def _sync_servers_to_vibe_config_locked(servers: list[JsonDict]) -> None:
             else:
                 entry.pop("args", None)
             new_entries.append(entry)
+
+    # vibe defaults startup_timeout_sec to 10s, and a discovery miss drops the whole
+    # stack for the session with nothing but a log line, so give every entry that
+    # does not carry one an explicit floor (see DEFAULT_STACK_STARTUP_TIMEOUT_SEC).
+    # This runs over entries preserved from config.toml too: the preserve-branch
+    # above keeps vibe-owned fields as they are, which would otherwise pin an
+    # already-installed stack to the 10s default forever. A value that is actually
+    # set — by a manifest, a package, or by hand here — is left alone.
+    for entry in new_entries:
+        if entry.get("startup_timeout_sec") is not None:
+            continue
+        is_container = Path(str(entry.get("command", ""))).name == "docker"
+        entry["startup_timeout_sec"] = (
+            DEFAULT_STACK_STARTUP_TIMEOUT_SEC if is_container else DEFAULT_STARTUP_TIMEOUT_SEC
+        )
 
     # Route every stack through the pre-warm proxy when the pool is enabled. vibe
     # then spawns the cheap `medmcp-mcp-proxy <stack>` shim, which forwards to the

--- a/tests/test_load_mcp_servers.py
+++ b/tests/test_load_mcp_servers.py
@@ -347,6 +347,28 @@ class TestStacksDDiscovery:
         assert servers[0]["skills_path"] == "/srv/data/skills"
         assert servers[0]["tool_timeout_sec"] == 7200.0
 
+    def test_startup_timeout_passthrough(self, tmp_path: Path) -> None:
+        """A manifest's startup_timeout_sec reaches the server config.
+
+        Without it the entry falls back to vibe's 10s default, which a container
+        stack cold-starts past — dropping the whole stack for the session.
+        """
+        stacks = tmp_path / "stacks.d"
+        _make_manifest(
+            stacks,
+            "medmcp-neuro",
+            'name = "medmcp-neuro"\ncommand = "docker"\nargs = ["run", "img"]\n'
+            "startup_timeout_sec = 180.0\n",
+        )
+        with (
+            patch("medmcp.settings.get_uv_tool_dir", return_value=None),
+            patch("medmcp.settings.VIBE_HOME", tmp_path),
+            patch("medmcp.settings.STACKS_D_PATH", stacks),
+        ):
+            servers = load_mcp_servers()
+
+        assert servers[0]["startup_timeout_sec"] == 180.0
+
     def test_uv_tool_wins_over_manifest(self, tmp_path: Path) -> None:
         """A uv-tool install overrides a manifest of the same name (local dev)."""
         _make_tool_env(tmp_path, "medmcp-neuro")

--- a/tests/test_stack_pool_sync.py
+++ b/tests/test_stack_pool_sync.py
@@ -138,3 +138,55 @@ def test_toggle_off_restores_real_command_and_strips_env(
     assert neuro["command"] == "docker"  # real command restored
     assert neuro["args"][0] == "run"
     assert "MEDMCP_BROKER_SOCK" not in cast("JsonDict", neuro.get("env", {}))
+
+
+# ── startup timeout floor ────────────────────────────────────────────────────
+
+
+def test_sync_writes_startup_timeout_floor(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Every entry gets a startup_timeout_sec; containers get the larger budget.
+
+    vibe's own default is 10s, which a container stack cold-starts past — and a
+    discovery miss drops the whole stack for the session.
+    """
+    _isolate(monkeypatch, tmp_path, pool=False)
+    sync_servers_to_vibe_config([_NEURO, _DICOM])
+    by = _entries_by_name(tmp_path)
+    assert by["medmcp-neuro"]["startup_timeout_sec"] == settings.DEFAULT_STACK_STARTUP_TIMEOUT_SEC
+    assert by["medmcp-dicom"]["startup_timeout_sec"] == settings.DEFAULT_STARTUP_TIMEOUT_SEC
+
+
+def test_sync_preserves_explicit_startup_timeout(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A value supplied by the manifest/package is never overwritten by the floor."""
+    _isolate(monkeypatch, tmp_path, pool=False)
+    sync_servers_to_vibe_config([{**_NEURO, "startup_timeout_sec": 15.0}])
+    assert _entries_by_name(tmp_path)["medmcp-neuro"]["startup_timeout_sec"] == 15.0
+
+
+def test_sync_repairs_existing_entry_without_startup_timeout(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A stack already in config.toml with no startup_timeout_sec is given one.
+
+    The preserve-branch keeps vibe-owned fields as they are, so without the floor
+    an already-installed stack would stay pinned to vibe's 10s default forever —
+    no reinstall would fix it. This is the regression that silently dropped a
+    container stack on first run.
+    """
+    _isolate(monkeypatch, tmp_path, pool=False)
+    # Simulate a config written before the floor existed.
+    sync_servers_to_vibe_config([_NEURO])
+    config = tmp_path / "config.toml"
+    config.write_text(
+        config.read_text().replace(
+            f"startup_timeout_sec = {settings.DEFAULT_STACK_STARTUP_TIMEOUT_SEC}\n", ""
+        )
+    )
+    assert "startup_timeout_sec" not in config.read_text()
+
+    sync_servers_to_vibe_config([_NEURO])
+    neuro = _entries_by_name(tmp_path)["medmcp-neuro"]
+    assert neuro["startup_timeout_sec"] == settings.DEFAULT_STACK_STARTUP_TIMEOUT_SEC
+    assert neuro["tool_timeout_sec"] == 7200.0  # other preserved fields survive


### PR DESCRIPTION
## Summary

Stacks were running on vibe's default 10s startup budget, because nothing on the
vibe path ever wrote `startup_timeout_sec`. A stack whose first launch after an
image pull takes longer than that is given up on during MCP discovery and loads
with none of its tools for that session. Container stacks now get 120s, others
60s, and the floor is applied at config-sync time so stacks already installed are
repaired without a reinstall.

## Related issue

N/A — found while diagnosing a live install whose `neuro-core` stack dropped out
at agent warm-up (`MCP stdio discovery failed for [... ghcr.io/medmcp/neuro-core:main]`).

## Test plan

- [x] `just check` — 426 passed, 2 skipped
- [x] New: container stacks get `DEFAULT_STACK_STARTUP_TIMEOUT_SEC`, others `DEFAULT_STARTUP_TIMEOUT_SEC`
- [x] New: an explicit value (manifest / package / hand edit) is never overwritten
- [x] New: an entry already in `config.toml` with no `startup_timeout_sec` is repaired — the case a reinstall could not fix
- [x] New: a manifest's `startup_timeout_sec` reaches the server config
- [x] Measured on a live install: warm start of a 12 GB stack is ~1.7s, so 120s is headroom, not latency
- [x] Verified a missing/unrunnable image still fails in ~0.6s rather than waiting out the timeout
- [x] Reproduced the no-tools state end to end (manifest pointed at a missing image) and confirmed recovery after restoring it

## Security & data handling

N/A — no new tool surface, network calls, or file-write paths. Only a timeout
value in the generated vibe config.

## Notes

Scope is deliberately narrow. This was found while chasing a chat that answered
"I am a general-purpose assistant"; that symptom is **not** fixed here and is not
claimed in the changelog. Reproducing it showed identity survives an empty tool
list — the agent still answers "I am MedMCP" with no stacks loaded — so that reply
remains unexplained and is likely unrelated.

Two things worth knowing, both verified while testing and neither addressed here:

- vibe **does** surface discovery failures in chat ("The following MCP servers
  failed to connect: …"), and discovery re-runs per session — so a stack that was
  merely slow recovers on the next chat. That bounds the severity of this bug.
- In a container, `.vibe/config.toml` and `.vibe/prompts` are image-baked rather
  than volumes, so runtime edits to either are lost on `compose up`. `stacks.d`,
  workflows, provenance and logs are volumes and persist.
