### PR TITLE
feat: external MCP servers (consent-gated) and todo-based planning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -226,6 +226,11 @@ __marimo__/
 # copy the image ships lives at docker/hooks.toml).
 .vibe/hooks.toml
 .vibe/pathguard_retries.json
+.vibe/external_mcp.json
+# Tokens for external MCP servers, passed to the core container via env_file.
+medmcp.env
+# Derived from .vibe/prompts/medmcp.md at sync time when external MCP is in use.
+.vibe/prompts/medmcp-external.md
 .vibe/provenance/
 .vibe/workflows/
 data/

--- a/.vibe/prompts/medmcp.md
+++ b/.vibe/prompts/medmcp.md
@@ -35,6 +35,12 @@ analysis pipelines through natural-language instructions.
 - When a tool result contains a `_render` field, follow its instructions exactly to
   produce your response — it contains per-call display rules and a required next action.
 
+**Planning multi-step work**
+- Whenever the user asks for more than one thing, write the parts to the `todo` tool — always, even when each part looks small. Look around first if you need to understand what is being asked; write the list before you start doing the work. Then keep it current: set a step to `in_progress` when you start it and `completed` when it lands.
+- `action: "write"` replaces the whole list. Send every item each time, reusing each item's `id`; sending only the one that changed deletes the rest.
+- Keep one step `in_progress` at a time.
+- A request for a single thing needs no list.
+
 **Skills**
 - Before starting any task, load the skill that matches the task name.
 - If no matching skill exists, proceed without one — do not block or invent skill names.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ Notable, user-visible changes to MedMCP. Format follows
   a `medmcp.env` file next to your compose file (or point `MEDMCP_ENV_FILE` at
   one); it is optional and read only if present.
 
+### Changed
+
+- **The agent now keeps a visible task list when you ask for more than one
+  thing.** Multi-part requests — strip this scan, register it, then report the
+  volumes — are written out as a checklist before the work starts and ticked off
+  as each part lands, so you can see what it understood you to be asking and how
+  far it has got. Single requests are unaffected.
+
 ### Fixed
 
 - **Tool stacks no longer go missing on the first run after installing them.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ Notable, user-visible changes to MedMCP. Format follows
 
 ## Unreleased
 
+### Added
+
+- **External MCP servers** (Settings → Advanced, off by default). Lets you connect
+  the agent to MCP tool services hosted outside your machine — a literature
+  search, a hospital system, a vendor API — alongside your local imaging stacks.
+  Because this ends the guarantee that nothing leaves your infrastructure, the
+  switch does not simply flip: it first explains what changes and asks you to
+  accept responsibility for what those services receive. Nothing is connected
+  until you do, and turning it off removes the servers from the agent again.
+  Servers are addressed by URL (`streamable-http` or `http`); if one needs a
+  token, you give the *name* of an environment variable rather than the token, so
+  no credential is ever written to disk. Tokens are sent as
+  `Authorization: Bearer …` by default, and services that expect something else
+  (an `X-API-Key` header, say) can set the header and value format themselves.
+  Individual servers can be switched off without deleting them, and every tool
+  call still asks for your approval. To supply a token, put `NAME=value` lines in
+  a `medmcp.env` file next to your compose file (or point `MEDMCP_ENV_FILE` at
+  one); it is optional and read only if present.
+
 ### Fixed
 
 - **Tool stacks no longer go missing on the first run after installing them.**

--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -93,6 +93,15 @@ services:
         condition: service_healthy
       llm-init:
         condition: service_completed_successfully
+    # Secrets for external MCP servers (Settings -> Advanced). The UI stores only
+    # the *name* of an environment variable, never a token, so the value has to
+    # reach this container some other way — and `environment:` below is a fixed
+    # allowlist that cannot forward a variable it does not already name. Put
+    # `MY_SERVICE_TOKEN=...` lines in this file (default ./medmcp.env, override
+    # with MEDMCP_ENV_FILE). Optional: absent is not an error.
+    env_file:
+      - path: ${MEDMCP_ENV_FILE:-./medmcp.env}
+        required: false
     environment:
       OLLAMA_BASE_URL: "http://llm:11434"
       # Names the model for both the agent's chat (the entrypoint writes it into

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,6 +81,15 @@ services:
         condition: service_healthy
       llm-init:
         condition: service_completed_successfully
