### PR TITLE
ci(images): stop concurrent builds racing for the :main tag

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -22,6 +22,23 @@ permissions:
   contents: read
   packages: write
 
+# Two merges landing close together used to race: both runs push the bare
+# :main tag, and whichever finished LAST won it — which was the run that had
+# started FIRST if it happened to be slower. That is how :main came to point at
+# an image built from the older commit, with nothing failing and nothing in the
+# logs to say the tag had gone backwards.
+#
+# Queue rather than cancel on main. Cancelling would fix the ordering too, but a
+# superseded commit would then never publish its :<sha> image, and those are what
+# a rollback pins to. Queued, the newer run simply finishes last and wins the tag.
+# Pull requests do cancel: a superseded PR build has nothing to publish and is
+# only spending runner time. (When several pushes queue at once GitHub keeps just
+# the newest pending run, so intermediate commits can still miss their :<sha>
+# image — the tip is always correct, which is what :main consumers depend on.)
+concurrency:
+  group: images-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CUDA_TAG: "12.8.1"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Notable, user-visible changes to MedMCP. Format follows
 
 ## Unreleased
 
+### Fixed
+
+- **Published images can no longer go backwards.** Two changes merged close
+  together could leave the `:main` image built from the *older* of them, because
+  both builds pushed the same tag and the one that started first sometimes
+  finished last. Nothing failed and nothing said the tag had moved backwards, so
+  a `docker compose pull` could quietly hand you an image missing the change you
+  had just merged. Image builds are now ordered, so the newest commit always wins
+  the tag.
+
 ### Changed
 
 - **The agent now keeps a visible task list when you ask for more than one


### PR DESCRIPTION
## Summary

Two merges a minute apart both triggered an `Images` run, and both pushed the bare `:main` tag. The run that started *first* finished *last*, so `:main` ended up built from the older commit. A `concurrency` group serializes them so the newest commit always wins the tag.

## Related issue

N/A — hit for real on 2026-08-18:

```
32152558972  f3c7d57  Images  success  started 15:07:39   ← newer commit
32152480115  be782a6  Images  success  started 15:06:50   ← finished last, won :main
```

The published `:main` (built 15:09:35) carried #106 but not #108. Nothing failed and no job was skipped; the only symptom was a `docker compose pull` that quietly lacked a change already on `main`. Re-running the newer build fixed the tag.

## Test plan

- [x] `.github/workflows/images.yml` parses; `pre-commit run check-yaml` passes
- [x] `concurrency.group` / `cancel-in-progress` resolve as intended (`images-${{ github.ref }}`, cancel only on `pull_request`)
- [x] `just check` — 441 passed, 2 skipped
- [ ] Real verification needs two pushes to `main` in quick succession, which only happens on merge — worth watching the next time two PRs land together

## Security & data handling

N/A — CI configuration only. No change to what is built, pushed, or to the `packages: write` permission.

## Notes

**Queue rather than cancel on `main`.** Cancelling would fix the ordering just as well, but a superseded commit would never publish its `:<sha>` image, and those are what a rollback pins to. Queued, the newer run finishes last and wins the tag. Pull requests keep `cancel-in-progress`, where a superseded build has nothing to publish and is only burning runner time.

**This narrows the window rather than closing it**, and the comment in the file says so:

- GitHub keeps only the newest *pending* run, so a burst of pushes can still leave intermediate commits without a `:<sha>` image. The tip is always correct, which is what `:main` consumers depend on.
- Two runs overlapping at the arch-tag stage could in principle have their `-amd64`/`-arm64` handoff tags merged across runs.

The complete fix is to build `:<sha>` only and re-point `:main` from it in the merge job, so the bare tag moves atomically from a known-good manifest. That is a larger change than this defect warrants today, but it is the direction if this recurs.
