### PR TITLE
fix(workflows): derive an output directory that repeats an input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,17 @@ Notable, user-visible changes to MedMCP. Format follows
 
 ### Fixed
 
-- **Workflows stop asking you to retype a folder you have already given them.**
-  A workflow distilled from a session asked for the scan *and* for the directory
-  that scan sits in — so a two-decision pipeline arrived with several boxes to
-  fill. That directory is still part of the workflow, because the session had it
-  and you may want the results somewhere else, but where it was simply the input
-  file's own folder it now fills itself in: leave it blank and the outputs land
-  beside the file you are replaying on, rather than back in the folder the
-  workflow was recorded from. Type a path in and that wins, as before. Where the
-  folder can't be worked out unambiguously — two inputs sitting in the same
-  directory, say — nothing is guessed and it is asked for as usual.
+- **Workflow runs only ask for the inputs you actually have to provide.**
+  A workflow distilled from a session used to ask for the scan *and* for the
+  directory that scan sits in — so a two-decision pipeline arrived with several
+  boxes to fill, and the folder was frozen to wherever the workflow happened to
+  be recorded. Where a step simply wrote next to its input, that folder is now
+  worked out from the file you give it and no longer appears in the form, so the
+  results land beside the file you are replaying on. It remains part of the
+  workflow, and *Change where results are written* opens it if you want the
+  output somewhere else. Where the folder can't be worked out unambiguously —
+  two inputs sitting in the same directory, say — nothing is guessed and it is
+  asked for as before.
 - **Tool stacks no longer go missing on the first run after installing them.**
   A stack that takes a moment to start the first time — the usual case, since its
   image has just been pulled and nothing is cached yet — could be given up on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Notable, user-visible changes to MedMCP. Format follows
 
 ### Fixed
 
+- **Workflows stop asking you to retype a folder you have already given them.**
+  A workflow distilled from a session asked for the scan *and* for the directory
+  that scan sits in — so a two-decision pipeline arrived with several boxes to
+  fill. That directory is still part of the workflow, because the session had it
+  and you may want the results somewhere else, but where it was simply the input
+  file's own folder it now fills itself in: leave it blank and the outputs land
+  beside the file you are replaying on, rather than back in the folder the
+  workflow was recorded from. Type a path in and that wins, as before. Where the
+  folder can't be worked out unambiguously — two inputs sitting in the same
+  directory, say — nothing is guessed and it is asked for as usual.
 - **Tool stacks no longer go missing on the first run after installing them.**
   A stack that takes a moment to start the first time — the usual case, since its
   image has just been pulled and nothing is cached yet — could be given up on

