### PR TITLE
feat(stacks): offer the TotalSegmentator stack in the catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ Notable, user-visible changes to MedMCP. Format follows
 [Keep a Changelog](https://keepachangelog.com/); entries land under
 **Unreleased** as PRs merge and move under a version heading at release time.
 
+## Unreleased
+
+### Added
+
+- **TotalSegmentator stack** in Settings → Stacks. Segments anatomical structures
+  on whole-body CT and MR — 117 structures in one pass with the general model,
+  plus focused models for the spine, lungs, liver, head and neck, and teeth — and
+  reports per-structure volumes. Requires a GPU.
+
 ## 0.1.0
 
 First public release. MedMCP is an on-premise agentic framework that exposes

--- a/catalog.ghcr.json
+++ b/catalog.ghcr.json
@@ -18,6 +18,12 @@
       "image": "ghcr.io/medmcp/neuro-ms:main",
       "description": "MS white-matter lesion segmentation and lesion load (LST-AI).",
       "gpu": true
+    },
+    {
+      "name": "medmcp-totalsegmentator",
+      "image": "ghcr.io/medmcp/totalsegmentator:main",
+      "description": "Whole-body anatomy segmentation on CT and MR (TotalSegmentator): 31 tasks, 117 structures.",
+      "gpu": true
     }
   ]
 }

--- a/catalog.json
+++ b/catalog.json
@@ -18,6 +18,12 @@
       "image": "medmcp-neuro-ms:dev",
       "description": "MS white-matter lesion segmentation and lesion load (LST-AI).",
       "gpu": true
+    },
+    {
+      "name": "medmcp-totalsegmentator",
+      "image": "medmcp-totalsegmentator:dev",
+      "description": "Whole-body anatomy segmentation on CT and MR (TotalSegmentator): 31 tasks, 117 structures.",
+      "gpu": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds `medmcp-totalsegmentator` to the stack catalog, so it appears in **Settings → Stacks → Available** and can be installed with one click. It segments anatomical structures on whole-body CT and MR — 117 structures in one pass with the general model, plus focused models for the spine, lungs, liver, head and neck, and teeth — and reports per-structure volumes. GPU stack.

The stack itself lives in [medmcp/medmcp-totalsegmentator](https://github.com/medmcp/medmcp-totalsegmentator). Only the Apache-2.0 licensed weights are bundled; the licence-gated tasks and the CC BY-NC aneurysm model are deliberately not included.

## Related issue

N/A.

## Test plan

- [x] `just check` passes (453 passed, 2 skipped)
- [x] Both catalog files parse, and the entry names match the image's `org.medmcp.stack` label (`medmcp-totalsegmentator`), which is what `install_stack_image` reads
- [x] `ghcr.io/medmcp/totalsegmentator:main` is published **before** this lands, as a real multi-arch manifest (`linux/amd64` + `linux/arm64`) — verified with `docker buildx imagetools inspect`. Merging earlier would have put an install button in the UI that 404s
- [ ] **Not yet done: installing it through the UI.** Nobody has run the published image; the CI build checks the label and architecture but cannot smoke-test a 21.5 GB image on a runner. This is the next step after merge

## Screenshots

N/A — catalog data only, no UI change.

## Security & data handling

No new tool surface in this repo. The stack it points at runs under the existing container isolation (`--network none`, `--cap-drop ALL`, `no-new-privileges`, workspace bind-mount only), and every model weight is baked into the image so it makes no network calls at run time. TotalSegmentator's upstream usage reporting is disabled in the image.

## Notes

- The image is large (~21.5 GB): ~9.8 GB of model weights on top of the CUDA/PyTorch stack. Installing it pulls that once.
- `catalog.json` points at the local `:dev` tag for development; `catalog.ghcr.json` at the published image.