+    # Secrets for external MCP servers (Settings -> Advanced). The UI stores only
+    # the *name* of an environment variable, never a token, so the value has to
+    # reach this container some other way — and `environment:` below is a fixed
+    # allowlist that cannot forward a variable it does not already name. Put
+    # `MY_SERVICE_TOKEN=...` lines in this file (default ./medmcp.env, override
+    # with MEDMCP_ENV_FILE). Optional: absent is not an error.
+    env_file:
+      - path: ${MEDMCP_ENV_FILE:-./medmcp.env}
+        required: false
     environment:
       OLLAMA_BASE_URL: "http://llm:11434"
       # Names the model for both the agent's chat (the entrypoint writes it into

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,6 +1,7 @@
 import type {
   BatchFromPlanResult,
   CatalogEntry,
+  ExternalMcpState,
   GpuInfo,
   InstalledStack,
   ReplayPreviewStep,
@@ -28,7 +29,11 @@ async function check(res: Response): Promise<Response> {
   return res
 }
 
-async function sendJson(method: 'POST' | 'PUT', url: string, body: object): Promise<Response> {
+async function sendJson(
+  method: 'POST' | 'PUT' | 'PATCH',
+  url: string,
+  body: object,
+): Promise<Response> {
   return check(
     await fetch(url, {
       method,
@@ -250,4 +255,43 @@ export async function batchFromPlan(name: string, planCsv: string): Promise<Batc
     plan_csv: planCsv,
   })
   return (await res.json()) as BatchFromPlanResult
+}
+
+// ── External MCP (advanced) ──────────────────────────────────
+// Every mutation restarts the agent server-side, so callers should refetch
+// rather than assume their optimistic view survived.
+
+export async function fetchExternalMcp(): Promise<ExternalMcpState> {
+  const res = await check(await fetch('/api/external-mcp'))
+  return (await res.json()) as ExternalMcpState
+}
+
+/** Record that the operator accepted the risks. Required before enabling. */
+export async function acknowledgeExternalMcp(): Promise<void> {
+  await postJson('/api/external-mcp/acknowledge', {})
+}
+
+export async function setExternalMcpEnabled(enabled: boolean): Promise<void> {
+  await sendJson('PUT', '/api/external-mcp', { enabled })
+}
+
+export async function addExternalServer(server: {
+  name: string
+  transport: string
+  url: string
+  api_key_env: string
+  api_key_header: string
+  api_key_format: string
+}): Promise<void> {
+  await postJson('/api/external-mcp/servers', server)
+}
+
+export async function setExternalServerActive(name: string, active: boolean): Promise<void> {
+  await sendJson('PATCH', `/api/external-mcp/servers/${encodeURIComponent(name)}`, { active })
+}
+
+export async function removeExternalServer(name: string): Promise<void> {
+  await check(
+    await fetch(`/api/external-mcp/servers/${encodeURIComponent(name)}`, { method: 'DELETE' }),
+  )
 }

--- a/frontend/src/components/ExternalMcpSection.tsx
+++ b/frontend/src/components/ExternalMcpSection.tsx
@@ -1,0 +1,334 @@
+import { useCallback, useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+import {
+  acknowledgeExternalMcp,
+  addExternalServer,
+  fetchExternalMcp,
+  removeExternalServer,
+  setExternalMcpEnabled,
+  setExternalServerActive,
+} from '../api'
+import type { ExternalMcpState } from '../types'
+import { Row, Toggle } from './SettingsControls'
+
+/**
+ * Advanced-settings section for wiring third-party MCP services into the
+ * workspace.
+ *
+ * The whole product guarantees that data stays on-premise, and this is the one
+ * control that breaks that guarantee, so the switch does not act on its own: the
+ * first time it is turned on it opens a consent dialog that has to be read and
+ * accepted. The acknowledgement is recorded server-side and is a precondition
+ * there too — the dialog is the explanation, not the enforcement.
+ */
+export function ExternalMcpSection() {
+  const [state, setState] = useState<ExternalMcpState | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [consenting, setConsenting] = useState(false)
+  const [understood, setUnderstood] = useState(false)
+  const [adding, setAdding] = useState(false)
+
+  const reload = useCallback(async () => {
+    setState(await fetchExternalMcp())
+  }, [])
+
+  useEffect(() => {
+    fetchExternalMcp()
+      .then(setState)
+      .catch((e: unknown) => setError(String(e)))
+  }, [])
+
+  /** Run a mutation, then refetch — every one of them restarts the agent. */
+  const run = useCallback(
+    (action: () => Promise<void>) => {
+      setBusy(true)
+      setError(null)
+      action()
+        .then(reload)
+        .catch((e: unknown) => setError(e instanceof Error ? e.message : String(e)))
+        .finally(() => setBusy(false))
+    },
+    [reload],
+  )
+
+  if (!state) return null
+
+  const onToggle = (next: boolean) => {
+    // Turning it on for the first time explains itself before it acts.
+    if (next && !state.acknowledged) {
+      setUnderstood(false)
+      setConsenting(true)
+      return
+    }
+    run(() => setExternalMcpEnabled(next))
+  }
+
+  const accept = () =>
+    run(async () => {
+      await acknowledgeExternalMcp()
+      await setExternalMcpEnabled(true)
+      setConsenting(false)
+    })
+
+  return (
+    <>
+      <Row
+        label="External MCP servers"
+        hint="Lets the agent use tools hosted outside this machine. Off by default — anything sent to such a server leaves your infrastructure."
+        checked={state.enabled}
+        onChange={onToggle}
+        disabled={busy}
+      />
+
+      {error && <div className="panel-error">{error}</div>}
+
+      {state.enabled && (
+        <div className="ext-mcp">
+          {state.servers.length === 0 && (
+            <div className="settings-row-hint ext-mcp-empty">No external servers yet.</div>
+          )}
+          {state.servers.map((s) => (
+            <div key={s.name} className="ext-mcp-server">
+              <div className="ext-mcp-server-text">
+                <div className="settings-row-label">{s.name}</div>
+                <div className="settings-row-hint ext-mcp-url">{s.url}</div>
+                <div className="settings-row-hint">
+                  {s.transport}
+                  {s.api_key_env ? ` · token from $${s.api_key_env}` : ' · no auth'}
+                  {s.api_key_env && s.api_key_header ? ` · ${s.api_key_header}` : ''}
+                </div>
+              </div>
+              <div className="ext-mcp-server-actions">
+                <Toggle
+                  checked={s.active}
+                  disabled={busy}
+                  onChange={(v) => run(() => setExternalServerActive(s.name, v))}
+                />
+                <button
+                  className="btn-text"
+                  disabled={busy}
+                  onClick={() => run(() => removeExternalServer(s.name))}
+                >
+                  Remove
+                </button>
+              </div>
+            </div>
+          ))}
+
+          {adding ? (
+            <AddServerForm
+              transports={state.transports}
+              busy={busy}
+              onCancel={() => setAdding(false)}
+              onSubmit={(server) =>
+                run(async () => {
+                  await addExternalServer(server)
+                  setAdding(false)
+                })
+              }
+            />
+          ) : (
+            <button className="btn-text" disabled={busy} onClick={() => setAdding(true)}>
+              + Add server
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Portalled to the body: this section renders inside .drawer, which is a
+          stacking context (position: fixed + z-index), so a backdrop rendered in
+          place cannot paint above the drawer no matter how high its z-index —
+          the settings behind the dialog would stay visible and clickable. */}
+      {consenting &&
+        createPortal(
+          <div className="modal-backdrop" onClick={() => setConsenting(false)}>
+            <div
+              className="modal ext-mcp-consent"
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="ext-mcp-consent-title"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <h3 id="ext-mcp-consent-title">Connect tools outside this machine?</h3>
+              <p>
+                MedMCP runs on-premise: today, no imaging data, patient metadata, or results leave
+                your infrastructure. Enabling external MCP servers ends that guarantee for the tools
+                you add.
+              </p>
+              <ul>
+                <li>
+                  Anything the agent passes to an external tool — file contents, paths, patient
+                  identifiers, results — is sent to whoever operates that server.
+                </li>
+                <li>
+                  You are responsible for what those services receive, for their terms and security,
+                  and for whether that is lawful for your data.
+                </li>
+                <li>
+                  The agent will no longer be told to keep everything on-premise, so it may choose
+                  these tools on its own. Each call still needs your approval, and the approval
+                  prompt is where you see what is being sent.
+                </li>
+                <li>Turning this off at any time removes those servers from the agent.</li>
+              </ul>
+              <label className="ext-mcp-understood">
+                <input
+                  type="checkbox"
+                  checked={understood}
+                  onChange={(e) => setUnderstood(e.target.checked)}
+                />
+                I understand and accept responsibility for data sent to external servers.
+              </label>
+              <div className="modal-actions">
+                <button className="btn-text" onClick={() => setConsenting(false)}>
+                  Cancel
+                </button>
+                <button className="btn-primary" disabled={!understood || busy} onClick={accept}>
+                  Enable
+                </button>
+              </div>
+            </div>
+          </div>,
+          document.body,
+        )}
+    </>
+  )
+}
+
+function AddServerForm({
+  transports,
+  busy,
+  onSubmit,
+  onCancel,
+}: {
+  transports: string[]
+  busy: boolean
+  onSubmit: (server: {
+    name: string
+    transport: string
+    url: string
+    api_key_env: string
+    api_key_header: string
+    api_key_format: string
+  }) => void
+  onCancel: () => void
+}) {
+  const [name, setName] = useState('')
+  const [transport, setTransport] = useState(transports[0] ?? 'streamable-http')
+  const [url, setUrl] = useState('')
+  const [envVar, setEnvVar] = useState('')
+  const [header, setHeader] = useState('')
+  const [format, setFormat] = useState('')
+  // Most services take a bearer token, so the scheme fields stay folded away
+  // until someone needs them.
+  const [customScheme, setCustomScheme] = useState(false)
+
+  return (
+    <form
+      className="ext-mcp-form"
+      onSubmit={(e) => {
+        e.preventDefault()
+        onSubmit({
+          name,
+          transport,
+          url,
+          api_key_env: envVar,
+          api_key_header: header,
+          api_key_format: format,
+        })
+      }}
+    >
+      <label>
+        Name
+        <input
+          className="wf-input"
+          value={name}
+          placeholder="pubmed"
+          onChange={(e) => setName(e.target.value)}
+        />
+      </label>
+      <label>
+        Transport
+        <select
+          className="wf-input"
+          value={transport}
+          onChange={(e) => setTransport(e.target.value)}
+        >
+          {transports.map((t) => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label>
+        URL
+        <input
+          className="wf-input"
+          value={url}
+          placeholder="https://example.org/mcp"
+          onChange={(e) => setUrl(e.target.value)}
+        />
+      </label>
+      <label>
+        Token env var (optional)
+        <input
+          className="wf-input"
+          value={envVar}
+          placeholder="PUBMED_TOKEN"
+          onChange={(e) => setEnvVar(e.target.value)}
+        />
+        {/* The token itself is never stored: only this name is written, and vibe
+            reads the value from the environment the workspace was started in. */}
+        <span className="settings-row-hint">
+          The name of an environment variable set where the workspace runs. The token itself is
+          never saved.
+        </span>
+      </label>
+
+      {/* Server-side these are refused without a token, since they would have
+          nothing to send — so only offer them once one is named. */}
+      {envVar &&
+        (customScheme ? (
+          <>
+            <label>
+              Header
+              <input
+                className="wf-input"
+                value={header}
+                placeholder="Authorization"
+                onChange={(e) => setHeader(e.target.value)}
+              />
+            </label>
+            <label>
+              Value format
+              <input
+                className="wf-input"
+                value={format}
+                placeholder="Bearer {token}"
+                onChange={(e) => setFormat(e.target.value)}
+              />
+              <span className="settings-row-hint">
+                Must contain <code>{'{token}'}</code>. For an API-key service, try header{' '}
+                <code>X-API-Key</code> with format <code>{'{token}'}</code>.
+              </span>
+            </label>
+          </>
+        ) : (
+          <button type="button" className="btn-text" onClick={() => setCustomScheme(true)}>
+            Not a bearer token?
+          </button>
+        ))}
+
+      <div className="ext-mcp-form-actions">
+        <button type="button" className="btn-text" onClick={onCancel}>
+          Cancel
+        </button>
+        <button type="submit" className="btn-primary" disabled={busy || !name || !url}>
+          Add
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/frontend/src/components/SettingsControls.tsx
+++ b/frontend/src/components/SettingsControls.tsx
@@ -1,0 +1,53 @@
+/**
+ * The drawer's switch primitives, shared by the settings sections.
+ *
+ * Lifted out of SettingsDrawer so a section living in its own file can render an
+ * identical row without either duplicating the markup or importing back into the
+ * drawer (which would be a cycle).
+ */
+
+export function Toggle({
+  checked,
+  onChange,
+  disabled,
+}: {
+  checked: boolean
+  onChange: (value: boolean) => void
+  disabled?: boolean
+}) {
+  return (
+    <button
+      role="switch"
+      aria-checked={checked}
+      className={`toggle${checked ? ' on' : ''}`}
+      disabled={disabled}
+      onClick={() => onChange(!checked)}
+    >
+      <span className="toggle-knob" />
+    </button>
+  )
+}
+
+export function Row({
+  label,
+  hint,
+  checked,
+  onChange,
+  disabled,
+}: {
+  label: string
+  hint?: string
+  checked: boolean
+  onChange: (value: boolean) => void
+  disabled?: boolean
+}) {
+  return (
+    <div className={`settings-row${disabled ? ' disabled' : ''}`}>
+      <div className="settings-row-text">
+        <div className="settings-row-label">{label}</div>
+        {hint && <div className="settings-row-hint">{hint}</div>}
+      </div>
+      <Toggle checked={checked} onChange={onChange} disabled={disabled} />
+    </div>
+  )
+}

--- a/frontend/src/components/SettingsDrawer.tsx
+++ b/frontend/src/components/SettingsDrawer.tsx
@@ -1,57 +1,13 @@
 import { useEffect, useState } from 'react'
 import { fetchGpus, fetchSettings, saveSettings } from '../api'
 import type { GpuInfo, SettingsState } from '../types'
+import { ExternalMcpSection } from './ExternalMcpSection'
+import { Row } from './SettingsControls'
 import { ChevronRightIcon, XIcon } from './icons'
 
 interface SettingsDrawerProps {
   open: boolean
   onClose: () => void
-}
-
-function Toggle({
-  checked,
-  onChange,
-  disabled,
-}: {
-  checked: boolean
-  onChange: (value: boolean) => void
-  disabled?: boolean
-}) {
-  return (
-    <button
-      role="switch"
-      aria-checked={checked}
-      className={`toggle${checked ? ' on' : ''}`}
-      disabled={disabled}
-      onClick={() => onChange(!checked)}
-    >
-      <span className="toggle-knob" />
-    </button>
-  )
-}
-
-function Row({
-  label,
-  hint,
-  checked,
-  onChange,
-  disabled,
-}: {
-  label: string
-  hint?: string
-  checked: boolean
-  onChange: (value: boolean) => void
-  disabled?: boolean
-}) {
-  return (
-    <div className={`settings-row${disabled ? ' disabled' : ''}`}>
-      <div className="settings-row-text">
-        <div className="settings-row-label">{label}</div>
-        {hint && <div className="settings-row-hint">{hint}</div>}
-      </div>
-      <Toggle checked={checked} onChange={onChange} disabled={disabled} />
-    </div>
-  )
 }
 
 /**
@@ -171,12 +127,15 @@ export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
                 Advanced
               </button>
               {advanced && (
-                <Row
-                  label="Record provenance"
-                  hint="Keeps a replayable record of what each chat did (manifest, tool log, permissions). Turning this off means a chat leaves no audit trail and cannot be distilled into a workflow."
-                  checked={state.record_provenance}
-                  onChange={(v) => apply({ ...state, record_provenance: v })}
-                />
+                <>
+                  <Row
+                    label="Record provenance"
+                    hint="Keeps a replayable record of what each chat did (manifest, tool log, permissions). Turning this off means a chat leaves no audit trail and cannot be distilled into a workflow."
+                    checked={state.record_provenance}
+                    onChange={(v) => apply({ ...state, record_provenance: v })}
+                  />
+                  <ExternalMcpSection />
+                </>
               )}
 
               <div className="drawer-footnote">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2732,3 +2732,136 @@ textarea.wf-input {
   opacity: 0.6;
   text-decoration: line-through;
 }
+
+/* ── External MCP (advanced settings) ────────────────────────────────────── */
+
+/* Sits above .drawer (z-index 21) on the shared .modal-backdrop (40), so the
+   consent dialog covers the settings panel that launched it. */
+.modal {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 41;
+  width: 520px;
+  max-width: 92vw;
+  max-height: 86vh;
+  overflow-y: auto;
+  padding: 20px 22px;
+  background: var(--card);
+  border: 1px solid var(--border2);
+  border-radius: 12px;
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.5);
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 18px;
+}
+
+.btn-text {
+  background: none;
+  border: none;
+  padding: 4px 8px;
+  color: var(--muted);
+}
+
+.btn-text:hover {
+  color: var(--text);
+}
+
+/* The one control that ends the on-premise guarantee — the red edge is the cue
+   that this dialog is not a routine confirmation. */
+.ext-mcp-consent {
+  border-color: rgba(210, 34, 41, 0.45);
+}
+
+.ext-mcp-consent h3 {
+  margin: 0 0 12px;
+  font-size: 15px;
+}
+
+.ext-mcp-consent p,
+.ext-mcp-consent li {
+  color: var(--muted);
+  font-size: 12.5px;
+  line-height: 1.6;
+}
+
+.ext-mcp-consent ul {
+  margin: 12px 0;
+  padding-left: 18px;
+}
+
+.ext-mcp-consent li {
+  margin-bottom: 8px;
+}
+
+.ext-mcp-understood {
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+  margin-top: 16px;
+  font-size: 12.5px;
+  line-height: 1.5;
+  cursor: pointer;
+}
+
+.ext-mcp {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 4px 0 10px 12px;
+  border-left: 1px solid var(--border);
+  margin-left: 4px;
+}
+
+.ext-mcp-empty {
+  font-style: italic;
+}
+
+.ext-mcp-server {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.ext-mcp-server-text {
+  min-width: 0;
+}
+
+/* URLs are long and unbreakable; let them wrap rather than widen the drawer. */
+.ext-mcp-url {
+  font-family: var(--mono);
+  overflow-wrap: anywhere;
+}
+
+.ext-mcp-server-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.ext-mcp-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.ext-mcp-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.ext-mcp-form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -266,3 +266,28 @@ export type ServerFrame =
     }
   | { type: 'done' }
   | { type: 'error'; message: string }
+
+/** One external MCP server (GET /api/external-mcp). */
+export interface ExternalServer {
+  name: string
+  transport: string
+  url: string
+  /** Name of the env var holding the token — never the token itself. */
+  api_key_env: string
+  /** Header to carry the token; empty means Authorization. */
+  api_key_header: string
+  /** Value format, e.g. "Bearer {token}"; empty means Bearer. */
+  api_key_format: string
+  active: boolean
+}
+
+/** State of the external-MCP feature (advanced settings). */
+export interface ExternalMcpState {
+  enabled: boolean
+  /** Whether the operator has accepted responsibility; required before enabling. */
+  acknowledged: boolean
+  acknowledged_at: string | null
+  /** Transports the server will accept, in preference order. */
+  transports: string[]
+  servers: ExternalServer[]
+}

--- a/src/medmcp/server.py
+++ b/src/medmcp/server.py
@@ -590,6 +590,127 @@ def _workflow_detail(name: str) -> JsonDict:
     }
 
 
+# ── External MCP servers (advanced) ──────────────────────────────────────────
+# Every mutation here changes what the agent can reach, so all of them are
+# audit-logged and all of them re-sync the vibe config and restart the agent —
+# the same treatment a stack change gets, for the same reason.
+
+
+class ExternalMcpEnabledPayload(BaseModel):
+    """Request body for turning external MCP support on or off."""
+
+    enabled: bool
+
+
+class ExternalServerPayload(BaseModel):
+    """Request body for registering an external MCP server."""
+
+    name: str
+    transport: str
+    url: str
+    api_key_env: str = ""
+    # Optional overrides for services that don't take a bearer token; empty means
+    # vibe's `Authorization: Bearer {token}` default.
+    api_key_header: str = ""
+    api_key_format: str = ""
+
+
+class ExternalServerActivePayload(BaseModel):
+    """Request body for activating/deactivating one external server."""
+
+    active: bool
+
+
+async def _apply_external_change() -> None:
+    """Re-discover servers, re-sync the vibe config, and restart the agent."""
+    await asyncio.to_thread(_apply_stack_change)
+    await _restart_vibe()
+
+
+@app.get("/api/external-mcp")
+async def get_external_mcp() -> JsonDict:
+    """Return the external-MCP state: the toggle, the acknowledgement, the servers."""
+
+    def _state() -> JsonDict:
+        state = settings.load_external_mcp()
+        return {
+            "enabled": bool(state["enabled"]),
+            "acknowledged": bool(state["acknowledged_at"]),
+            "acknowledged_at": state["acknowledged_at"],
+            "transports": list(settings.EXTERNAL_MCP_TRANSPORTS),
+            "servers": state["servers"],
+        }
+
+    return await asyncio.to_thread(_state)
+
+
+@app.post("/api/external-mcp/acknowledge")
+async def post_external_mcp_acknowledge() -> JsonDict:
+    """Record that the operator accepted responsibility for external services."""
+    state = await asyncio.to_thread(settings.acknowledge_external_mcp)
+    _audit.info("external MCP acknowledged at %s", state["acknowledged_at"])
+    return {"ok": True, "acknowledged_at": state["acknowledged_at"]}
+
+
+@app.put("/api/external-mcp")
+async def put_external_mcp(payload: ExternalMcpEnabledPayload) -> JsonDict:
+    """Enable or disable external MCP support (enabling requires the acknowledgement)."""
+    try:
+        await asyncio.to_thread(settings.set_external_mcp_enabled, payload.enabled)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    _audit.info("external MCP %s", "enabled" if payload.enabled else "disabled")
+    await _apply_external_change()
+    return {"ok": True, "enabled": payload.enabled, "restarted": True}
+
+
+@app.post("/api/external-mcp/servers")
+async def post_external_server(payload: ExternalServerPayload) -> JsonDict:
+    """Register an external MCP server."""
+    try:
+        entry = await asyncio.to_thread(
+            settings.add_external_server,
+            payload.name,
+            payload.transport,
+            payload.url,
+            payload.api_key_env,
+            True,
+            payload.api_key_header,
+            payload.api_key_format,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    _audit.info("external MCP server added: %s -> %s", entry["name"], entry["url"])
+    await _apply_external_change()
+    return {"ok": True, "server": entry, "restarted": True}
+
+
+@app.patch("/api/external-mcp/servers/{name}")
+async def patch_external_server(name: str, payload: ExternalServerActivePayload) -> JsonDict:
+    """Activate or deactivate a single external server without deleting it."""
+    try:
+        await asyncio.to_thread(settings.set_external_server_active, name, payload.active)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    _audit.info(
+        "external MCP server %s: %s", "activated" if payload.active else "deactivated", name
+    )
+    await _apply_external_change()
+    return {"ok": True, "restarted": True}
+
+
+@app.delete("/api/external-mcp/servers/{name}")
+async def delete_external_server(name: str) -> JsonDict:
+    """Remove an external MCP server."""
+    try:
+        await asyncio.to_thread(settings.remove_external_server, name)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    _audit.info("external MCP server removed: %s", name)
+    await _apply_external_change()
+    return {"ok": True, "restarted": True}
+
+
 @app.get("/api/workflows")
 async def get_workflows() -> JsonDict:
     """List the personal workflows available to the replay engine."""

--- a/src/medmcp/settings.py
+++ b/src/medmcp/settings.py
@@ -31,9 +31,12 @@ import tempfile
 import threading
 import tomllib
 from collections.abc import Callable
+from datetime import UTC, datetime
 from functools import lru_cache
 from pathlib import Path
+from string import Formatter
 from typing import Any, cast
+from urllib.parse import urlparse
 
 import httpx
 import tomli_w
@@ -545,12 +548,26 @@ def load_mcp_servers() -> list[JsonDict]:
             if command and Path(command).name == "docker":
                 log.debug("Skipping orphaned container-stack config.toml entry %r", name)
                 continue
+            # An HTTP entry here is one this sync wrote for an external server —
+            # source #4 owns those. Re-adopting it would strip it back to a stdio
+            # entry with an empty command, which is the feedback loop above in a
+            # different costume, and would survive the feature being switched off.
+            if str(srv.get("transport", "")) in EXTERNAL_MCP_TRANSPORTS or srv.get("url"):
+                log.debug("Skipping external-server config.toml entry %r", name)
+                continue
             servers[name] = {
                 "name": name,
                 "command": command,
                 "args": cast("list[Any]", srv.get("args", [])),
                 "env": {},
             }
+
+    # ── 4. External MCP servers (advanced; gated on an explicit acknowledgement)
+    # Last, and non-shadowing: a local stack of the same name always wins, so a
+    # remote entry can never displace an audited on-premise tool set.
+    for entry in external_servers():
+        if entry["name"] not in servers:
+            servers[entry["name"]] = entry
 
     return list(servers.values())
 
@@ -601,6 +618,301 @@ def active_servers() -> list[JsonDict]:
     """Return only the active subset of all discovered servers."""
     active_names = load_active_server_names()
     return [s for s in load_mcp_servers() if s["name"] in active_names]
+
+
+# ── External MCP servers (advanced, off by default) ──────────────────────────
+# Wiring the workspace to a third-party MCP service crosses the on-premise
+# boundary the rest of the product guarantees, so this is gated twice: the
+# operator must enable the feature *and* have acknowledged what it means. Nothing
+# is discovered until both hold, which is why `external_mcp_enabled()` — not the
+# stored `enabled` flag — is what discovery consults.
+#
+# Remote HTTP transports only. A stdio entry here would mean launching an
+# arbitrary binary on the host, which is a categorically larger hole than a
+# network call the permission flow already gates, so it is not offered.
+#
+# Credentials are stored as the *name* of an environment variable, never a token:
+# `.vibe/config.toml` is rewritten on every sync and readable by anything in the
+# container, so it is the wrong place for a secret.
+EXTERNAL_MCP_PATH: Path = VIBE_HOME / "external_mcp.json"
+EXTERNAL_MCP_TRANSPORTS: tuple[str, ...] = ("streamable-http", "http")
+_ENV_VAR_RE: re.Pattern[str] = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+# RFC 7230 token characters — the same set vibe validates header names against.
+_HEADER_NAME_RE: re.Pattern[str] = re.compile(r"[A-Za-z0-9!#$%&'*+.^_`|~-]+")
+
+
+def _default_external_state() -> JsonDict:
+    return {"enabled": False, "acknowledged_at": None, "servers": []}
+
+
+def load_external_mcp() -> JsonDict:
+    """Return the external-MCP state (``enabled``/``acknowledged_at``/``servers``)."""
+    if not EXTERNAL_MCP_PATH.exists():
+        return _default_external_state()
+    try:
+        data = cast("JsonDict", json.loads(EXTERNAL_MCP_PATH.read_text()))
+    except (json.JSONDecodeError, OSError) as exc:
+        log.warning("could not read %s; treating as disabled: %s", EXTERNAL_MCP_PATH, exc)
+        return _default_external_state()
+    state = _default_external_state()
+    state["enabled"] = bool(data.get("enabled"))
+    ack = data.get("acknowledged_at")
+    state["acknowledged_at"] = str(ack) if ack else None
+    servers = data.get("servers")
+    state["servers"] = list(cast("list[JsonDict]", servers)) if isinstance(servers, list) else []
+    return state
+
+
+def _save_external_mcp(state: JsonDict) -> None:
+    _atomic_write_json(EXTERNAL_MCP_PATH, state)
+
+
+def external_mcp_acknowledged() -> bool:
+    """Whether the operator has accepted responsibility for external services."""
+    return bool(load_external_mcp()["acknowledged_at"])
+
+
+def external_mcp_enabled() -> bool:
+    """Whether external MCP servers may be discovered at all.
+
+    Both the toggle and the acknowledgement are required — a state file that
+    somehow carries ``enabled`` without one is treated as off rather than trusted.
+    """
+    state = load_external_mcp()
+    return bool(state["enabled"]) and bool(state["acknowledged_at"])
+
+
+def acknowledge_external_mcp() -> JsonDict:
+    """Record that the operator accepted the risks; idempotent (first time wins)."""
+    state = load_external_mcp()
+    if not state["acknowledged_at"]:
+        state["acknowledged_at"] = datetime.now(UTC).isoformat(timespec="seconds")
+        _save_external_mcp(state)
+    return state
+
+
+def set_external_mcp_enabled(enabled: bool) -> JsonDict:
+    """Turn the feature on or off. Enabling without an acknowledgement is refused."""
+    state = load_external_mcp()
+    if enabled and not state["acknowledged_at"]:
+        raise ValueError("external MCP must be acknowledged before it can be enabled")
+    state["enabled"] = bool(enabled)
+    _save_external_mcp(state)
+    return state
+
+
+def _validate_api_key_format(fmt: str) -> None:
+    """Raise ``ValueError`` unless *fmt* is a format string using only ``{token}``.
+
+    Mirrors vibe's own check. Enumerating the replacement fields beats searching
+    for the ``{token}`` substring: ``{{token}}`` contains it but escapes to a
+    literal, and ``{token:>5}`` is valid without containing it.
+    """
+    try:
+        fields = [name for _, name, _, _ in Formatter().parse(fmt) if name is not None]
+    except ValueError as exc:
+        raise ValueError(f"invalid token format: {fmt!r} (not a valid format string)") from exc
+    if any(name != "token" for name in fields):
+        raise ValueError(f"invalid token format: {fmt!r} (may only reference {{token}})")
+    if "token" not in fields:
+        raise ValueError(f"invalid token format: {fmt!r} (must contain {{token}})")
+
+
+def _validate_external_server(
+    name: str,
+    transport: str,
+    url: str,
+    api_key_env: str,
+    api_key_header: str = "",
+    api_key_format: str = "",
+) -> None:
+    """Raise ``ValueError`` if any field of a proposed external server is unusable."""
+    if not _STACK_NAME_RE.fullmatch(name):
+        raise ValueError(f"invalid server name: {name!r} (lowercase letters, digits and '-')")
+    if transport not in EXTERNAL_MCP_TRANSPORTS:
+        allowed = ", ".join(EXTERNAL_MCP_TRANSPORTS)
+        raise ValueError(f"invalid transport: {transport!r} (allowed: {allowed})")
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        raise ValueError(f"invalid url: {url!r} (must be an http(s) URL)")
+    if api_key_env and not _ENV_VAR_RE.fullmatch(api_key_env):
+        raise ValueError(f"invalid environment variable name: {api_key_env!r}")
+    if api_key_header and not _HEADER_NAME_RE.fullmatch(api_key_header):
+        raise ValueError(f"invalid header name: {api_key_header!r}")
+    if api_key_format:
+        _validate_api_key_format(api_key_format)
+    # vibe ignores the header/format fields when no token is configured and warns
+    # about it; refuse up front rather than storing settings that do nothing.
+    if (api_key_header or api_key_format) and not api_key_env:
+        raise ValueError("a header or token format needs an environment variable to send")
+
+
+def add_external_server(
+    name: str,
+    transport: str,
+    url: str,
+    api_key_env: str = "",
+    active: bool = True,
+    api_key_header: str = "",
+    api_key_format: str = "",
+) -> JsonDict:
+    """Register an external MCP server and return the stored entry.
+
+    The name must not collide with a discovered stack: a duplicate would shadow a
+    local, audited tool set with a remote one of the operator's choosing.
+
+    ``api_key_header``/``api_key_format`` are optional overrides for services that
+    do not take a bearer token (``X-API-Key: <token>``, say); left empty, vibe's
+    ``Authorization: Bearer {token}`` default applies.
+    """
+    name, transport, url = name.strip(), transport.strip(), url.strip()
+    api_key_env = api_key_env.strip()
+    api_key_header, api_key_format = api_key_header.strip(), api_key_format.strip()
+    _validate_external_server(name, transport, url, api_key_env, api_key_header, api_key_format)
+
+    state = load_external_mcp()
+    if any(str(s.get("name")) == name for s in cast("list[JsonDict]", state["servers"])):
+        raise ValueError(f"an external server named {name!r} already exists")
+    local = {s["name"] for s in load_mcp_servers() if not s.get("external")}
+    if name in local:
+        raise ValueError(f"{name!r} is already the name of an installed stack")
+
+    entry: JsonDict = {
+        "name": name,
+        "transport": transport,
+        "url": url,
+        "api_key_env": api_key_env,
+        "api_key_header": api_key_header,
+        "api_key_format": api_key_format,
+        "active": bool(active),
+    }
+    cast("list[JsonDict]", state["servers"]).append(entry)
+    _save_external_mcp(state)
+
+    # A server the operator just added is meant to be on. Once written, the active
+    # set is an explicit list rather than "everything discovered", so without this
+    # the new entry would be discovered and then silently left out of the sync.
+    if active:
+        load_mcp_servers.cache_clear()
+        save_active_server_names(load_active_server_names() | {name})
+    return entry
+
+
+def remove_external_server(name: str) -> None:
+    """Delete an external server by name."""
+    state = load_external_mcp()
+    servers = cast("list[JsonDict]", state["servers"])
+    remaining = [s for s in servers if str(s.get("name")) != name]
+    if len(remaining) == len(servers):
+        raise FileNotFoundError(f"no external server named {name!r}")
+    state["servers"] = remaining
+    _save_external_mcp(state)
+
+
+def set_external_server_active(name: str, active: bool) -> None:
+    """Enable or disable a single external server without deleting it."""
+    state = load_external_mcp()
+    for srv in cast("list[JsonDict]", state["servers"]):
+        if str(srv.get("name")) == name:
+            srv["active"] = bool(active)
+            _save_external_mcp(state)
+            return
+    raise FileNotFoundError(f"no external server named {name!r}")
+
+
+def external_servers() -> list[JsonDict]:
+    """Return active external servers as server-config dicts, or [] when gated off."""
+    if not external_mcp_enabled():
+        return []
+    out: list[JsonDict] = []
+    for srv in cast("list[JsonDict]", load_external_mcp()["servers"]):
+        if not srv.get("active"):
+            continue
+        name, url = str(srv.get("name", "")), str(srv.get("url", ""))
+        transport = str(srv.get("transport", ""))
+        env_var = str(srv.get("api_key_env") or "")
+        header = str(srv.get("api_key_header") or "")
+        fmt = str(srv.get("api_key_format") or "")
+        try:
+            _validate_external_server(name, transport, url, env_var, header, fmt)
+        except ValueError as exc:
+            log.warning("skipping malformed external server %r: %s", name, exc)
+            continue
+        entry: JsonDict = {
+            "name": name,
+            "transport": transport,
+            "url": url,
+            "external": True,
+        }
+        if env_var:
+            # Shape fixed by vibe's MCPAuth: a discriminated union on ``type``
+            # whose members forbid extra keys, so a missing discriminator or a
+            # misspelled field is a hard validation error, not a silent no-op —
+            # the server would simply fail to load. ``test_generated_entry_*``
+            # validates what we write here against vibe's own model.
+            #
+            # vibe reads the token from the environment itself (defaulting to an
+            # ``Authorization: Bearer {token}`` header); the variable's name is
+            # all that is ever written to disk.
+            auth: JsonDict = {"type": "static", "api_key_env": env_var}
+            # Written only when overridden, so a server on the default scheme
+            # produces the same config it did before these fields existed.
+            if header:
+                auth["api_key_header"] = header
+            if fmt:
+                auth["api_key_format"] = fmt
+            entry["auth"] = auth
+        out.append(entry)
+    return out
+
+
+# The base prompt tells the agent it runs entirely on-premise and must never
+# suggest sending data to external services. With an external server wired up
+# that is no longer true, and an agent holding tools it has been told never to
+# use behaves erratically — it refuses them, or narrates the contradiction.
+#
+# vibe resolves `system_prompt_id` to exactly one file with no append hook, so
+# the enabled state needs its own prompt. It is *derived* from the base rather
+# than checked in beside it: two hand-maintained copies of a 70-line prompt drift,
+# and the drift is silent. The anchor below is asserted by a test, so editing it
+# out of the base prompt fails CI instead of quietly producing an identical file.
+BASE_SYSTEM_PROMPT_ID: str = "medmcp"
+EXTERNAL_SYSTEM_PROMPT_ID: str = "medmcp-external"
+ONPREM_RULE: str = "- You run entirely on-premise. Never suggest sending data to external services."
+EXTERNAL_RULE: str = (
+    "- Your tool stacks run on-premise. This workspace also has external MCP servers "
+    "configured; the operator enabled them and accepted responsibility for what they "
+    "receive, so use their tools when they fit the task."
+)
+
+
+def write_external_prompt_variant() -> bool:
+    """Derive the external-enabled system prompt next to the base one.
+
+    Returns ``False`` — leaving the base prompt in force — when the source is
+    missing or no longer carries the on-premise rule, so a prompt edit can never
+    silently hand the agent a variant identical to the one it was meant to relax.
+    """
+    prompts = VIBE_HOME / "prompts"
+    base = prompts / f"{BASE_SYSTEM_PROMPT_ID}.md"
+    try:
+        text = base.read_text()
+    except OSError as exc:
+        log.warning("cannot read %s; keeping the base system prompt: %s", base, exc)
+        return False
+    if ONPREM_RULE not in text:
+        log.warning(
+            "%s no longer contains the on-premise rule; keeping the base system prompt", base
+        )
+        return False
+    try:
+        (prompts / f"{EXTERNAL_SYSTEM_PROMPT_ID}.md").write_text(
+            text.replace(ONPREM_RULE, EXTERNAL_RULE)
+        )
+    except OSError as exc:
+        log.warning("could not write the external system prompt: %s", exc)
+        return False
+    return True
 
 
 # ── Container-stack install / uninstall (UI-driven) ──────────────────────────
@@ -1240,7 +1552,20 @@ def _sync_servers_to_vibe_config_locked(servers: list[JsonDict]) -> None:
     new_entries: list[JsonDict] = []
     for srv in servers:
         name = srv["name"]
-        if name in existing_by_name:
+        if srv.get("external"):
+            # An HTTP server has no command/args to preserve or overwrite, and
+            # nothing about it is owned by config.toml — the state file is the
+            # single source of truth, so it is rebuilt from scratch each sync.
+            # That also means disabling the feature removes these entries.
+            entry = {
+                "transport": srv["transport"],
+                "name": name,
+                "url": srv["url"],
+            }
+            if srv.get("auth"):
+                entry["auth"] = srv["auth"]
+            new_entries.append(entry)
+        elif name in existing_by_name:
             # Preserve vibe-acp-specific fields (timeouts, transport, etc.)
             # and overwrite discovery-owned fields (command, args).
             entry = dict(existing_by_name[name])
@@ -1292,14 +1617,29 @@ def _sync_servers_to_vibe_config_locked(servers: list[JsonDict]) -> None:
     # then spawns the cheap `medmcp-mcp-proxy <stack>` shim, which forwards to the
     # persistent BackendPool; the real launch specs go to backends.json. Disabled
     # is byte-for-byte the legacy behaviour, minus any stale proxy env keys.
+    # External servers are exempt: the pool exists to amortise process spawn and
+    # CUDA init for local stacks, and there is no such cost to amortise for an
+    # HTTP endpoint — routing one through a spawn-shim would only break it.
     if stack_pool_enabled():
-        _write_backend_registry(servers)
+        _write_backend_registry([s for s in servers if not s.get("external")])
         ws_root = os.environ.get("MEDMCP_WORKSPACE") or None
-        new_entries = [_proxied_entry(entry, ws_root) for entry in new_entries]
+        new_entries = [
+            entry if entry.get("url") else _proxied_entry(entry, ws_root) for entry in new_entries
+        ]
     else:
         _strip_pool_env(new_entries)
 
     cfg["mcp_servers"] = new_entries
+
+    # Point vibe at the prompt that matches the posture actually in force. Only a
+    # value this function owns is overwritten, so a hand-set custom prompt id is
+    # left alone rather than being reset on the next sync.
+    use_external = any(s.get("external") for s in servers) and write_external_prompt_variant()
+    owned_prompt_ids = ("", BASE_SYSTEM_PROMPT_ID, EXTERNAL_SYSTEM_PROMPT_ID)
+    if str(cfg.get("system_prompt_id", "")) in owned_prompt_ids:
+        cfg["system_prompt_id"] = (
+            EXTERNAL_SYSTEM_PROMPT_ID if use_external else BASE_SYSTEM_PROMPT_ID
+        )
 
     # Collect skills_path values from discovered servers and write them to
     # skill_paths so vibe-acp loads the bundled skill docs automatically.

--- a/tests/test_external_mcp.py
+++ b/tests/test_external_mcp.py
@@ -1,0 +1,398 @@
+"""Tests for external MCP servers — the double gate, validation, and sync output.
+
+This feature deliberately crosses the on-premise boundary the rest of the product
+guarantees, so most of what is asserted here is what does *not* happen: no
+discovery without an acknowledgement, no secret written to disk, no remote entry
+shadowing a local stack, and no relaxed system prompt unless one is actually in use.
+"""
+
+from __future__ import annotations
+
+import json
+import tomllib
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from medmcp import settings
+
+JsonDict = dict[str, Any]
+
+
+@pytest.fixture(autouse=True)
+def _isolate(  # pyright: ignore[reportUnusedFunction]  # autouse fixture, invoked by pytest
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Point every piece of on-disk state at a tmp dir."""
+    prompts = tmp_path / "prompts"
+    prompts.mkdir()
+    (prompts / "medmcp.md").write_text(
+        f"You are MedMCP.\n\n**Operational rules**\n{settings.ONPREM_RULE}\n- Other rule.\n"
+    )
+    monkeypatch.setattr(settings, "VIBE_HOME", tmp_path)
+    monkeypatch.setattr(settings, "EXTERNAL_MCP_PATH", tmp_path / "external_mcp.json")
+    monkeypatch.setattr(settings, "ACTIVE_STACKS_PATH", tmp_path / "active_stacks.json")
+    monkeypatch.setattr(settings, "STACKS_D_PATH", tmp_path / "absent-stacks.d")
+    # Source #1 too, or the machine's real uv-tool stacks turn up in discovery.
+    monkeypatch.setattr(settings, "get_uv_tool_dir", lambda: None)
+    monkeypatch.delenv("MEDMCP_STACK_POOL", raising=False)
+    settings.load_mcp_servers.cache_clear()
+
+
+def _entries(tmp_path: Path) -> dict[str, JsonDict]:
+    with (tmp_path / "config.toml").open("rb") as fh:
+        cfg = tomllib.load(fh)
+    return {str(e["name"]): e for e in cast("list[JsonDict]", cfg["mcp_servers"])}
+
+
+def _add(
+    name: str = "pubmed",
+    transport: str = "streamable-http",
+    url: str = "https://example.org/mcp",
+    api_key_env: str = "",
+    api_key_header: str = "",
+    api_key_format: str = "",
+) -> JsonDict:
+    return settings.add_external_server(
+        name,
+        transport,
+        url,
+        api_key_env,
+        True,
+        api_key_header,
+        api_key_format,
+    )
+
+
+# ── the double gate ──────────────────────────────────────────────────────────
+
+
+def test_default_state_is_off() -> None:
+    """Absent state file means disabled, unacknowledged, no servers."""
+    state = settings.load_external_mcp()
+    assert state == {"enabled": False, "acknowledged_at": None, "servers": []}
+    assert settings.external_mcp_enabled() is False
+
+
+def test_enable_without_acknowledgement_is_refused() -> None:
+    """The acknowledgement is a precondition, not a UI-only formality."""
+    with pytest.raises(ValueError, match="acknowledged"):
+        settings.set_external_mcp_enabled(True)
+    assert settings.external_mcp_enabled() is False
+
+
+def test_acknowledge_then_enable() -> None:
+    """With the acknowledgement recorded, the toggle takes effect."""
+    settings.acknowledge_external_mcp()
+    settings.set_external_mcp_enabled(True)
+    assert settings.external_mcp_enabled() is True
+
+
+def test_acknowledgement_is_idempotent() -> None:
+    """Re-acknowledging keeps the original timestamp rather than resetting it."""
+    first = settings.acknowledge_external_mcp()["acknowledged_at"]
+    assert settings.acknowledge_external_mcp()["acknowledged_at"] == first
+
+
+def test_enabled_flag_alone_does_not_open_the_gate() -> None:
+    """A hand-edited state file claiming enabled without an ack is still off."""
+    settings.EXTERNAL_MCP_PATH.write_text(
+        json.dumps(
+            {"enabled": True, "acknowledged_at": None, "servers": [{"name": "x", "active": True}]}
+        )
+    )
+    assert settings.external_mcp_enabled() is False
+    assert settings.external_servers() == []
+
+
+def test_servers_hidden_until_enabled() -> None:
+    """A configured, active server is not discovered while the feature is off."""
+    settings.acknowledge_external_mcp()
+    _add()
+    assert settings.external_servers() == []
+    settings.set_external_mcp_enabled(True)
+    assert [s["name"] for s in settings.external_servers()] == ["pubmed"]
+
+
+# ── validation ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"name": "Bad Name"}, "invalid server name"),
+        ({"transport": "stdio"}, "invalid transport"),
+        ({"url": "ftp://example.org"}, "invalid url"),
+        ({"url": "not-a-url"}, "invalid url"),
+        ({"api_key_env": "not valid!"}, "invalid environment variable"),
+    ],
+)
+def test_rejects_bad_input(kwargs: dict[str, Any], match: str) -> None:
+    """Each field is validated before anything is written."""
+    settings.acknowledge_external_mcp()
+    with pytest.raises(ValueError, match=match):
+        _add(**kwargs)
+    assert settings.load_external_mcp()["servers"] == []
+
+
+def test_stdio_is_not_an_allowed_transport() -> None:
+    """Stdio would mean launching an arbitrary binary on the host — not offered."""
+    assert "stdio" not in settings.EXTERNAL_MCP_TRANSPORTS
+
+
+def test_duplicate_name_rejected() -> None:
+    """Two servers cannot share a name."""
+    settings.acknowledge_external_mcp()
+    _add()
+    with pytest.raises(ValueError, match="already exists"):
+        _add()
+
+
+def test_cannot_shadow_an_installed_stack(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A remote entry must not be able to take an audited local stack's name."""
+    monkeypatch.setattr(
+        settings,
+        "load_mcp_servers",
+        lambda: [{"name": "medmcp-neuro", "command": "/bin/medmcp-neuro"}],
+    )
+    settings.acknowledge_external_mcp()
+    with pytest.raises(ValueError, match="already the name of an installed stack"):
+        _add("medmcp-neuro")
+
+
+# ── discovery + sync ─────────────────────────────────────────────────────────
+
+
+def test_sync_writes_http_entry_without_command(tmp_path: Path) -> None:
+    """The synced entry is an HTTP server: transport + url, and no command/args."""
+    settings.acknowledge_external_mcp()
+    settings.set_external_mcp_enabled(True)
+    _add(api_key_env="PUBMED_TOKEN")
+    settings.load_mcp_servers.cache_clear()
+
+    settings.sync_servers_to_vibe_config(settings.active_servers())
+    entry = _entries(tmp_path)["pubmed"]
+    assert entry["transport"] == "streamable-http"
+    assert entry["url"] == "https://example.org/mcp"
+    assert "command" not in entry
+    assert "args" not in entry
+    assert entry["auth"] == {"type": "static", "api_key_env": "PUBMED_TOKEN"}
+
+
+@pytest.mark.parametrize("env_var", ["", "PUBMED_TOKEN"])
+def test_generated_entry_validates_against_vibes_own_model(
+    tmp_path: Path, env_var: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """What we write must satisfy vibe's schema, not merely look plausible.
+
+    vibe's ``MCPAuth`` is a discriminated union whose members forbid extra keys,
+    so a missing ``type`` or a misspelled field is a hard validation error and the
+    server silently fails to load. Asserting our own dict shape cannot catch that
+    — only vibe's model can, so parse the real synced entry with it.
+    """
+    from vibe.core.config.models import (  # pyright: ignore[reportMissingTypeStubs]  # vibe ships no stubs
+        MCPStreamableHttp,
+    )
+
+    settings.acknowledge_external_mcp()
+    settings.set_external_mcp_enabled(True)
+    _add(api_key_env=env_var)
+    settings.load_mcp_servers.cache_clear()
+    settings.sync_servers_to_vibe_config(settings.active_servers())
+
+    parsed = MCPStreamableHttp.model_validate(_entries(tmp_path)["pubmed"])
+    assert parsed.url == "https://example.org/mcp"
+
+    # And the token actually reaches the wire, read from the environment at
+    # request time rather than from anything we stored.
+    if env_var:
+        monkeypatch.setenv(env_var, "s3cret")
+        assert parsed.http_headers() == {"Authorization": "Bearer s3cret"}
+    else:
+        assert parsed.http_headers() == {}
+
+
+def test_custom_header_and_format_reach_the_wire(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An API-key service (non-bearer) is configurable and sends the right header."""
+    from vibe.core.config.models import (  # pyright: ignore[reportMissingTypeStubs]  # vibe ships no stubs
+        MCPStreamableHttp,
+    )
+
+    settings.acknowledge_external_mcp()
+    settings.set_external_mcp_enabled(True)
+    _add(api_key_env="SVC_KEY", api_key_header="X-API-Key", api_key_format="{token}")
+    settings.load_mcp_servers.cache_clear()
+    settings.sync_servers_to_vibe_config(settings.active_servers())
+
+    monkeypatch.setenv("SVC_KEY", "abc123")
+    parsed = MCPStreamableHttp.model_validate(_entries(tmp_path)["pubmed"])
+    assert parsed.http_headers() == {"X-API-Key": "abc123"}
+
+
+def test_default_scheme_writes_no_override_keys(tmp_path: Path) -> None:
+    """A bearer-token server produces the same config it did before these fields."""
+    settings.acknowledge_external_mcp()
+    settings.set_external_mcp_enabled(True)
+    _add(api_key_env="TOK")
+    settings.load_mcp_servers.cache_clear()
+    settings.sync_servers_to_vibe_config(settings.active_servers())
+    assert _entries(tmp_path)["pubmed"]["auth"] == {"type": "static", "api_key_env": "TOK"}
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"api_key_env": "T", "api_key_header": "bad header"}, "invalid header name"),
+        ({"api_key_env": "T", "api_key_format": "Bearer"}, "must contain"),
+        ({"api_key_env": "T", "api_key_format": "{token} {other}"}, "may only reference"),
+        ({"api_key_env": "T", "api_key_format": "{{token}}"}, "must contain"),
+        ({"api_key_header": "X-API-Key"}, "needs an environment variable"),
+    ],
+)
+def test_rejects_bad_auth_scheme(kwargs: dict[str, Any], match: str) -> None:
+    """Header/format are validated the same way vibe validates them.
+
+    The last case matters most: vibe silently ignores these fields without a
+    token, so storing them would look configured and do nothing.
+    """
+    settings.acknowledge_external_mcp()
+    with pytest.raises(ValueError, match=match):
+        _add(**kwargs)
+
+
+def test_added_server_is_active_even_with_an_explicit_active_set() -> None:
+    """Once active_stacks.json exists it is an explicit list, so add must join it."""
+    settings.save_active_server_names({"medmcp-neuro"})
+    settings.acknowledge_external_mcp()
+    settings.set_external_mcp_enabled(True)
+    _add()
+    settings.load_mcp_servers.cache_clear()
+    assert "pubmed" in settings.load_active_server_names()
+    assert "pubmed" in [s["name"] for s in settings.active_servers()]
+
+
+def test_no_token_is_ever_written(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Only the env var *name* reaches disk — never the credential it holds.
+
+    Asserts on the secret's value rather than on field names, so it keeps testing
+    the actual property as the stored shape grows.
+    """
+    monkeypatch.setenv("PUBMED_TOKEN", "s3cret-do-not-persist")
+    settings.acknowledge_external_mcp()
+    settings.set_external_mcp_enabled(True)
+    _add(api_key_env="PUBMED_TOKEN")
+    settings.load_mcp_servers.cache_clear()
+    settings.sync_servers_to_vibe_config(settings.active_servers())
+
+    for path in (tmp_path / "external_mcp.json", tmp_path / "config.toml"):
+        text = path.read_text()
+        assert "PUBMED_TOKEN" in text  # the name is expected
+        assert "s3cret-do-not-persist" not in text  # the value must never be
+
+
+def test_disabling_removes_the_entries(tmp_path: Path) -> None:
+    """Turning the feature off takes the servers out of the vibe config."""
+    settings.acknowledge_external_mcp()
+    settings.set_external_mcp_enabled(True)
+    _add()
+    settings.load_mcp_servers.cache_clear()
+    settings.sync_servers_to_vibe_config(settings.active_servers())
+    assert "pubmed" in _entries(tmp_path)
+
+    settings.set_external_mcp_enabled(False)
+    settings.load_mcp_servers.cache_clear()
+    settings.sync_servers_to_vibe_config(settings.active_servers())
+    assert "pubmed" not in _entries(tmp_path)
+
+
+def test_synced_entry_is_not_readopted_as_a_stdio_stack(tmp_path: Path) -> None:
+    """Discovery must not pick its own HTTP output back up as a broken local stack."""
+    settings.acknowledge_external_mcp()
+    settings.set_external_mcp_enabled(True)
+    _add()
+    settings.load_mcp_servers.cache_clear()
+    settings.sync_servers_to_vibe_config(settings.active_servers())
+
+    settings.set_external_mcp_enabled(False)
+    settings.load_mcp_servers.cache_clear()
+    assert [s["name"] for s in settings.load_mcp_servers()] == []
+
+
+def test_deactivating_one_server_leaves_it_configured(tmp_path: Path) -> None:
+    """Deactivating hides a server from discovery without forgetting its settings."""
+    settings.acknowledge_external_mcp()
+    settings.set_external_mcp_enabled(True)
+    _add()
+    settings.set_external_server_active("pubmed", False)
+    assert settings.external_servers() == []
+    assert len(cast("list[JsonDict]", settings.load_external_mcp()["servers"])) == 1
+
+
+def test_remove_unknown_server_raises() -> None:
+    """Removing a name that was never registered is a 404, not a silent no-op."""
+    with pytest.raises(FileNotFoundError):
+        settings.remove_external_server("nope")
+
+
+# ── system prompt ────────────────────────────────────────────────────────────
+
+
+def test_prompt_switches_only_while_external_is_in_use(tmp_path: Path) -> None:
+    """The relaxed prompt applies when an external server is active, and not otherwise."""
+    settings.sync_servers_to_vibe_config([])
+    with (tmp_path / "config.toml").open("rb") as fh:
+        assert tomllib.load(fh)["system_prompt_id"] == settings.BASE_SYSTEM_PROMPT_ID
+
+    settings.acknowledge_external_mcp()
+    settings.set_external_mcp_enabled(True)
+    _add()
+    settings.load_mcp_servers.cache_clear()
+    settings.sync_servers_to_vibe_config(settings.active_servers())
+
+    with (tmp_path / "config.toml").open("rb") as fh:
+        assert tomllib.load(fh)["system_prompt_id"] == settings.EXTERNAL_SYSTEM_PROMPT_ID
+    variant = (tmp_path / "prompts" / f"{settings.EXTERNAL_SYSTEM_PROMPT_ID}.md").read_text()
+    assert settings.ONPREM_RULE not in variant
+    assert settings.EXTERNAL_RULE in variant
+
+    settings.set_external_mcp_enabled(False)
+    settings.load_mcp_servers.cache_clear()
+    settings.sync_servers_to_vibe_config(settings.active_servers())
+    with (tmp_path / "config.toml").open("rb") as fh:
+        assert tomllib.load(fh)["system_prompt_id"] == settings.BASE_SYSTEM_PROMPT_ID
+
+
+def test_custom_prompt_id_is_left_alone(tmp_path: Path) -> None:
+    """Only a prompt id this sync owns is rewritten."""
+    (tmp_path / "config.toml").write_text('system_prompt_id = "my-own"\n')
+    settings.sync_servers_to_vibe_config([])
+    with (tmp_path / "config.toml").open("rb") as fh:
+        assert tomllib.load(fh)["system_prompt_id"] == "my-own"
+
+
+def test_missing_anchor_keeps_the_base_prompt(tmp_path: Path) -> None:
+    """A prompt edit that drops the rule must not silently yield a no-op variant."""
+    (tmp_path / "prompts" / "medmcp.md").write_text("You are MedMCP.\n")
+    assert settings.write_external_prompt_variant() is False
+
+    settings.acknowledge_external_mcp()
+    settings.set_external_mcp_enabled(True)
+    _add()
+    settings.load_mcp_servers.cache_clear()
+    settings.sync_servers_to_vibe_config(settings.active_servers())
+    with (tmp_path / "config.toml").open("rb") as fh:
+        assert tomllib.load(fh)["system_prompt_id"] == settings.BASE_SYSTEM_PROMPT_ID
+
+
+def test_shipped_prompt_still_contains_the_anchor() -> None:
+    """Guards the real prompt against drift.
+
+    ``write_external_prompt_variant`` degrades to "keep the base prompt" when the
+    rule it rewrites is gone, which is the safe direction but also a silent one —
+    the feature would just stop relaxing the prompt. This fails loudly instead.
+    """
+    shipped = Path(__file__).resolve().parents[1] / ".vibe" / "prompts" / "medmcp.md"
+    assert settings.ONPREM_RULE in shipped.read_text()


### PR DESCRIPTION
## Summary

Two independent changes, bundled at the author's request:

- **External MCP servers** (Settings → Advanced, off by default) — lets the agent
  reach MCP tool services hosted outside this machine, behind an explicit consent
  gate, alongside the local imaging stacks.
- **Planning with the `todo` tool** — the tool was enabled and auto-approved but
  never mentioned in the system prompt, so a multi-part request was worked
  through invisibly.

## Related issue

N/A.

## Test plan

- [x] `just check` — 460 passed, 2 skipped; `npm run lint` + `npm run build` clean
- [x] New `tests/test_external_mcp.py` (25 tests): the double gate, transport/URL/env-var validation, no-token-at-rest, non-shadowing, the prompt switch, and the derived `auth` block validated against **vibe's own `MCPStreamableHttp` model** (a shape assertion cannot catch a missing discriminator)
- [x] Custom header/format reaches the wire: `X-API-Key: abc123` with the env var set
- [x] Live: enabled through the real consent dialog, added a real remote server (DeepWiki, `streamable-http`, no auth) and confirmed the agent listed its tools beside `medmcp-neuro-core`
- [x] Live: `compose config` shows a token from `medmcp.env` landing in the core service; absent file still validates
- [x] UI checked in a real browser: consent dialog renders, **Enable** stays disabled until the box is ticked, backdrop is topmost over the drawer
- [x] Live: a three-part imaging request produced a `todo` call after a short look around and before the pipeline began

## Security & data handling

**This is the one feature that ends the on-premise guarantee, so the review
should focus here.**

- Off by default and gated **twice**: discovery consults `external_mcp_enabled()`
  (toggle **and** recorded acknowledgement), never the stored flag alone, so a
  hand-edited state file claiming `enabled` without an acknowledgement stays off.
- **Remote HTTP transports only.** A stdio entry would mean launching an
  arbitrary binary on the host — categorically larger than a network call the
  permission flow already gates.
- **No credential at rest.** Only the *name* of an environment variable is
  stored; `config.toml` is rewritten on every sync and readable by anything in
  the container. A test asserts the secret's value never appears on disk. Values
  reach the container through an optional `env_file` (`medmcp.env`, gitignored).
- An external name **may not shadow an installed stack**, or a remote server
  could take an audited local tool set's name.
- Every mutation is audit-logged and restarts the agent. No auto-approval path is
  added: each tool call still requires an explicit click.
- With a server active the system prompt switches to a variant that drops the
  "never send data to external services" rule, since the operator has accepted
  responsibility for it. The variant is **derived** from the base prompt at sync
  time (one substitution), and a test fails if the substituted rule is ever
  edited out — otherwise the feature would silently stop relaxing anything.

**OAuth is deliberately not wired up.** vibe supports it, but stores tokens in
the OS keyring and the container has `keyring.backends.fail.Keyring`; a
file-backed store would put refresh tokens on disk and give up the property that
makes env-var-only correct. Most OAuth-advertising MCP servers accept a personal
access token through the static path (verified against GitHub and Linear, both of
which challenge with `Bearer`).

## Notes

The two changes are unrelated and were developed on separate branches
(`feat/external-mcp-servers`, `feat/prompt-todo-planning`, both pushed); they are
combined here only because a single PR was requested. They can be reviewed
independently — the second is two files.

Known rough edges in the external-MCP API, left for a follow-up: adding a server
while the feature is disabled returns `ok: true` with no indication it will not be
used, and `active_stacks.json` accumulates the names of removed servers.
