### PR TITLE
feat(prompt): plan multi-part requests with the todo tool

### DIFF
--- a/.vibe/prompts/medmcp.md
+++ b/.vibe/prompts/medmcp.md
@@ -35,6 +35,12 @@ analysis pipelines through natural-language instructions.
 - When a tool result contains a `_render` field, follow its instructions exactly to
   produce your response — it contains per-call display rules and a required next action.
 
+**Planning multi-step work**
+- Whenever the user asks for more than one thing, write the parts to the `todo` tool — always, even when each part looks small. Look around first if you need to understand what is being asked; write the list before you start doing the work. Then keep it current: set a step to `in_progress` when you start it and `completed` when it lands.
+- `action: "write"` replaces the whole list. Send every item each time, reusing each item's `id`; sending only the one that changed deletes the rest.
+- Keep one step `in_progress` at a time.
+- A request for a single thing needs no list.
+
 **Skills**
 - Before starting any task, load the skill that matches the task name.
 - If no matching skill exists, proceed without one — do not block or invent skill names.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Notable, user-visible changes to MedMCP. Format follows
 
 ## Unreleased
 
+### Changed
+
+- **The agent now keeps a visible task list when you ask for more than one
+  thing.** Multi-part requests — strip this scan, register it, then report the
+  volumes — are written out as a checklist before the work starts and ticked off
+  as each part lands, so you can see what it understood you to be asking and how
+  far it has got. Single requests are unaffected.
+
 ### Fixed
 
 - **Tool stacks no longer go missing on the first run after installing them.**


### PR DESCRIPTION
## Summary

The `todo` tool was enabled and auto-approved but never mentioned in the system
prompt, so the agent had no reason to reach for it: a request with three parts
was worked through invisibly, with nothing on screen saying what it had taken the
request to mean or how far it had got. The prompt now asks for a task list
whenever the user asks for more than one thing.

## Related issue

N/A.

## Test plan

- [x] `just check` — 426 passed, 2 skipped
- [x] Live against the running agent: a three-part imaging request ("skull-strip
      the T1, then register to MNI, then tell me the output names") produced a
      `todo` call, after a short look around and before the pipeline began
- [x] The two `bash` permission prompts in that run were **declined**, so nothing
      ran on real data

## Security & data handling

N/A — prompt text only. No new tool surface: `todo` was already enabled and
already auto-approved (`permission = "always"`), and this does not change any
permission.

## Notes

Exploring before planning is allowed on purpose. An earlier draft demanded that
`todo` be the *first* tool call; understanding a request often needs a look at
the workspace first, so the requirement is only that the list exists before the
work starts.

The prompt also spells out that `action: "write"` replaces the entire list.
Sending only the item that changed silently deletes the rest — the failure mode
that would make a task list untrustworthy exactly when it is most useful.

Worth setting expectations: this is a nudge, not a guarantee. In a second live
check, a two-part question was answered directly without a list. The prompt
raises the odds; it cannot bind a local model. If it needs to be dependable, a
turn-level check would be the lever, not prompt wording.