--- a/frontend/src/components/WorkflowPanel.tsx
+++ b/frontend/src/components/WorkflowPanel.tsx
@@ -194,12 +194,15 @@ function InputField({
   description,
   value,
   onChange,
+  defaultHint = '',
 }: {
   name: string
   example: string
   description: string
   value: string
   onChange: (v: string) => void
+  /** Set when the input fills itself if left blank; shown instead of an example. */
+  defaultHint?: string
 }) {
   const [dropReady, setDropReady] = useState(false)
   return (
@@ -207,11 +210,12 @@ function InputField({
       <span className="wf-input-label">
         <code>{name}</code>
         {description && <span className="wf-input-desc">{description}</span>}
+        {defaultHint && <span className="wf-input-desc">{defaultHint}</span>}
       </span>
       <input
         className={dropReady ? 'wf-input drop-ready' : 'wf-input'}
         value={value}
-        placeholder={example ? `e.g. ${example}` : 'value'}
+        placeholder={defaultHint ? 'leave blank to derive it' : example ? `e.g. ${example}` : 'value'}
         onChange={(e) => onChange(e.target.value)}
         onDragOver={(e) => {
           if (e.dataTransfer.types.includes(DRAG_PATH_MIME) || getDraggedFilePath() !== null) {
@@ -988,6 +992,9 @@ export const WorkflowPanel = memo(function WorkflowPanel({
       {mode.kind === 'inputs' &&
         ((m: Extract<Mode, { kind: 'inputs' }>) => {
           const inputNames = d.inputs.map((i) => i.name)
+          // An input carrying a default fills itself server-side when left
+          // blank, so requiring it here would put the typing straight back.
+          const requiredNames = d.inputs.filter((i) => !i.default).map((i) => i.name)
           const emptyRow = (): Record<string, string> =>
             Object.fromEntries(inputNames.map((n) => [n, '']))
           // Distribute the selected files across rows: every N files (N = number
@@ -1009,15 +1016,17 @@ export const WorkflowPanel = memo(function WorkflowPanel({
             const filled = m.rows.filter((r) => Object.values(r).some((v) => v.trim()))
             setMode({ ...m, rows: [...filled, ...added] })
           }
-          const singleIncomplete = inputNames.some((n) => !(m.values[n] ?? '').trim())
-          const completeRows = m.rows.filter((r) => inputNames.every((n) => (r[n] ?? '').trim()))
+          const singleIncomplete = requiredNames.some((n) => !(m.values[n] ?? '').trim())
+          const completeRows = m.rows.filter((r) =>
+            requiredNames.every((n) => (r[n] ?? '').trim()),
+          )
           const previewDisabled = m.batch ? completeRows.length === 0 : singleIncomplete
           return (
             <form
               className="wf-form"
               onSubmit={(e) => {
                 e.preventDefault()
-                void toPreview(d.name, { batch: m.batch, values: m.values, rows: m.rows }, inputNames)
+                void toPreview(d.name, { batch: m.batch, values: m.values, rows: m.rows }, requiredNames)
               }}
             >
               <div className="wf-mode-toggle">
@@ -1049,7 +1058,7 @@ export const WorkflowPanel = memo(function WorkflowPanel({
                 <>
                   <div className="wf-hint">
                     Provide a value for each input — select a file in the explorer to fill it, or
-                    type / drag a path.
+                    type / drag a path. Inputs marked optional fill themselves in.
                   </div>
                   {d.inputs.map((i) => (
                     <InputField
@@ -1057,6 +1066,7 @@ export const WorkflowPanel = memo(function WorkflowPanel({
                       name={i.name}
                       example={i.example}
                       description={i.description}
+                      defaultHint={i.default ? 'optional — defaults to the input file’s folder' : ''}
                       value={m.values[i.name] ?? ''}
                       onChange={(v) => setMode({ ...m, values: { ...m.values, [i.name]: v } })}
                     />

--- a/frontend/src/components/WorkflowPanel.tsx
+++ b/frontend/src/components/WorkflowPanel.tsx
@@ -422,6 +422,8 @@ export const WorkflowPanel = memo(function WorkflowPanel({
   const [now, setNow] = useState(0)
   const [planCsv, setPlanCsv] = useState('')
   const [planSkipped, setPlanSkipped] = useState<BatchPlanSkip[] | null>(null)
+  // Derived inputs stay collapsed until the user wants to redirect the output.
+  const [showDerived, setShowDerived] = useState(false)
   const runWs = useRef<WebSocket | null>(null)
   const fileInputRef = useRef<HTMLInputElement | null>(null)
 
@@ -994,20 +996,25 @@ export const WorkflowPanel = memo(function WorkflowPanel({
           const inputNames = d.inputs.map((i) => i.name)
           // An input carrying a default fills itself server-side when left
           // blank, so requiring it here would put the typing straight back.
-          const requiredNames = d.inputs.filter((i) => !i.default).map((i) => i.name)
+          const requiredInputs = d.inputs.filter((i) => !i.default)
+          const derivedInputs = d.inputs.filter((i) => i.default)
+          const requiredNames = requiredInputs.map((i) => i.name)
           const emptyRow = (): Record<string, string> =>
             Object.fromEntries(inputNames.map((n) => [n, '']))
           // Distribute the selected files across rows: every N files (N = number
-          // of inputs) fill one row's inputs in order. So a 2-input workflow turns
-          // 2 selected files into one run (in_1, in_2), 4 files into two runs, etc.
-          // A single-input workflow gets one row per file. Drops blank rows.
+          // of inputs the user fills) fill one row's inputs in order. So a 2-input
+          // workflow turns 2 selected files into one run (in_1, in_2), 4 files into
+          // two runs, etc. A single-input workflow gets one row per file. Derived
+          // inputs are excluded: they resolve per row from the files chosen here,
+          // and counting them would consume a selected file per row for a value
+          // nobody picked. Drops blank rows.
           const addFromSelection = () => {
-            const k = inputNames.length
+            const k = requiredNames.length
             if (k === 0 || selectedPaths.length === 0) return
             const added: Record<string, string>[] = []
             for (let i = 0; i < selectedPaths.length; i += k) {
               const row = emptyRow()
-              inputNames.forEach((n, j) => {
+              requiredNames.forEach((n, j) => {
                 const file = selectedPaths[i + j]
                 if (file) row[n] = file
               })
@@ -1058,31 +1065,61 @@ export const WorkflowPanel = memo(function WorkflowPanel({
                 <>
                   <div className="wf-hint">
                     Provide a value for each input — select a file in the explorer to fill it, or
-                    type / drag a path. Inputs marked optional fill themselves in.
+                    type / drag a path.
                   </div>
-                  {d.inputs.map((i) => (
+                  {requiredInputs.map((i) => (
                     <InputField
                       key={i.name}
                       name={i.name}
                       example={i.example}
                       description={i.description}
-                      defaultHint={i.default ? 'optional — defaults to the input file’s folder' : ''}
                       value={m.values[i.name] ?? ''}
                       onChange={(v) => setMode({ ...m, values: { ...m.values, [i.name]: v } })}
                     />
                   ))}
+                  {/* Derived inputs are worked out from the ones above, so they are
+                      not questions to put to the user. They stay reachable — the
+                      recipe still declares them and a caller may want the results
+                      somewhere else — but behind a disclosure rather than as empty
+                      boxes that look like something is missing. */}
+                  {derivedInputs.length > 0 && (
+                    <>
+                      <button
+                        type="button"
+                        className="btn-text wf-derived-toggle"
+                        onClick={() => setShowDerived((v) => !v)}
+                      >
+                        {showDerived ? 'Hide' : 'Change'} where results are written
+                      </button>
+                      {showDerived &&
+                        derivedInputs.map((i) => (
+                          <InputField
+                            key={i.name}
+                            name={i.name}
+                            example={i.example}
+                            description={i.description}
+                            defaultHint="leave blank to write beside the input file"
+                            value={m.values[i.name] ?? ''}
+                            onChange={(v) =>
+                              setMode({ ...m, values: { ...m.values, [i.name]: v } })
+                            }
+                          />
+                        ))}
+                    </>
+                  )}
                 </>
               ) : (
                 <>
                   <div className="wf-hint">
                     One row per run — each runs the whole workflow on its own inputs. Drag a file
                     into any cell, or select files in the explorer and “Add from selection” (every{' '}
-                    {d.inputs.length} selected file{d.inputs.length === 1 ? '' : 's'} fill one row).
+                    {requiredInputs.length} selected file{requiredInputs.length === 1 ? '' : 's'}{' '}
+                    fill one row).
                   </div>
                   <div className="wf-batch-table">
                     <div className="wf-batch-row wf-batch-head">
                       <span className="wf-batch-idx">#</span>
-                      {d.inputs.map((i) => (
+                      {requiredInputs.map((i) => (
                         <span key={i.name} className="wf-batch-col" title={inputOptionLabel(i)}>
                           {i.name}
                         </span>
@@ -1092,7 +1129,7 @@ export const WorkflowPanel = memo(function WorkflowPanel({
                     {m.rows.map((row, ri) => (
                       <div key={ri} className="wf-batch-row">
                         <span className="wf-batch-idx">{ri + 1}</span>
-                        {d.inputs.map((i) => (
+                        {requiredInputs.map((i) => (
                           <BatchCell
                             key={i.name}
                             value={row[i.name] ?? ''}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2732,3 +2732,20 @@ textarea.wf-input {
   opacity: 0.6;
   text-decoration: line-through;
 }
+
+/* A quiet disclosure, not an action: the derived inputs behind it are optional,
+   so it must not compete with Preview steps for attention. */
+.wf-derived-toggle {
+  align-self: flex-start;
+  border: none;
+  background: none;
+  padding: 2px 0;
+  font-weight: 500;
+  color: var(--muted);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.wf-derived-toggle:hover {
+  color: var(--text);
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -148,7 +148,7 @@ export interface WorkflowDetail {
   name: string
   kind: 'active' | 'draft'
   description: string
-  inputs: { name: string; example: string; description: string }[]
+  inputs: { name: string; example: string; description: string; default?: string }[]
   steps: { server: string; tool: string; arguments: Record<string, unknown> }[]
   requires: StackRequirement[]
   manual_steps: string[]

--- a/src/medmcp/distill.py
+++ b/src/medmcp/distill.py
@@ -29,7 +29,7 @@ import os
 import re
 import shutil
 from collections.abc import Collection
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, cast
 
 import httpx
@@ -250,6 +250,33 @@ def _manual_step_label(tool: str, arguments: JsonDict) -> str:
     return f"builtin:{tool}"
 
 
+_DIR_REF_RE = re.compile(r"dir\((.+)\)")
+
+
+def _derive_container_dir_defaults(inputs: dict[str, WorkflowInput]) -> None:
+    """Give an input that was another input's folder a derived default.
+
+    A tool's ``output_dir`` is usually the directory its input file already sits
+    in, so replay asks for the same thing twice. It stays a declared input —
+    the session had it, and a caller may legitimately want the results
+    somewhere else — but gains a default so it need not be retyped, and so the
+    outputs follow the file being replayed on rather than the folder the
+    workflow was recorded from.
+
+    Only an unambiguous parent-of relationship earns a default. With two inputs
+    in the same folder there is no principled anchor, and silently picking one
+    would make the destination follow whichever happened to be lifted first.
+    """
+    for path, inp in inputs.items():
+        anchors = [
+            other_inp.name
+            for other, other_inp in inputs.items()
+            if other != path and str(PurePosixPath(other).parent) == path.rstrip("/")
+        ]
+        if len(anchors) == 1:
+            inp.default = f"{{{{dir({anchors[0]})}}}}"
+
+
 def build_recipe(
     messages: list[JsonDict],
     *,
@@ -322,6 +349,7 @@ def build_recipe(
             RecipeStep(server=server, tool=tool, arguments=new_args, produces=produces)
         )
 
+    _derive_container_dir_defaults(inputs)
     recipe.inputs = list(inputs.values())
     recipe.manual_steps = manual_steps
     return recipe
@@ -623,6 +651,7 @@ def load_recipe(draft_dir: Path) -> Recipe:
             name=str(i.get("name", "")),
             example=str(i.get("example", "")),
             description=str(i.get("description", "")),
+            default=str(i.get("default", "")),
         )
         for i in cast("list[JsonDict]", data.get("inputs", []))
     ]

--- a/src/medmcp/replay.py
+++ b/src/medmcp/replay.py
@@ -313,6 +313,11 @@ async def mcp_caller(
 # ── Validation & execution ────────────────────────────────────────────────────
 
 
+def _is_unset(value: object) -> bool:
+    """Whether *value* counts as not supplied: absent, or whitespace-only text."""
+    return value is None or (isinstance(value, str) and not value.strip())
+
+
 def apply_input_defaults(recipe: Recipe, inputs: dict[str, Any]) -> dict[str, Any]:
     """Return *inputs* with any unbound input filled in from its declared default.
 
@@ -325,7 +330,14 @@ def apply_input_defaults(recipe: Recipe, inputs: dict[str, Any]) -> dict[str, An
     An explicitly supplied value always wins: the default exists to save typing,
     not to override a caller who pointed the workflow somewhere else.
     """
-    bound: dict[str, Any] = dict(inputs)
+    # A blank is not a value. The run form posts every field it rendered, so an
+    # input the caller deliberately left empty arrives as "" — and treating that
+    # as bound skipped the default and sent an empty output_dir to the tool,
+    # which then wrote relative to its own working directory, outside the
+    # workspace: the run reported success and no files appeared. Dropping blanks
+    # here also means a blank *required* input reaches validate() as missing,
+    # failing loudly rather than writing somewhere nobody will look.
+    bound: dict[str, Any] = {k: v for k, v in inputs.items() if not _is_unset(v)}
     for inp in recipe.inputs:
         if inp.name in bound or not inp.default:
             continue

--- a/src/medmcp/replay.py
+++ b/src/medmcp/replay.py
@@ -29,6 +29,7 @@ from collections.abc import AsyncGenerator, Awaitable, Callable
 from contextlib import AsyncExitStack, asynccontextmanager, suppress
 from dataclasses import dataclass, field
 from datetime import timedelta
+from pathlib import PurePosixPath
 from typing import Any, cast
 
 import mcp.types as mcp_types
@@ -43,6 +44,27 @@ JsonDict = dict[str, Any]
 ToolCaller = Callable[[str, str, JsonDict], Awaitable[tuple[bool, JsonDict, "str | None"]]]
 
 _PLACEHOLDER_RE = re.compile(r"\{\{([^{}]+)\}\}")
+# A derived reference: ``{{dir(<ref>)}}`` is the directory holding whatever
+# ``<ref>`` resolves to. Distillation emits these instead of declaring a second
+# input for a folder the caller has already implied — asking for a file and then
+# for the directory that file sits in is one piece of information, not two, and
+# on replay the outputs should follow the new file rather than the old folder.
+_DERIVED_DIR_RE = re.compile(r"dir\((.+)\)")
+
+
+def _resolve_ref(ref: str, bindings: dict[str, Any]) -> object | None:
+    """Resolve one placeholder ref; ``None`` when it cannot be resolved.
+
+    ``None`` rather than a sentinel string so an unresolvable ref can be left
+    verbatim by the caller, which is how :func:`unresolved_refs` still sees it.
+    """
+    derived = _DERIVED_DIR_RE.fullmatch(ref)
+    if derived is not None:
+        inner = _resolve_ref(derived.group(1).strip(), bindings)
+        return None if inner is None else str(PurePosixPath(str(inner)).parent)
+    return bindings.get(ref)
+
+
 # Imaging tools (registration, segmentation) can run for minutes.
 DEFAULT_TOOL_TIMEOUT_SEC: float = 900.0
 
@@ -89,12 +111,12 @@ def resolve_value(value: object, bindings: dict[str, Any]) -> object:
     if isinstance(value, str):
         whole = _PLACEHOLDER_RE.fullmatch(value.strip())
         if whole is not None:
-            ref = whole.group(1).strip()
-            return bindings.get(ref, value)
+            resolved = _resolve_ref(whole.group(1).strip(), bindings)
+            return value if resolved is None else resolved
 
         def _sub(match: re.Match[str]) -> str:
-            ref = match.group(1).strip()
-            return str(bindings[ref]) if ref in bindings else match.group(0)
+            resolved = _resolve_ref(match.group(1).strip(), bindings)
+            return match.group(0) if resolved is None else str(resolved)
 
         return _PLACEHOLDER_RE.sub(_sub, value)
     if isinstance(value, dict):
@@ -291,13 +313,37 @@ async def mcp_caller(
 # ── Validation & execution ────────────────────────────────────────────────────
 
 
+def apply_input_defaults(recipe: Recipe, inputs: dict[str, Any]) -> dict[str, Any]:
+    """Return *inputs* with any unbound input filled in from its declared default.
+
+    A default is a placeholder expression that may reference other inputs (see
+    :class:`~medmcp.workflow.WorkflowInput`), so it is resolved against the
+    bindings accumulated so far, in declaration order. A default whose anchor is
+    itself unbound is skipped rather than substituted half-resolved, leaving the
+    input genuinely missing so :func:`validate` reports it.
+
+    An explicitly supplied value always wins: the default exists to save typing,
+    not to override a caller who pointed the workflow somewhere else.
+    """
+    bound: dict[str, Any] = dict(inputs)
+    for inp in recipe.inputs:
+        if inp.name in bound or not inp.default:
+            continue
+        resolved = resolve_value(inp.default, bound)
+        if unresolved_refs(resolved):
+            continue
+        bound[inp.name] = resolved
+    return bound
+
+
 def validate(recipe: Recipe, inputs: dict[str, Any], servers: list[JsonDict]) -> str | None:
     """Return a human-readable error if *recipe* can't be replayed, else ``None``.
 
     Checks that every declared input has a value, every referenced stack is
     installed, and that the recipe has no built-in (non-MCP) tool steps.
     """
-    missing_inputs = [i.name for i in recipe.inputs if i.name not in inputs]
+    bound = apply_input_defaults(recipe, inputs)
+    missing_inputs = [i.name for i in recipe.inputs if i.name not in bound]
     if missing_inputs:
         return f"missing values for inputs: {', '.join(missing_inputs)}"
 
@@ -337,7 +383,9 @@ async def replay_with_caller(
     *inputs* maps placeholder names (``in_1`` …) to concrete values. Outputs a
     step produces are captured and bound as ``{{stepM.<key>}}`` for later steps.
     """
-    bindings: dict[str, Any] = dict(inputs)
+    # Defaults are filled here, the one place every replay path funnels through
+    # (single run and each batch item alike), so no caller can forget them.
+    bindings: dict[str, Any] = apply_input_defaults(recipe, inputs)
     result = ReplayResult()
 
     for index, step in enumerate(recipe.steps, start=1):

--- a/src/medmcp/server.py
+++ b/src/medmcp/server.py
@@ -777,7 +777,9 @@ async def post_replay_preview(name: str, payload: ReplayPreviewPayload) -> JsonD
         error = replay.validate(recipe, inputs, settings.active_servers())
         if error is not None:
             return {"ok": False, "error": error, "steps": []}
-        bindings: dict[str, Any] = dict(inputs)
+        # Same defaults the run will use, so the preview shows what will actually
+        # be sent rather than an unresolved placeholder the user never filled in.
+        bindings: dict[str, Any] = replay.apply_input_defaults(recipe, inputs)
         steps = [
             {
                 "index": i,

--- a/src/medmcp/workflow.py
+++ b/src/medmcp/workflow.py
@@ -30,12 +30,24 @@ class WorkflowInput:
     """The concrete value seen in the originating session, kept as documentation."""
     description: str = ""
     """Optional human description of what this input is."""
+    default: str = ""
+    """Optional placeholder expression filling this input when left unbound.
+
+    Distillation sets this where the session's value was derivable from another
+    input — an ``output_dir`` that was simply the input file's folder, say. The
+    input stays declared, because the session genuinely had it and the caller may
+    want to point it elsewhere; the default only spares them retyping something
+    they have already said. Resolved by the replay engine, so it may reference
+    other inputs (e.g. ``{{dir(in_1)}}``).
+    """
 
     def to_dict(self) -> JsonDict:
         """Return a plain-dict form suitable for YAML/JSON serialization."""
         out: JsonDict = {"name": self.name, "example": self.example}
         if self.description:
             out["description"] = self.description
+        if self.default:
+            out["default"] = self.default
         return out
 
 

--- a/tests/test_distill.py
+++ b/tests/test_distill.py
@@ -638,3 +638,87 @@ def test_refine_draft_model_failure_raises(tmp_path: Path) -> None:
         except RuntimeError:
             return
     raise AssertionError("expected RuntimeError")
+
+
+# ── derived defaults for container directories ───────────────────────────────
+
+
+def _pipeline(output_dirs: list[str], second_input: str | None = None) -> list[JsonDict]:
+    """A skull-strip → register session whose steps write to *output_dirs*."""
+    d = "/data/subj_01"
+    strip_args: JsonDict = {"input_path": f"{d}/t1.nii.gz", "output_dir": output_dirs[0]}
+    if second_input is not None:
+        strip_args["mask_path"] = second_input
+    return [
+        {"role": "user", "content": "strip and register"},
+        _assistant_call("c1", "medmcp-neuro_skull_strip", strip_args),
+        _tool_result("c1", f"ok: True\nstructured: {{'brain_path': '{d}/t1_brain.nii.gz'}}"),
+        _assistant_call(
+            "c2",
+            "medmcp-neuro_register_to_template",
+            {"input_path": f"{d}/t1_brain.nii.gz", "output_dir": output_dirs[1]},
+        ),
+        _tool_result("c2", f"ok: True\nstructured: {{'registered_path': '{d}/t1_mni.nii.gz'}}"),
+    ]
+
+
+def _recipe_from(msgs: list[JsonDict]) -> Recipe:
+    return distill.build_recipe(msgs, server_names=["medmcp-neuro"], name="n", description="d")
+
+
+def _defaults(recipe: Recipe) -> dict[str, str]:
+    return {i.name: i.default for i in recipe.inputs}
+
+
+def test_output_dir_in_the_inputs_folder_gets_a_derived_default() -> None:
+    """The folder an input already sits in should not have to be retyped.
+
+    It stays a declared input — the session had it, and a caller may want the
+    results elsewhere — but defaults to the input's folder, which also makes the
+    outputs follow the file being replayed on.
+    """
+    recipe = _recipe_from(_pipeline(["/data/subj_01", "/data/subj_01"]))
+
+    assert [i.name for i in recipe.inputs] == ["in_1", "in_2"]
+    assert _defaults(recipe) == {"in_1": "", "in_2": "{{dir(in_1)}}"}
+    # The recipe still reproduces the session: nothing was dropped or rewritten.
+    assert recipe.steps[0].arguments["output_dir"] == "{{in_2}}"
+    assert recipe.steps[1].arguments["input_path"] == "{{step1.brain_path}}"
+
+
+def test_output_dir_elsewhere_gets_no_default() -> None:
+    """A destination that is not derivable is a real decision, so it is asked for."""
+    recipe = _recipe_from(_pipeline(["/data/subj_01", "/exports/run7"]))
+    assert _defaults(recipe)["in_3"] == ""
+
+
+def test_ambiguous_folder_gets_no_default() -> None:
+    """Two inputs in one folder give no principled anchor, so none is invented.
+
+    Picking one silently would make the destination follow whichever input
+    happened to be lifted first — a wrong answer that looks like a right one.
+    """
+    recipe = _recipe_from(
+        _pipeline(["/data/subj_01", "/data/subj_01"], second_input="/data/subj_01/mask.nii.gz")
+    )
+    dir_input = next(i for i in recipe.inputs if i.example == "/data/subj_01")
+    assert dir_input.default == ""
+
+
+def test_inputs_are_never_dropped() -> None:
+    """Distillation reproduces the session; it does not decide an argument is surplus."""
+    recipe = _recipe_from(_pipeline(["/data/subj_01", "/exports/run7"]))
+    assert [i.example for i in recipe.inputs] == [
+        "/data/subj_01/t1.nii.gz",
+        "/data/subj_01",
+        "/exports/run7",
+    ]
+
+
+def test_default_survives_a_recipe_round_trip(tmp_path: Path) -> None:
+    """A default is only useful if it is still there after save/load."""
+    recipe = _recipe_from(_pipeline(["/data/subj_01", "/data/subj_01"]))
+    draft = tmp_path / "wf"
+    draft.mkdir()
+    (draft / "recipe.yaml").write_text(yaml.safe_dump(recipe.to_dict()), encoding="utf-8")
+    assert _defaults(distill.load_recipe(draft))["in_2"] == "{{dir(in_1)}}"

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -428,3 +428,98 @@ async def test_mcp_caller_respawns_after_transport_crash(monkeypatch: pytest.Mon
 
     assert spawns[0] == 2  # the dead server was re-spawned, not reused
     assert outcome == (True, {"brain_path": "/b"}, None)
+
+
+# ── derived {{dir(...)}} references ──────────────────────────────────────────
+
+
+def test_resolves_a_derived_directory() -> None:
+    """`{{dir(ref)}}` is the folder holding whatever `ref` resolves to."""
+    bindings = {"in_1": "/data/subj_09/t1.nii.gz"}
+    args = {"input_path": "{{in_1}}", "output_dir": "{{dir(in_1)}}"}
+    assert replay.resolve_arguments(args, bindings) == {
+        "input_path": "/data/subj_09/t1.nii.gz",
+        "output_dir": "/data/subj_09",
+    }
+
+
+def test_derived_directory_follows_the_new_input() -> None:
+    """The point of deriving it: outputs land beside the file being replayed on."""
+    args = {"output_dir": "{{dir(in_1)}}"}
+    assert replay.resolve_arguments(args, {"in_1": "/other/subj_42/scan.nii.gz"}) == {
+        "output_dir": "/other/subj_42"
+    }
+
+
+def test_derived_directory_substitutes_inside_a_larger_string() -> None:
+    """A derived ref works embedded in text, not just as a whole value."""
+    args = {"note": "writing to {{dir(in_1)}}/derivatives"}
+    assert replay.resolve_arguments(args, {"in_1": "/data/s/t1.nii.gz"}) == {
+        "note": "writing to /data/s/derivatives"
+    }
+
+
+def test_unresolvable_derived_ref_is_left_verbatim() -> None:
+    """Left intact so unresolved_refs still reports it rather than silently emptying."""
+    args = {"output_dir": "{{dir(nope)}}"}
+    assert replay.resolve_arguments(args, {"in_1": "/data/x.nii.gz"}) == args
+    assert "dir(nope)" in replay.unresolved_refs(args)
+
+
+def test_default_fills_an_unbound_input() -> None:
+    """An input left blank takes its derived default."""
+    recipe = Recipe(
+        name="w",
+        description="",
+        inputs=[
+            WorkflowInput(name="in_1", example="/a/t1.nii.gz"),
+            WorkflowInput(name="in_2", example="/a", default="{{dir(in_1)}}"),
+        ],
+    )
+    assert replay.apply_input_defaults(recipe, {"in_1": "/b/scan.nii.gz"}) == {
+        "in_1": "/b/scan.nii.gz",
+        "in_2": "/b",
+    }
+
+
+def test_explicit_value_beats_the_default() -> None:
+    """The default saves typing; it must never override a stated destination."""
+    recipe = Recipe(
+        name="w",
+        description="",
+        inputs=[
+            WorkflowInput(name="in_1", example="/a/t1.nii.gz"),
+            WorkflowInput(name="in_2", example="/a", default="{{dir(in_1)}}"),
+        ],
+    )
+    bound = replay.apply_input_defaults(recipe, {"in_1": "/b/scan.nii.gz", "in_2": "/exports"})
+    assert bound["in_2"] == "/exports"
+
+
+def test_default_with_an_unbound_anchor_stays_missing() -> None:
+    """Half-resolved is worse than absent: validate must still report it."""
+    recipe = Recipe(
+        name="w",
+        description="",
+        inputs=[
+            WorkflowInput(name="in_1", example="/a/t1.nii.gz"),
+            WorkflowInput(name="in_2", example="/a", default="{{dir(in_1)}}"),
+        ],
+    )
+    assert replay.apply_input_defaults(recipe, {}) == {}
+    error = replay.validate(recipe, {}, [])
+    assert error is not None and "in_1" in error and "in_2" in error
+
+
+def test_validate_accepts_an_input_covered_by_its_default() -> None:
+    """A defaulted input must not be reported as missing."""
+    recipe = Recipe(
+        name="w",
+        description="",
+        inputs=[
+            WorkflowInput(name="in_1", example="/a/t1.nii.gz"),
+            WorkflowInput(name="in_2", example="/a", default="{{dir(in_1)}}"),
+        ],
+        steps=[RecipeStep(server="s", tool="t", arguments={"p": "{{in_2}}"})],
+    )
+    assert replay.validate(recipe, {"in_1": "/b/scan.nii.gz"}, [{"name": "s"}]) is None

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -523,3 +523,48 @@ def test_validate_accepts_an_input_covered_by_its_default() -> None:
         steps=[RecipeStep(server="s", tool="t", arguments={"p": "{{in_2}}"})],
     )
     assert replay.validate(recipe, {"in_1": "/b/scan.nii.gz"}, [{"name": "s"}]) is None
+
+
+def test_blank_optional_input_still_takes_its_default() -> None:
+    """The regression that made replays write nowhere.
+
+    The run form posts every field it rendered, so an input deliberately left
+    empty arrives as "". Treating that as bound skipped the default and sent an
+    empty output_dir to the tool, which wrote relative to its own working
+    directory — outside the workspace. The run reported success and no files
+    appeared.
+    """
+    recipe = Recipe(
+        name="w",
+        description="",
+        inputs=[
+            WorkflowInput(name="in_1", example="/a/t1.nii.gz"),
+            WorkflowInput(name="in_2", example="/a", default="{{dir(in_1)}}"),
+        ],
+        steps=[
+            RecipeStep(
+                server="s",
+                tool="t",
+                arguments={"input_path": "{{in_1}}", "output_dir": "{{in_2}}"},
+            )
+        ],
+    )
+    posted = {"in_1": "/data/subj_42/scan.nii.gz", "in_2": ""}
+    bound = replay.apply_input_defaults(recipe, posted)
+
+    assert bound["in_2"] == "/data/subj_42"
+    assert replay.resolve_arguments(recipe.steps[0].arguments, bound)["output_dir"] == (
+        "/data/subj_42"
+    )
+
+
+def test_blank_required_input_is_reported_missing() -> None:
+    """A blank with no default must fail loudly, not run with an empty argument."""
+    recipe = Recipe(
+        name="w",
+        description="",
+        inputs=[WorkflowInput(name="in_1", example="/a/t1.nii.gz")],
+        steps=[RecipeStep(server="s", tool="t", arguments={"p": "{{in_1}}"})],
+    )
+    error = replay.validate(recipe, {"in_1": "   "}, [{"name": "s"}])
+    assert error is not None and "in_1" in error


### PR DESCRIPTION
## Summary

A workflow distilled from a session asked for the scan **and** for the directory
that scan already sits in, so a two-decision pipeline arrived with several boxes
to fill — and because the folder was captured as a literal value, replaying on
another subject wrote the results back beside the original file unless the caller
noticed. That directory is now derived from the input it belongs to: still part
of the workflow, but filled in for you and kept out of the run form.

## Related issue

N/A — reported while distilling and replaying real sessions ("I always have too
many arguments", then "it ran but no files ever showed up").

## Test plan

- [x] `just check` — 441 passed, 2 skipped; `npm run lint` + `npm run build` clean
- [x] New: an `output_dir` that is exactly an input's parent folder gets `default: {{dir(in_1)}}`; one elsewhere does not
- [x] New: **no** default when the anchor is ambiguous (two inputs in one folder)
- [x] New: inputs are never dropped — the recipe still reproduces the session
- [x] New: `{{dir(...)}}` resolves whole, embedded, and is left verbatim when unresolvable
- [x] New: an explicit value beats the default; a default whose anchor is unbound stays missing for `validate`
- [x] New: a blank optional input still takes its default; a blank **required** input is reported missing
- [x] Round-trip: a default survives `recipe.yaml` save/load
- [x] End to end on real data: distilled from `patient_06`, replayed onto `patient_01/visit_01` with the derived field blank → output written beside the replayed scan, nothing written outside the workspace
- [x] UI checked in a real browser: the run form shows one field; *Change where results are written* reveals the second

## Security & data handling

No new tool surface or network calls. One behaviour change worth naming: a
replayed step now writes beside the file being replayed on, rather than to the
folder recorded in the workflow. That is the intended fix — outputs follow the
data — but it does move where files land for anyone relying on the old value.
Explicitly setting the field keeps the previous behaviour.

## Notes

Two mistakes from earlier iterations are worth recording, since both shaped the
final design:

- The first attempt **removed** the redundant input. That is a guess about
  intent, not a generalisation — distillation reproduces a session. The input is
  now kept and only defaulted.
- The first attempt also anchored the default to a *produced* path, emitting
  `{{dir(step3.x)}}` inside step 1 — a forward reference nothing can resolve.
  Anchors are inputs only, which are bound before any step runs.

Workflows distilled before this change keep working unchanged; re-distil to pick
up the default. The recipe format addition is additive (`WorkflowInput.default`).
