### PR TITLE
feat: connect external MCP servers behind an explicit consent gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -224,6 +224,11 @@ __marimo__/
 # copy the image ships lives at docker/hooks.toml).
 .vibe/hooks.toml
 .vibe/pathguard_retries.json
+.vibe/external_mcp.json
+# Tokens for external MCP servers, passed to the core container via env_file.
+medmcp.env
+# Derived from .vibe/prompts/medmcp.md at sync time when external MCP is in use.
+.vibe/prompts/medmcp-external.md
 .vibe/provenance/
 .vibe/workflows/
 data/

--- a/.gitignore
+++ b/.gitignore
@@ -214,8 +214,6 @@ __marimo__/
 .vibe/vibehistory
 .vibe/trusted_folders.toml
 .vibe/active_stacks.json
-.vibe/active_workflows.json
-.vibe/workflows_enabled.json
 .vibe/provenance_enabled.json
 .vibe/explain_enabled.json
 .vibe/ui_sessions.json
@@ -231,7 +229,6 @@ __marimo__/
 data/
 node_modules/
 frontend/dist/
-.vibe/explain_enabled.json
 
 # Container-stack manifests + extracted skills are runtime state written by the
 # UI install flow; keep only the directory (README) in git.

--- a/.gitignore
+++ b/.gitignore
@@ -224,7 +224,7 @@ __marimo__/
 # copy the image ships lives at docker/hooks.toml).
 .vibe/hooks.toml
 .vibe/pathguard_retries.json
-.vibe/external_mcp.json
+.vibe/state/
 # Tokens for external MCP servers, passed to the core container via env_file.
 medmcp.env
 # Derived from .vibe/prompts/medmcp.md at sync time when external MCP is in use.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ Notable, user-visible changes to MedMCP. Format follows
   Because this ends the guarantee that nothing leaves your infrastructure, the
   switch does not simply flip: it first explains what changes and asks you to
   accept responsibility for what those services receive. Nothing is connected
-  until you do, and turning it off removes the servers from the agent again.
+  until you do, and turning it off both removes the servers from the agent and
+  withdraws your acceptance, so switching it back on asks again.
   Servers are addressed by URL (`streamable-http` or `http`); if one needs a
   token, you give the *name* of an environment variable rather than the token, so
   no credential is ever written to disk. Tokens are sent as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,10 @@ Notable, user-visible changes to MedMCP. Format follows
   Individual servers can be switched off without deleting them, and every tool
   call still asks for your approval. While anything external is connected, a red
   strip under the header says so from every panel, names the servers, and offers
-  a one-click disconnect — the settings switch is easy to forget, this is not. To supply a token, put `NAME=value` lines in
+  a one-click disconnect — the settings switch is easy to forget, this is not.
+  Turning it off disconnects every server at once, whatever their individual
+  switches say, and the setting states plainly that nothing is connected any
+  more; the agent is restarted so nothing already running keeps a connection. To supply a token, put `NAME=value` lines in
   a `medmcp.env` file next to your compose file (or point `MEDMCP_ENV_FILE` at
   one); it is optional and read only if present.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,9 @@ Notable, user-visible changes to MedMCP. Format follows
   the agent is restarted so nothing already running keeps a connection. Servers
   and your acceptance are kept across restarts and updates. To supply a token, put `NAME=value` lines in
   a `medmcp.env` file next to your compose file (or point `MEDMCP_ENV_FILE` at
-  one); it is optional and read only if present.
+  one); it is optional and read only if present. If the variable turns out not to
+  be set where the agent runs, the setting says so — rather than leaving you with
+  an unexplained rejection from the service.
 
 ## 0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,12 @@ Notable, user-visible changes to MedMCP. Format follows
   until you do, and turning it off both removes the servers from the agent and
   withdraws your acceptance, so switching it back on asks again.
   Servers are addressed by URL (`streamable-http` or `http`); if one needs a
-  token, you give the *name* of an environment variable rather than the token, so
-  no credential is ever written to disk. Tokens are sent as
-  `Authorization: Bearer …` by default, and services that expect something else
-  (an `X-API-Key` header, say) can set the header and value format themselves.
+  token, you paste it into the form. It is kept on this machine, handed to the
+  agent when it starts, and never written into the agent's configuration or sent
+  back to the browser — you can replace it later, but nothing can read it out.
+  Tokens are sent as `Authorization: Bearer …` by default, and services that
+  expect something else (an `X-API-Key` header, say) can set the header and value
+  format themselves.
   Individual servers can be switched off without deleting them, and every tool
   call still asks for your approval. While anything external is enabled, a red
   strip under the header says so from every panel, names the servers, and turns
@@ -33,11 +35,12 @@ Notable, user-visible changes to MedMCP. Format follows
   Turning it off applies to every server at once, whatever their individual
   switches say, and the setting states plainly that nothing is enabled any more;
   the agent is restarted so nothing already running keeps a connection. Servers
-  and your acceptance are kept across restarts and updates. To supply a token, put `NAME=value` lines in
-  a `medmcp.env` file next to your compose file (or point `MEDMCP_ENV_FILE` at
-  one); it is optional and read only if present. If the variable turns out not to
-  be set where the agent runs, the setting says so — rather than leaving you with
-  an unexplained rejection from the service.
+  and your acceptance are kept across restarts and updates. A deployment that
+  manages its own secrets can name an environment variable instead of a token: put
+  `NAME=value` lines in a `medmcp.env` file next to your compose file (or point
+  `MEDMCP_ENV_FILE` at one), which is optional and read only if present. If a
+  named variable turns out not to be set where the agent runs, the setting says
+  so — rather than leaving you with an unexplained rejection from the service.
 
 ## 0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,12 +27,13 @@ Notable, user-visible changes to MedMCP. Format follows
   `Authorization: Bearer …` by default, and services that expect something else
   (an `X-API-Key` header, say) can set the header and value format themselves.
   Individual servers can be switched off without deleting them, and every tool
-  call still asks for your approval. While anything external is connected, a red
-  strip under the header says so from every panel, names the servers, and offers
-  a one-click disconnect — the settings switch is easy to forget, this is not.
-  Turning it off disconnects every server at once, whatever their individual
-  switches say, and the setting states plainly that nothing is connected any
-  more; the agent is restarted so nothing already running keeps a connection. To supply a token, put `NAME=value` lines in
+  call still asks for your approval. While anything external is enabled, a red
+  strip under the header says so from every panel, names the servers, and turns
+  them all off in one click — the settings switch is easy to forget, this is not.
+  Turning it off applies to every server at once, whatever their individual
+  switches say, and the setting states plainly that nothing is enabled any more;
+  the agent is restarted so nothing already running keeps a connection. Servers
+  and your acceptance are kept across restarts and updates. To supply a token, put `NAME=value` lines in
   a `medmcp.env` file next to your compose file (or point `MEDMCP_ENV_FILE` at
   one); it is optional and read only if present.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,9 @@ Notable, user-visible changes to MedMCP. Format follows
   `Authorization: Bearer …` by default, and services that expect something else
   (an `X-API-Key` header, say) can set the header and value format themselves.
   Individual servers can be switched off without deleting them, and every tool
-  call still asks for your approval. To supply a token, put `NAME=value` lines in
+  call still asks for your approval. While anything external is connected, a red
+  strip under the header says so from every panel, names the servers, and offers
+  a one-click disconnect — the settings switch is easy to forget, this is not. To supply a token, put `NAME=value` lines in
   a `medmcp.env` file next to your compose file (or point `MEDMCP_ENV_FILE` at
   one); it is optional and read only if present.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ Notable, user-visible changes to MedMCP. Format follows
   the general CT model and 50 with the MR one, plus focused models for the spine,
   lungs, liver, head and neck, and teeth — and reports per-structure volumes. A
   GPU is strongly recommended; it also runs on CPU, considerably more slowly.
+- **External MCP servers** (Settings → Advanced, off by default). Lets you connect
+  the agent to MCP tool services hosted outside your machine — a literature
+  search, a hospital system, a vendor API — alongside your local imaging stacks.
+  Because this ends the guarantee that nothing leaves your infrastructure, the
+  switch does not simply flip: it first explains what changes and asks you to
+  accept responsibility for what those services receive. Nothing is connected
+  until you do, and turning it off removes the servers from the agent again.
+  Servers are addressed by URL (`streamable-http` or `http`); if one needs a
+  token, you give the *name* of an environment variable rather than the token, so
+  no credential is ever written to disk. Tokens are sent as
+  `Authorization: Bearer …` by default, and services that expect something else
+  (an `X-API-Key` header, say) can set the header and value format themselves.
+  Individual servers can be switched off without deleting them, and every tool
+  call still asks for your approval. To supply a token, put `NAME=value` lines in
+  a `medmcp.env` file next to your compose file (or point `MEDMCP_ENV_FILE` at
+  one); it is optional and read only if present.
 
 ## 0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@ Notable, user-visible changes to MedMCP. Format follows
 
 ### Added
 
-- **TotalSegmentator stack** in Settings → Stacks. Segments anatomical structures
-  on whole-body CT and MR — 117 structures in one pass with the general model,
-  plus focused models for the spine, lungs, liver, head and neck, and teeth — and
-  reports per-structure volumes. Requires a GPU.
+- **TotalSegmentator stack**, installable from the Tool stacks window. Segments
+  anatomical structures on whole-body CT and MR — 117 structures in one pass with
+  the general CT model and 50 with the MR one, plus focused models for the spine,
+  lungs, liver, head and neck, and teeth — and reports per-structure volumes. A
+  GPU is strongly recommended; it also runs on CPU, considerably more slowly.
 
 ## 0.1.0
 

--- a/catalog.ghcr.json
+++ b/catalog.ghcr.json
@@ -22,7 +22,7 @@
     {
       "name": "medmcp-totalsegmentator",
       "image": "ghcr.io/medmcp/totalsegmentator:main",
-      "description": "Whole-body anatomy segmentation on CT and MR (TotalSegmentator): 31 tasks, 117 structures.",
+      "description": "Whole-body anatomy segmentation on CT and MR, plus focused models for the spine, lungs, liver, head and neck, and teeth (TotalSegmentator).",
       "gpu": true
     }
   ]

--- a/catalog.json
+++ b/catalog.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Curated catalog of installable MedMCP tool stacks shown in the UI (Settings -> Stacks -> Available). Override the source with MEDMCP_CATALOG_URL (an http(s) URL or a file path) to point at a published/air-gapped-mirror catalog; image refs there are typically ghcr.io/medmcp/<stack>:<tag>. The bundled defaults below use the locally built :dev images.",
+  "_comment": "Curated catalog of installable MedMCP tool stacks shown in the UI (the Tool stacks window). Override the source with MEDMCP_CATALOG_URL (an http(s) URL or a file path) to point at a published/air-gapped-mirror catalog; image refs there are typically ghcr.io/medmcp/<stack>:<tag>. The bundled defaults below use the locally built :dev images.",
   "stacks": [
     {
       "name": "medmcp-dicom",
@@ -22,7 +22,7 @@
     {
       "name": "medmcp-totalsegmentator",
       "image": "medmcp-totalsegmentator:dev",
-      "description": "Whole-body anatomy segmentation on CT and MR (TotalSegmentator): 31 tasks, 117 structures.",
+      "description": "Whole-body anatomy segmentation on CT and MR, plus focused models for the spine, lungs, liver, head and neck, and teeth (TotalSegmentator).",
       "gpu": true
     }
   ]

--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -154,6 +154,9 @@ services:
       - "vibe-workflows:/app/.vibe/workflows"
       - "vibe-provenance:/app/.vibe/provenance"
       - "vibe-logs:/app/.vibe/logs"
+      # External MCP servers and the consent that armed them. Losing these on an
+      # image update would silently disconnect a configured setup.
+      - "vibe-state:/app/.vibe/state"
       # Host registry creds, read-only at a staging path — the entrypoint copies
       # only `auths` to /root/.docker/config.json, dropping the host's
       # `currentContext` (which would break every in-container stack pull/run).
@@ -166,3 +169,4 @@ volumes:
   vibe-workflows:
   vibe-provenance:
   vibe-logs:
+  vibe-state:

--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -93,6 +93,15 @@ services:
         condition: service_healthy
       llm-init:
         condition: service_completed_successfully
+    # Secrets for external MCP servers (Settings -> Advanced). The UI stores only
+    # the *name* of an environment variable, never a token, so the value has to
+    # reach this container some other way — and `environment:` below is a fixed
+    # allowlist that cannot forward a variable it does not already name. Put
+    # `MY_SERVICE_TOKEN=...` lines in this file (default ./medmcp.env, override
+    # with MEDMCP_ENV_FILE). Optional: absent is not an error.
+    env_file:
+      - path: ${MEDMCP_ENV_FILE:-./medmcp.env}
+        required: false
     environment:
       OLLAMA_BASE_URL: "http://llm:11434"
       # Names the model for both the agent's chat (the entrypoint writes it into

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,6 +144,9 @@ services:
       - "vibe-workflows:/app/.vibe/workflows"
       - "vibe-provenance:/app/.vibe/provenance"
       - "vibe-logs:/app/.vibe/logs"
+      # External MCP servers and the consent that armed them. Losing these on an
+      # image update would silently disconnect a configured setup.
+      - "vibe-state:/app/.vibe/state"
       # Host registry creds, read-only at a staging path — the entrypoint copies
       # only `auths` to /root/.docker/config.json, dropping the host's
       # `currentContext` (which would break every in-container stack pull/run).
@@ -158,3 +161,4 @@ volumes:
   vibe-workflows:
   vibe-provenance:
   vibe-logs:
+  vibe-state:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,6 +81,15 @@ services:
         condition: service_healthy
       llm-init:
         condition: service_completed_successfully
+    # Secrets for external MCP servers (Settings -> Advanced). The UI stores only
+    # the *name* of an environment variable, never a token, so the value has to
+    # reach this container some other way — and `environment:` below is a fixed
+    # allowlist that cannot forward a variable it does not already name. Put
+    # `MY_SERVICE_TOKEN=...` lines in this file (default ./medmcp.env, override
+    # with MEDMCP_ENV_FILE). Optional: absent is not an error.
+    env_file:
+      - path: ${MEDMCP_ENV_FILE:-./medmcp.env}
+        required: false
     environment:
       OLLAMA_BASE_URL: "http://llm:11434"
       # Names the model for both the agent's chat (the entrypoint writes it into

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Group, Panel, Separator } from 'react-resizable-panels'
 import { Chat } from './components/Chat'
+import { ExternalMcpBanner } from './components/ExternalMcpBanner'
 import { FileExplorer } from './components/FileExplorer'
 import { StackMarketplace } from './components/StackMarketplace'
 import { SettingsDrawer } from './components/SettingsDrawer'
@@ -20,6 +21,13 @@ export default function App() {
   // Files multi-selected in the explorer — feeds the workflow batch editor.
   const [selectedPaths, setSelectedPaths] = useState<string[]>([])
   const [settingsOpen, setSettingsOpen] = useState(false)
+  // Set when the settings drawer is opened from the external-MCP warning, so it
+  // lands on the control the banner is talking about.
+  const [settingsAdvanced, setSettingsAdvanced] = useState(false)
+  // Bumped whenever external-MCP state may have changed, so the standing
+  // warning re-reads it instead of waiting for a reload.
+  const [externalVersion, setExternalVersion] = useState(0)
+  const notifyExternalChanged = useCallback(() => setExternalVersion((v) => v + 1), [])
   const [marketOpen, setMarketOpen] = useState(false)
   // The vibe session that received the last prompt — what "Save chat as
   // workflow" distills. Survives a reconnect (which starts an empty session).
@@ -100,7 +108,23 @@ export default function App() {
           <GearIcon />
         </button>
       </header>
-      <SettingsDrawer open={settingsOpen} onClose={() => setSettingsOpen(false)} />
+      <ExternalMcpBanner
+        refreshSignal={externalVersion}
+        onReview={() => {
+          setSettingsAdvanced(true)
+          setSettingsOpen(true)
+        }}
+      />
+      <SettingsDrawer
+        open={settingsOpen}
+        onClose={() => {
+          setSettingsOpen(false)
+          setSettingsAdvanced(false)
+        }}
+        advancedOpen={settingsAdvanced}
+        onAdvancedToggle={setSettingsAdvanced}
+        onExternalChanged={notifyExternalChanged}
+      />
       <StackMarketplace open={marketOpen} onClose={() => setMarketOpen(false)} />
       <Group
         orientation="vertical"

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,6 +1,7 @@
 import type {
   BatchFromPlanResult,
   CatalogEntry,
+  ExternalMcpState,
   GpuInfo,
   InstalledStack,
   ReplayPreviewStep,
@@ -28,7 +29,11 @@ async function check(res: Response): Promise<Response> {
   return res
 }
 
-async function sendJson(method: 'POST' | 'PUT', url: string, body: object): Promise<Response> {
+async function sendJson(
+  method: 'POST' | 'PUT' | 'PATCH',
+  url: string,
+  body: object,
+): Promise<Response> {
   return check(
     await fetch(url, {
       method,
@@ -250,4 +255,43 @@ export async function batchFromPlan(name: string, planCsv: string): Promise<Batc
     plan_csv: planCsv,
   })
   return (await res.json()) as BatchFromPlanResult
+}
+
+// ── External MCP (advanced) ──────────────────────────────────
+// Every mutation restarts the agent server-side, so callers should refetch
+// rather than assume their optimistic view survived.
+
+export async function fetchExternalMcp(): Promise<ExternalMcpState> {
+  const res = await check(await fetch('/api/external-mcp'))
+  return (await res.json()) as ExternalMcpState
+}
+
+/** Record that the operator accepted the risks. Required before enabling. */
+export async function acknowledgeExternalMcp(): Promise<void> {
+  await postJson('/api/external-mcp/acknowledge', {})
+}
+
+export async function setExternalMcpEnabled(enabled: boolean): Promise<void> {
+  await sendJson('PUT', '/api/external-mcp', { enabled })
+}
+
+export async function addExternalServer(server: {
+  name: string
+  transport: string
+  url: string
+  api_key_env: string
+  api_key_header: string
+  api_key_format: string
+}): Promise<void> {
+  await postJson('/api/external-mcp/servers', server)
+}
+
+export async function setExternalServerActive(name: string, active: boolean): Promise<void> {
+  await sendJson('PATCH', `/api/external-mcp/servers/${encodeURIComponent(name)}`, { active })
+}
+
+export async function removeExternalServer(name: string): Promise<void> {
+  await check(
+    await fetch(`/api/external-mcp/servers/${encodeURIComponent(name)}`, { method: 'DELETE' }),
+  )
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -279,11 +279,18 @@ export async function addExternalServer(server: {
   name: string
   transport: string
   url: string
+  /** The token itself — stored server-side, never returned by any endpoint. */
+  token: string
   api_key_env: string
   api_key_header: string
   api_key_format: string
 }): Promise<void> {
   await postJson('/api/external-mcp/servers', server)
+}
+
+/** Replace one server's stored token. The value is write-only across this API. */
+export async function replaceExternalToken(name: string, token: string): Promise<void> {
+  await sendJson('PATCH', `/api/external-mcp/servers/${encodeURIComponent(name)}`, { token })
 }
 
 export async function setExternalServerActive(name: string, active: boolean): Promise<void> {

--- a/frontend/src/components/ExternalMcpBanner.tsx
+++ b/frontend/src/components/ExternalMcpBanner.tsx
@@ -1,0 +1,74 @@
+import { useCallback, useEffect, useState } from 'react'
+import { fetchExternalMcp, setExternalMcpEnabled } from '../api'
+import type { ExternalMcpState } from '../types'
+
+interface ExternalMcpBannerProps {
+  /** Bumped by anything that may have changed the external-MCP state. */
+  refreshSignal: number
+  /** Open the settings drawer on the section that owns this feature. */
+  onReview: () => void
+}
+
+/**
+ * A standing warning, shown for as long as external MCP servers are connected.
+ *
+ * The consent dialog is a moment; this is the reminder that outlives it. Someone
+ * who turned the feature on days ago — or who sat down at a workspace where
+ * somebody else did — has no cue that tool calls can now leave the machine,
+ * because the switch lives behind an Advanced disclosure inside a drawer that is
+ * closed almost all of the time. So the warning goes where the work happens.
+ *
+ * Deliberately not dismissible, and it carries the off switch itself: it stops
+ * when the thing it reports stops, and never because someone clicked it away.
+ */
+export function ExternalMcpBanner({ refreshSignal, onReview }: ExternalMcpBannerProps) {
+  const [state, setState] = useState<ExternalMcpState | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  const load = useCallback(() => {
+    // Best-effort: a failed read must not blank the app. It also must not leave
+    // a stale "connected" banner up, so the state is cleared either way.
+    fetchExternalMcp()
+      .then(setState)
+      .catch(() => setState(null))
+  }, [])
+
+  useEffect(load, [load, refreshSignal])
+
+  const disconnect = useCallback(() => {
+    setBusy(true)
+    setExternalMcpEnabled(false)
+      .catch(() => undefined)
+      .finally(() => {
+        setBusy(false)
+        load()
+      })
+  }, [load])
+
+  // The feature can be on with everything switched off; nothing is reachable
+  // then, so there is nothing to warn about.
+  const active = state?.enabled ? state.servers.filter((s) => s.active) : []
+  if (active.length === 0) return null
+
+  const plural = active.length === 1 ? '' : 's'
+  return (
+    <div className="ext-banner" role="status">
+      <span className="ext-banner-dot" aria-hidden="true" />
+      <span className="ext-banner-text">
+        <strong>
+          {active.length} external MCP server{plural} connected.
+        </strong>{' '}
+        What the agent sends {active.length === 1 ? 'it' : 'them'} leaves this machine.
+      </span>
+      <span className="ext-banner-names" title="Connected external servers">
+        {active.map((s) => s.name).join(', ')}
+      </span>
+      <button className="btn-plain ext-banner-action" onClick={onReview} disabled={busy}>
+        Review
+      </button>
+      <button className="btn-plain ext-banner-action" onClick={disconnect} disabled={busy}>
+        {busy ? 'Disconnecting…' : 'Disconnect all'}
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/components/ExternalMcpBanner.tsx
+++ b/frontend/src/components/ExternalMcpBanner.tsx
@@ -10,7 +10,12 @@ interface ExternalMcpBannerProps {
 }
 
 /**
- * A standing warning, shown for as long as external MCP servers are connected.
+ * A standing warning, shown for as long as external MCP servers are enabled.
+ *
+ * "Enabled", not "connected": nothing here observes a handshake. What is known
+ * is that the agent may reach these servers, which is the thing worth warning
+ * about — a server that is unreachable today answers tomorrow, and the warning
+ * should not have gone quiet in between.
  *
  * The consent dialog is a moment; this is the reminder that outlives it. Someone
  * who turned the feature on days ago — or who sat down at a workspace where
@@ -35,7 +40,7 @@ export function ExternalMcpBanner({ refreshSignal, onReview }: ExternalMcpBanner
 
   useEffect(load, [load, refreshSignal])
 
-  const disconnect = useCallback(() => {
+  const turnAllOff = useCallback(() => {
     setBusy(true)
     setExternalMcpEnabled(false)
       .catch(() => undefined)
@@ -56,18 +61,18 @@ export function ExternalMcpBanner({ refreshSignal, onReview }: ExternalMcpBanner
       <span className="ext-banner-dot" aria-hidden="true" />
       <span className="ext-banner-text">
         <strong>
-          {active.length} external MCP server{plural} connected.
+          {active.length} external MCP server{plural} enabled.
         </strong>{' '}
         What the agent sends {active.length === 1 ? 'it' : 'them'} leaves this machine.
       </span>
-      <span className="ext-banner-names" title="Connected external servers">
+      <span className="ext-banner-names" title="Enabled external servers">
         {active.map((s) => s.name).join(', ')}
       </span>
       <button className="btn-plain ext-banner-action" onClick={onReview} disabled={busy}>
         Review
       </button>
-      <button className="btn-plain ext-banner-action" onClick={disconnect} disabled={busy}>
-        {busy ? 'Disconnecting…' : 'Disconnect all'}
+      <button className="btn-plain ext-banner-action" onClick={turnAllOff} disabled={busy}>
+        {busy ? 'Turning off…' : 'Turn all off'}
       </button>
     </div>
   )

--- a/frontend/src/components/ExternalMcpSection.tsx
+++ b/frontend/src/components/ExternalMcpSection.tsx
@@ -116,6 +116,14 @@ export function ExternalMcpSection({ onChanged }: ExternalMcpSectionProps) {
                   {s.api_key_env ? ` · token from $${s.api_key_env}` : ' · no auth'}
                   {s.api_key_env && s.api_key_header ? ` · ${s.api_key_header}` : ''}
                 </div>
+                {/* Without this the only symptom is the remote service's 401:
+                    vibe sends the request unauthenticated rather than failing. */}
+                {s.api_key_env && s.token_present === false && (
+                  <div className="settings-row-hint ext-mcp-missing-token">
+                    ${s.api_key_env} is not set where the agent runs — requests go out with no
+                    credential. Add it to medmcp.env and recreate the container.
+                  </div>
+                )}
               </div>
               <div className="ext-mcp-server-actions">
                 <Toggle
@@ -303,8 +311,10 @@ function AddServerForm({
         {/* The token itself is never stored: only this name is written, and vibe
             reads the value from the environment the workspace was started in. */}
         <span className="settings-row-hint">
-          The name of an environment variable set where the workspace runs. The token itself is
-          never saved.
+          The name of an environment variable set where the workspace runs — not the token, which
+          is never saved. In the container install, put <code>NAME=value</code> in{' '}
+          <code>medmcp.env</code> next to your compose file and recreate the container; running on
+          the host, export it in the shell that starts the workspace.
         </span>
       </label>
 

--- a/frontend/src/components/ExternalMcpSection.tsx
+++ b/frontend/src/components/ExternalMcpSection.tsx
@@ -97,7 +97,7 @@ export function ExternalMcpSection({ onChanged }: ExternalMcpSectionProps) {
       {!state.enabled && state.servers.length > 0 && (
         <div className="settings-row-hint ext-mcp-disconnected">
           {state.servers.length} server{state.servers.length === 1 ? '' : 's'} configured, none
-          connected. Nothing is sent outside this machine while this is off.
+          enabled. Nothing is sent outside this machine while this is off.
         </div>
       )}
 

--- a/frontend/src/components/ExternalMcpSection.tsx
+++ b/frontend/src/components/ExternalMcpSection.tsx
@@ -16,10 +16,11 @@ import { Row, Toggle } from './SettingsControls'
  * workspace.
  *
  * The whole product guarantees that data stays on-premise, and this is the one
- * control that breaks that guarantee, so the switch does not act on its own: the
- * first time it is turned on it opens a consent dialog that has to be read and
+ * control that breaks that guarantee, so the switch does not act on its own:
+ * every time it is turned on it opens a consent dialog that has to be read and
  * accepted. The acknowledgement is recorded server-side and is a precondition
- * there too — the dialog is the explanation, not the enforcement.
+ * there too — the dialog is the explanation, not the enforcement — and turning
+ * the feature off clears it again, so re-arming it can never happen in silence.
  */
 export function ExternalMcpSection() {
   const [state, setState] = useState<ExternalMcpState | null>(null)
@@ -55,7 +56,9 @@ export function ExternalMcpSection() {
   if (!state) return null
 
   const onToggle = (next: boolean) => {
-    // Turning it on for the first time explains itself before it acts.
+    // Turning it on explains itself before it acts, every time: the server
+    // clears the acknowledgement on disable, so `acknowledged` is only ever true
+    // for a feature that is already on.
     if (next && !state.acknowledged) {
       setUnderstood(false)
       setConsenting(true)
@@ -170,7 +173,10 @@ export function ExternalMcpSection() {
                   these tools on its own. Each call still needs your approval, and the approval
                   prompt is where you see what is being sent.
                 </li>
-                <li>Turning this off at any time removes those servers from the agent.</li>
+                <li>
+                  Turning this off at any time removes those servers from the agent, and you
+                  will be asked to accept this again before it can be switched back on.
+                </li>
               </ul>
               <label className="ext-mcp-understood">
                 <input

--- a/frontend/src/components/ExternalMcpSection.tsx
+++ b/frontend/src/components/ExternalMcpSection.tsx
@@ -92,6 +92,15 @@ export function ExternalMcpSection({ onChanged }: ExternalMcpSectionProps) {
 
       {error && <div className="panel-error">{error}</div>}
 
+      {/* Someone who turns this off to be sure nothing is leaving gets told so.
+          An empty space is not an answer to that question. */}
+      {!state.enabled && state.servers.length > 0 && (
+        <div className="settings-row-hint ext-mcp-disconnected">
+          {state.servers.length} server{state.servers.length === 1 ? '' : 's'} configured, none
+          connected. Nothing is sent outside this machine while this is off.
+        </div>
+      )}
+
       {state.enabled && (
         <div className="ext-mcp">
           {state.servers.length === 0 && (

--- a/frontend/src/components/ExternalMcpSection.tsx
+++ b/frontend/src/components/ExternalMcpSection.tsx
@@ -1,0 +1,334 @@
+import { useCallback, useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+import {
+  acknowledgeExternalMcp,
+  addExternalServer,
+  fetchExternalMcp,
+  removeExternalServer,
+  setExternalMcpEnabled,
+  setExternalServerActive,
+} from '../api'
+import type { ExternalMcpState } from '../types'
+import { Row, Toggle } from './SettingsControls'
+
+/**
+ * Advanced-settings section for wiring third-party MCP services into the
+ * workspace.
+ *
+ * The whole product guarantees that data stays on-premise, and this is the one
+ * control that breaks that guarantee, so the switch does not act on its own: the
+ * first time it is turned on it opens a consent dialog that has to be read and
+ * accepted. The acknowledgement is recorded server-side and is a precondition
+ * there too — the dialog is the explanation, not the enforcement.
+ */
+export function ExternalMcpSection() {
+  const [state, setState] = useState<ExternalMcpState | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [consenting, setConsenting] = useState(false)
+  const [understood, setUnderstood] = useState(false)
+  const [adding, setAdding] = useState(false)
+
+  const reload = useCallback(async () => {
+    setState(await fetchExternalMcp())
+  }, [])
+
+  useEffect(() => {
+    fetchExternalMcp()
+      .then(setState)
+      .catch((e: unknown) => setError(String(e)))
+  }, [])
+
+  /** Run a mutation, then refetch — every one of them restarts the agent. */
+  const run = useCallback(
+    (action: () => Promise<void>) => {
+      setBusy(true)
+      setError(null)
+      action()
+        .then(reload)
+        .catch((e: unknown) => setError(e instanceof Error ? e.message : String(e)))
+        .finally(() => setBusy(false))
+    },
+    [reload],
+  )
+
+  if (!state) return null
+
+  const onToggle = (next: boolean) => {
+    // Turning it on for the first time explains itself before it acts.
+    if (next && !state.acknowledged) {
+      setUnderstood(false)
+      setConsenting(true)
+      return
+    }
+    run(() => setExternalMcpEnabled(next))
+  }
+
+  const accept = () =>
+    run(async () => {
+      await acknowledgeExternalMcp()
+      await setExternalMcpEnabled(true)
+      setConsenting(false)
+    })
+
+  return (
+    <>
+      <Row
+        label="External MCP servers"
+        hint="Lets the agent use tools hosted outside this machine. Off by default — anything sent to such a server leaves your infrastructure."
+        checked={state.enabled}
+        onChange={onToggle}
+        disabled={busy}
+      />
+
+      {error && <div className="panel-error">{error}</div>}
+
+      {state.enabled && (
+        <div className="ext-mcp">
+          {state.servers.length === 0 && (
+            <div className="settings-row-hint ext-mcp-empty">No external servers yet.</div>
+          )}
+          {state.servers.map((s) => (
+            <div key={s.name} className="ext-mcp-server">
+              <div className="ext-mcp-server-text">
+                <div className="settings-row-label">{s.name}</div>
+                <div className="settings-row-hint ext-mcp-url">{s.url}</div>
+                <div className="settings-row-hint">
+                  {s.transport}
+                  {s.api_key_env ? ` · token from $${s.api_key_env}` : ' · no auth'}
+                  {s.api_key_env && s.api_key_header ? ` · ${s.api_key_header}` : ''}
+                </div>
+              </div>
+              <div className="ext-mcp-server-actions">
+                <Toggle
+                  checked={s.active}
+                  disabled={busy}
+                  onChange={(v) => run(() => setExternalServerActive(s.name, v))}
+                />
+                <button
+                  className="btn-text"
+                  disabled={busy}
+                  onClick={() => run(() => removeExternalServer(s.name))}
+                >
+                  Remove
+                </button>
+              </div>
+            </div>
+          ))}
+
+          {adding ? (
+            <AddServerForm
+              transports={state.transports}
+              busy={busy}
+              onCancel={() => setAdding(false)}
+              onSubmit={(server) =>
+                run(async () => {
+                  await addExternalServer(server)
+                  setAdding(false)
+                })
+              }
+            />
+          ) : (
+            <button className="btn-text" disabled={busy} onClick={() => setAdding(true)}>
+              + Add server
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Portalled to the body: this section renders inside .drawer, which is a
+          stacking context (position: fixed + z-index), so a backdrop rendered in
+          place cannot paint above the drawer no matter how high its z-index —
+          the settings behind the dialog would stay visible and clickable. */}
+      {consenting &&
+        createPortal(
+          <div className="modal-backdrop" onClick={() => setConsenting(false)}>
+            <div
+              className="modal ext-mcp-consent"
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="ext-mcp-consent-title"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <h3 id="ext-mcp-consent-title">Connect tools outside this machine?</h3>
+              <p>
+                MedMCP runs on-premise: today, no imaging data, patient metadata, or results leave
+                your infrastructure. Enabling external MCP servers ends that guarantee for the tools
+                you add.
+              </p>
+              <ul>
+                <li>
+                  Anything the agent passes to an external tool — file contents, paths, patient
+                  identifiers, results — is sent to whoever operates that server.
+                </li>
+                <li>
+                  You are responsible for what those services receive, for their terms and security,
+                  and for whether that is lawful for your data.
+                </li>
+                <li>
+                  The agent will no longer be told to keep everything on-premise, so it may choose
+                  these tools on its own. Each call still needs your approval, and the approval
+                  prompt is where you see what is being sent.
+                </li>
+                <li>Turning this off at any time removes those servers from the agent.</li>
+              </ul>
+              <label className="ext-mcp-understood">
+                <input
+                  type="checkbox"
+                  checked={understood}
+                  onChange={(e) => setUnderstood(e.target.checked)}
+                />
+                I understand and accept responsibility for data sent to external servers.
+              </label>
+              <div className="modal-actions">
+                <button className="btn-text" onClick={() => setConsenting(false)}>
+                  Cancel
+                </button>
+                <button className="btn-primary" disabled={!understood || busy} onClick={accept}>
+                  Enable
+                </button>
+              </div>
+            </div>
+          </div>,
+          document.body,
+        )}
+    </>
+  )
+}
+
+function AddServerForm({
+  transports,
+  busy,
+  onSubmit,
+  onCancel,
+}: {
+  transports: string[]
+  busy: boolean
+  onSubmit: (server: {
+    name: string
+    transport: string
+    url: string
+    api_key_env: string
+    api_key_header: string
+    api_key_format: string
+  }) => void
+  onCancel: () => void
+}) {
+  const [name, setName] = useState('')
+  const [transport, setTransport] = useState(transports[0] ?? 'streamable-http')
+  const [url, setUrl] = useState('')
+  const [envVar, setEnvVar] = useState('')
+  const [header, setHeader] = useState('')
+  const [format, setFormat] = useState('')
+  // Most services take a bearer token, so the scheme fields stay folded away
+  // until someone needs them.
+  const [customScheme, setCustomScheme] = useState(false)
+
+  return (
+    <form
+      className="ext-mcp-form"
+      onSubmit={(e) => {
+        e.preventDefault()
+        onSubmit({
+          name,
+          transport,
+          url,
+          api_key_env: envVar,
+          api_key_header: header,
+          api_key_format: format,
+        })
+      }}
+    >
+      <label>
+        Name
+        <input
+          className="wf-input"
+          value={name}
+          placeholder="pubmed"
+          onChange={(e) => setName(e.target.value)}
+        />
+      </label>
+      <label>
+        Transport
+        <select
+          className="wf-input"
+          value={transport}
+          onChange={(e) => setTransport(e.target.value)}
+        >
+          {transports.map((t) => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label>
+        URL
+        <input
+          className="wf-input"
+          value={url}
+          placeholder="https://example.org/mcp"
+          onChange={(e) => setUrl(e.target.value)}
+        />
+      </label>
+      <label>
+        Token env var (optional)
+        <input
+          className="wf-input"
+          value={envVar}
+          placeholder="PUBMED_TOKEN"
+          onChange={(e) => setEnvVar(e.target.value)}
+        />
+        {/* The token itself is never stored: only this name is written, and vibe
+            reads the value from the environment the workspace was started in. */}
+        <span className="settings-row-hint">
+          The name of an environment variable set where the workspace runs. The token itself is
+          never saved.
+        </span>
+      </label>
+
+      {/* Server-side these are refused without a token, since they would have
+          nothing to send — so only offer them once one is named. */}
+      {envVar &&
+        (customScheme ? (
+          <>
+            <label>
+              Header
+              <input
+                className="wf-input"
+                value={header}
+                placeholder="Authorization"
+                onChange={(e) => setHeader(e.target.value)}
+              />
+            </label>
+            <label>
+              Value format
+              <input
+                className="wf-input"
+                value={format}
+                placeholder="Bearer {token}"
+                onChange={(e) => setFormat(e.target.value)}
+              />
+              <span className="settings-row-hint">
+                Must contain <code>{'{token}'}</code>. For an API-key service, try header{' '}
+                <code>X-API-Key</code> with format <code>{'{token}'}</code>.
+              </span>
+            </label>
+          </>
+        ) : (
+          <button type="button" className="btn-text" onClick={() => setCustomScheme(true)}>
+            Not a bearer token?
+          </button>
+        ))}
+
+      <div className="ext-mcp-form-actions">
+        <button type="button" className="btn-text" onClick={onCancel}>
+          Cancel
+        </button>
+        <button type="submit" className="btn-primary" disabled={busy || !name || !url}>
+          Add
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/frontend/src/components/ExternalMcpSection.tsx
+++ b/frontend/src/components/ExternalMcpSection.tsx
@@ -22,7 +22,12 @@ import { Row, Toggle } from './SettingsControls'
  * there too — the dialog is the explanation, not the enforcement — and turning
  * the feature off clears it again, so re-arming it can never happen in silence.
  */
-export function ExternalMcpSection() {
+interface ExternalMcpSectionProps {
+  /** Called after any change that may have altered what is connected. */
+  onChanged?: () => void
+}
+
+export function ExternalMcpSection({ onChanged }: ExternalMcpSectionProps) {
   const [state, setState] = useState<ExternalMcpState | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
@@ -47,10 +52,11 @@ export function ExternalMcpSection() {
       setError(null)
       action()
         .then(reload)
+        .then(() => onChanged?.())
         .catch((e: unknown) => setError(e instanceof Error ? e.message : String(e)))
         .finally(() => setBusy(false))
     },
-    [reload],
+    [reload, onChanged],
   )
 
   if (!state) return null

--- a/frontend/src/components/ExternalMcpSection.tsx
+++ b/frontend/src/components/ExternalMcpSection.tsx
@@ -5,10 +5,11 @@ import {
   addExternalServer,
   fetchExternalMcp,
   removeExternalServer,
+  replaceExternalToken,
   setExternalMcpEnabled,
   setExternalServerActive,
 } from '../api'
-import type { ExternalMcpState } from '../types'
+import type { ExternalMcpState, ExternalServer } from '../types'
 import { Row, Toggle } from './SettingsControls'
 
 /**
@@ -34,6 +35,8 @@ export function ExternalMcpSection({ onChanged }: ExternalMcpSectionProps) {
   const [consenting, setConsenting] = useState(false)
   const [understood, setUnderstood] = useState(false)
   const [adding, setAdding] = useState(false)
+  // Name of the server whose token is being replaced, if any.
+  const [replacing, setReplacing] = useState<string | null>(null)
 
   const reload = useCallback(async () => {
     setState(await fetchExternalMcp())
@@ -113,16 +116,37 @@ export function ExternalMcpSection({ onChanged }: ExternalMcpSectionProps) {
                 <div className="settings-row-hint ext-mcp-url">{s.url}</div>
                 <div className="settings-row-hint">
                   {s.transport}
-                  {s.api_key_env ? ` · token from $${s.api_key_env}` : ' · no auth'}
+                  {tokenSource(s)}
                   {s.api_key_env && s.api_key_header ? ` · ${s.api_key_header}` : ''}
                 </div>
-                {/* Without this the only symptom is the remote service's 401:
-                    vibe sends the request unauthenticated rather than failing. */}
+                {/* Only reachable on the env-var path. Without it the sole symptom
+                    is the remote service's 401: vibe sends the request
+                    unauthenticated rather than failing where the cause is. */}
                 {s.api_key_env && s.token_present === false && (
                   <div className="settings-row-hint ext-mcp-missing-token">
                     ${s.api_key_env} is not set where the agent runs — requests go out with no
-                    credential. Add it to medmcp.env and recreate the container.
+                    credential. Add it to medmcp.env and restart, or replace it with a stored
+                    token.
                   </div>
+                )}
+                {replacing === s.name ? (
+                  <ReplaceTokenForm
+                    busy={busy}
+                    onCancel={() => setReplacing(null)}
+                    onSubmit={(value) => {
+                      run(() => replaceExternalToken(s.name, value))
+                      setReplacing(null)
+                    }}
+                  />
+                ) : (
+                  <button
+                    type="button"
+                    className="btn-plain ext-mcp-replace"
+                    disabled={busy}
+                    onClick={() => setReplacing(s.name)}
+                  >
+                    {s.token_managed ? 'Replace token' : 'Store a token here instead'}
+                  </button>
                 )}
               </div>
               <div className="ext-mcp-server-actions">
@@ -225,6 +249,50 @@ export function ExternalMcpSection({ onChanged }: ExternalMcpSectionProps) {
   )
 }
 
+/** Where a server's credential comes from, for the one-line summary. */
+function tokenSource(s: ExternalServer): string {
+  if (s.token_managed) return ' · token stored here'
+  if (s.api_key_env) return ` · token from $${s.api_key_env}`
+  return ' · no auth'
+}
+
+/** Write-only token entry: the current value is never available to prefill. */
+function ReplaceTokenForm({
+  busy,
+  onSubmit,
+  onCancel,
+}: {
+  busy: boolean
+  onSubmit: (token: string) => void
+  onCancel: () => void
+}) {
+  const [value, setValue] = useState('')
+  return (
+    <form
+      className="ext-mcp-replace-form"
+      onSubmit={(e) => {
+        e.preventDefault()
+        if (value.trim()) onSubmit(value)
+      }}
+    >
+      <input
+        className="wf-input"
+        type="password"
+        value={value}
+        autoComplete="off"
+        placeholder="new token"
+        onChange={(e) => setValue(e.target.value)}
+      />
+      <button className="btn-plain" type="submit" disabled={busy || !value.trim()}>
+        Save
+      </button>
+      <button className="btn-plain" type="button" onClick={onCancel}>
+        Cancel
+      </button>
+    </form>
+  )
+}
+
 function AddServerForm({
   transports,
   busy,
@@ -237,6 +305,7 @@ function AddServerForm({
     name: string
     transport: string
     url: string
+    token: string
     api_key_env: string
     api_key_header: string
     api_key_format: string
@@ -246,7 +315,11 @@ function AddServerForm({
   const [name, setName] = useState('')
   const [transport, setTransport] = useState(transports[0] ?? 'streamable-http')
   const [url, setUrl] = useState('')
+  const [token, setToken] = useState('')
   const [envVar, setEnvVar] = useState('')
+  // The token goes in directly; naming a variable the deployment already sets is
+  // the path for a site that manages its own secrets, so it folds away.
+  const [useEnvVar, setUseEnvVar] = useState(false)
   const [header, setHeader] = useState('')
   const [format, setFormat] = useState('')
   // Most services take a bearer token, so the scheme fields stay folded away
@@ -262,7 +335,8 @@ function AddServerForm({
           name,
           transport,
           url,
-          api_key_env: envVar,
+          token: useEnvVar ? '' : token,
+          api_key_env: useEnvVar ? envVar : '',
           api_key_header: header,
           api_key_format: format,
         })
@@ -300,27 +374,51 @@ function AddServerForm({
           onChange={(e) => setUrl(e.target.value)}
         />
       </label>
-      <label>
-        Token env var (optional)
-        <input
-          className="wf-input"
-          value={envVar}
-          placeholder="PUBMED_TOKEN"
-          onChange={(e) => setEnvVar(e.target.value)}
-        />
-        {/* The token itself is never stored: only this name is written, and vibe
-            reads the value from the environment the workspace was started in. */}
-        <span className="settings-row-hint">
-          The name of an environment variable set where the workspace runs — not the token, which
-          is never saved. In the container install, put <code>NAME=value</code> in{' '}
-          <code>medmcp.env</code> next to your compose file and recreate the container; running on
-          the host, export it in the shell that starts the workspace.
-        </span>
-      </label>
+      {useEnvVar ? (
+        <label>
+          Token env var (optional)
+          <input
+            className="wf-input"
+            value={envVar}
+            placeholder="PUBMED_TOKEN"
+            onChange={(e) => setEnvVar(e.target.value)}
+          />
+          <span className="settings-row-hint">
+            The name of a variable already set where the agent runs — for a deployment that
+            manages its own secrets. In the container install that means an entry in{' '}
+            <code>medmcp.env</code> and a restart.
+          </span>
+        </label>
+      ) : (
+        <label>
+          Token (optional)
+          <input
+            className="wf-input"
+            type="password"
+            value={token}
+            autoComplete="off"
+            placeholder="paste the service's token"
+            onChange={(e) => setToken(e.target.value)}
+          />
+          {/* Kept out of config.toml and out of every response body; handed to the
+              agent process at startup. See settings.load_external_secrets. */}
+          <span className="settings-row-hint">
+            Stored on this machine and given to the agent when it starts. It is never written to
+            the agent's config and never sent back to this page.
+          </span>
+        </label>
+      )}
+      <button
+        type="button"
+        className="btn-plain ext-mcp-token-mode"
+        onClick={() => setUseEnvVar((v) => !v)}
+      >
+        {useEnvVar ? 'Enter a token instead' : 'Use an environment variable instead'}
+      </button>
 
       {/* Server-side these are refused without a token, since they would have
           nothing to send — so only offer them once one is named. */}
-      {envVar &&
+      {(useEnvVar ? envVar : token) &&
         (customScheme ? (
           <>
             <label>

--- a/frontend/src/components/SettingsControls.tsx
+++ b/frontend/src/components/SettingsControls.tsx
@@ -1,0 +1,53 @@
+/**
+ * The drawer's switch primitives, shared by the settings sections.
+ *
+ * Lifted out of SettingsDrawer so a section living in its own file can render an
+ * identical row without either duplicating the markup or importing back into the
+ * drawer (which would be a cycle).
+ */
+
+export function Toggle({
+  checked,
+  onChange,
+  disabled,
+}: {
+  checked: boolean
+  onChange: (value: boolean) => void
+  disabled?: boolean
+}) {
+  return (
+    <button
+      role="switch"
+      aria-checked={checked}
+      className={`toggle${checked ? ' on' : ''}`}
+      disabled={disabled}
+      onClick={() => onChange(!checked)}
+    >
+      <span className="toggle-knob" />
+    </button>
+  )
+}
+
+export function Row({
+  label,
+  hint,
+  checked,
+  onChange,
+  disabled,
+}: {
+  label: string
+  hint?: string
+  checked: boolean
+  onChange: (value: boolean) => void
+  disabled?: boolean
+}) {
+  return (
+    <div className={`settings-row${disabled ? ' disabled' : ''}`}>
+      <div className="settings-row-text">
+        <div className="settings-row-label">{label}</div>
+        {hint && <div className="settings-row-hint">{hint}</div>}
+      </div>
+      <Toggle checked={checked} onChange={onChange} disabled={disabled} />
+    </div>
+  )
+}

--- a/frontend/src/components/SettingsDrawer.tsx
+++ b/frontend/src/components/SettingsDrawer.tsx
@@ -8,6 +8,13 @@ import { ChevronRightIcon, XIcon } from './icons'
 interface SettingsDrawerProps {
   open: boolean
   onClose: () => void
+  /** Whether the Advanced disclosure is expanded (owned by the caller, so the
+   *  warning banner can open the drawer straight onto the control it names). */
+  advancedOpen: boolean
+  /** Expand or collapse Advanced. */
+  onAdvancedToggle: (open: boolean) => void
+  /** Called when external-MCP state changed, so the banner can catch up. */
+  onExternalChanged?: () => void
 }
 
 /**
@@ -15,13 +22,18 @@ interface SettingsDrawerProps {
  * switches, and the stack GPU. Every change is saved immediately; stack and GPU
  * changes restart the agent (the chat reconnects into a fresh session).
  */
-export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
+export function SettingsDrawer({
+  open,
+  onClose,
+  advancedOpen,
+  onAdvancedToggle,
+  onExternalChanged,
+}: SettingsDrawerProps) {
   const [state, setState] = useState<SettingsState | null>(null)
   const [gpus, setGpus] = useState<GpuInfo[]>([])
   const [error, setError] = useState<string | null>(null)
   const [notice, setNotice] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
-  const [advanced, setAdvanced] = useState(false)
 
   // Clear the toast on its own: it confirms something that already happened, so
   // leaving it up implies a state that still needs attention.
@@ -118,15 +130,15 @@ export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
               <button
                 type="button"
                 className="settings-advanced-toggle"
-                onClick={() => setAdvanced((v) => !v)}
+                onClick={() => onAdvancedToggle(!advancedOpen)}
               >
                 <ChevronRightIcon
                   size={12}
-                  className={advanced ? 'settings-chevron open' : 'settings-chevron'}
+                  className={advancedOpen ? 'settings-chevron open' : 'settings-chevron'}
                 />
                 Advanced
               </button>
-              {advanced && (
+              {advancedOpen && (
                 <>
                   <Row
                     label="Record provenance"
@@ -134,7 +146,7 @@ export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
                     checked={state.record_provenance}
                     onChange={(v) => apply({ ...state, record_provenance: v })}
                   />
-                  <ExternalMcpSection />
+                  <ExternalMcpSection onChanged={onExternalChanged} />
                 </>
               )}
 

--- a/frontend/src/components/SettingsDrawer.tsx
+++ b/frontend/src/components/SettingsDrawer.tsx
@@ -1,57 +1,13 @@
 import { useEffect, useState } from 'react'
 import { fetchGpus, fetchSettings, saveSettings } from '../api'
 import type { GpuInfo, SettingsState } from '../types'
+import { ExternalMcpSection } from './ExternalMcpSection'
+import { Row } from './SettingsControls'
 import { ChevronRightIcon, XIcon } from './icons'
 
 interface SettingsDrawerProps {
   open: boolean
   onClose: () => void
-}
-
-function Toggle({
-  checked,
-  onChange,
-  disabled,
-}: {
-  checked: boolean
-  onChange: (value: boolean) => void
-  disabled?: boolean
-}) {
-  return (
-    <button
-      role="switch"
-      aria-checked={checked}
-      className={`toggle${checked ? ' on' : ''}`}
-      disabled={disabled}
-      onClick={() => onChange(!checked)}
-    >
-      <span className="toggle-knob" />
-    </button>
-  )
-}
-
-function Row({
-  label,
-  hint,
-  checked,
-  onChange,
-  disabled,
-}: {
-  label: string
-  hint?: string
-  checked: boolean
-  onChange: (value: boolean) => void
-  disabled?: boolean
-}) {
-  return (
-    <div className={`settings-row${disabled ? ' disabled' : ''}`}>
-      <div className="settings-row-text">
-        <div className="settings-row-label">{label}</div>
-        {hint && <div className="settings-row-hint">{hint}</div>}
-      </div>
-      <Toggle checked={checked} onChange={onChange} disabled={disabled} />
-    </div>
-  )
 }
 
 /**
@@ -171,12 +127,15 @@ export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
                 Advanced
               </button>
               {advanced && (
-                <Row
-                  label="Record provenance"
-                  hint="Keeps a replayable record of what each chat did (manifest, tool log, permissions). Turning this off means a chat leaves no audit trail and cannot be distilled into a workflow."
-                  checked={state.record_provenance}
-                  onChange={(v) => apply({ ...state, record_provenance: v })}
-                />
+                <>
+                  <Row
+                    label="Record provenance"
+                    hint="Keeps a replayable record of what each chat did (manifest, tool log, permissions). Turning this off means a chat leaves no audit trail and cannot be distilled into a workflow."
+                    checked={state.record_provenance}
+                    onChange={(v) => apply({ ...state, record_provenance: v })}
+                  />
+                  <ExternalMcpSection />
+                </>
               )}
 
               <div className="drawer-footnote">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2749,6 +2749,25 @@ textarea.wf-input {
 .wf-derived-toggle:hover {
   color: var(--text);
 }
+/* The reassurance the banner's absence cannot give: with the feature off, the
+   section says in words that nothing is connected. */
+.ext-mcp-disconnected {
+  position: relative;
+  margin: 2px 0 6px;
+  padding-left: 14px;
+}
+
+.ext-mcp-disconnected::before {
+  content: '';
+  position: absolute;
+  left: 2px;
+  top: 6px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--ok);
+}
+
 /* ── External MCP: the standing connection warning ───────────────────────── */
 
 /* A strip under the header, up for exactly as long as external servers are

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2768,6 +2768,13 @@ textarea.wf-input {
   background: var(--ok);
 }
 
+/* A named token variable that does not exist where the agent runs. Not an error
+   state — the server is configured correctly, the environment is not. */
+.ext-mcp-missing-token {
+  margin-top: 2px;
+  color: var(--red-tint);
+}
+
 /* ── External MCP: the standing connection warning ───────────────────────── */
 
 /* A strip under the header, up for exactly as long as external servers are

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2768,6 +2768,38 @@ textarea.wf-input {
   background: var(--ok);
 }
 
+/* Switching between "type the token" and "name a variable the deployment sets".
+   A quiet link, not a control that competes with the fields around it. */
+.ext-mcp-token-mode {
+  align-self: flex-start;
+  padding: 0;
+  border-color: transparent;
+  font-size: 11px;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.ext-mcp-replace {
+  align-self: flex-start;
+  margin-top: 4px;
+  padding: 0;
+  border-color: transparent;
+  font-size: 11px;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.ext-mcp-replace-form {
+  display: flex;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.ext-mcp-replace-form .wf-input {
+  flex: 1;
+  min-width: 0;
+}
+
 /* A named token variable that does not exist where the agent runs. Not an error
    state — the server is configured correctly, the environment is not. */
 .ext-mcp-missing-token {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2749,6 +2749,61 @@ textarea.wf-input {
 .wf-derived-toggle:hover {
   color: var(--text);
 }
+/* ── External MCP: the standing connection warning ───────────────────────── */
+
+/* A strip under the header, up for exactly as long as external servers are
+   connected. Red rather than amber: while it shows, the on-premise guarantee the
+   rest of the product makes is not in force. It is not dismissible, so it stays
+   quiet — one line, no icon chrome — and carries its own way out. */
+.ext-banner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+  padding: 7px 18px;
+  font-size: 12px;
+  color: var(--red-tint);
+  background: rgba(210, 34, 41, 0.12);
+  border-bottom: 1px solid rgba(210, 34, 41, 0.4);
+}
+
+.ext-banner-dot {
+  width: 7px;
+  height: 7px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  background: var(--red);
+  box-shadow: 0 0 0 3px rgba(210, 34, 41, 0.2);
+}
+
+.ext-banner-text strong {
+  font-weight: 600;
+}
+
+/* The names identify what is connected without widening the strip; they yield
+   first when the window is narrow, since the warning itself must survive. */
+.ext-banner-names {
+  min-width: 0;
+  margin-right: auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.ext-banner-action {
+  flex-shrink: 0;
+  padding: 2px 8px;
+  color: var(--red-tint);
+}
+
+.ext-banner-action:hover:not(:disabled) {
+  color: var(--text);
+  border-color: rgba(210, 34, 41, 0.5);
+}
+
 /* ── External MCP (advanced settings) ────────────────────────────────────── */
 
 /* Sits above .drawer (z-index 21) on the shared .modal-backdrop (40), so the

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2749,3 +2749,135 @@ textarea.wf-input {
 .wf-derived-toggle:hover {
   color: var(--text);
 }
+/* ── External MCP (advanced settings) ────────────────────────────────────── */
+
+/* Sits above .drawer (z-index 21) on the shared .modal-backdrop (40), so the
+   consent dialog covers the settings panel that launched it. */
+.modal {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 41;
+  width: 520px;
+  max-width: 92vw;
+  max-height: 86vh;
+  overflow-y: auto;
+  padding: 20px 22px;
+  background: var(--card);
+  border: 1px solid var(--border2);
+  border-radius: 12px;
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.5);
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 18px;
+}
+
+.btn-text {
+  background: none;
+  border: none;
+  padding: 4px 8px;
+  color: var(--muted);
+}
+
+.btn-text:hover {
+  color: var(--text);
+}
+
+/* The one control that ends the on-premise guarantee — the red edge is the cue
+   that this dialog is not a routine confirmation. */
+.ext-mcp-consent {
+  border-color: rgba(210, 34, 41, 0.45);
+}
+
+.ext-mcp-consent h3 {
+  margin: 0 0 12px;
+  font-size: 15px;
+}
+
+.ext-mcp-consent p,
+.ext-mcp-consent li {
+  color: var(--muted);
+  font-size: 12.5px;
+  line-height: 1.6;
+}
+
+.ext-mcp-consent ul {
+  margin: 12px 0;
+  padding-left: 18px;
+}
+
+.ext-mcp-consent li {
+  margin-bottom: 8px;
+}
+
+.ext-mcp-understood {
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+  margin-top: 16px;
+  font-size: 12.5px;
+  line-height: 1.5;
+  cursor: pointer;
+}
+
+.ext-mcp {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 4px 0 10px 12px;
+  border-left: 1px solid var(--border);
+  margin-left: 4px;
+}
+
+.ext-mcp-empty {
+  font-style: italic;
+}
+
+.ext-mcp-server {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.ext-mcp-server-text {
+  min-width: 0;
+}
+
+/* URLs are long and unbreakable; let them wrap rather than widen the drawer. */
+.ext-mcp-url {
+  font-family: var(--mono);
+  overflow-wrap: anywhere;
+}
+
+.ext-mcp-server-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.ext-mcp-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.ext-mcp-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.ext-mcp-form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -282,6 +282,9 @@ export interface ExternalServer {
   /** Whether `api_key_env` actually holds a token where the agent runs. Presence
    *  only — the value never leaves the server. */
   token_present?: boolean
+  /** Whether the token is stored by MedMCP rather than named as a deployment
+   *  variable. Managed tokens are present by construction. */
+  token_managed?: boolean
 }
 
 /** State of the external-MCP feature (advanced settings). */

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -279,6 +279,9 @@ export interface ExternalServer {
   /** Value format, e.g. "Bearer {token}"; empty means Bearer. */
   api_key_format: string
   active: boolean
+  /** Whether `api_key_env` actually holds a token where the agent runs. Presence
+   *  only — the value never leaves the server. */
+  token_present?: boolean
 }
 
 /** State of the external-MCP feature (advanced settings). */

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -266,3 +266,28 @@ export type ServerFrame =
     }
   | { type: 'done' }
   | { type: 'error'; message: string }
+
+/** One external MCP server (GET /api/external-mcp). */
+export interface ExternalServer {
+  name: string
+  transport: string
+  url: string
+  /** Name of the env var holding the token — never the token itself. */
+  api_key_env: string
+  /** Header to carry the token; empty means Authorization. */
+  api_key_header: string
+  /** Value format, e.g. "Bearer {token}"; empty means Bearer. */
+  api_key_format: string
+  active: boolean
+}
+
+/** State of the external-MCP feature (advanced settings). */
+export interface ExternalMcpState {
+  enabled: boolean
+  /** Whether the operator has accepted responsibility; required before enabling. */
+  acknowledged: boolean
+  acknowledged_at: string | null
+  /** Transports the server will accept, in preference order. */
+  transports: string[]
+  servers: ExternalServer[]
+}

--- a/src/medmcp/acp.py
+++ b/src/medmcp/acp.py
@@ -18,6 +18,7 @@ import json
 import logging
 import os
 import sys
+from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import Any, cast
 
@@ -95,10 +96,25 @@ class VibeAcpClient:
     callers cannot interleave bytes mid-frame.
     """
 
-    def __init__(self, cwd: str = PROJECT_ROOT, vibe_home: Path = VIBE_HOME) -> None:
-        """Build an unstarted client. Call :meth:`ensure_started` before use."""
+    def __init__(
+        self,
+        cwd: str = PROJECT_ROOT,
+        vibe_home: Path = VIBE_HOME,
+        extra_env: Callable[[], Mapping[str, str]] | None = None,
+    ) -> None:
+        """Build an unstarted client. Call :meth:`ensure_started` before use.
+
+        *extra_env* supplies variables for the agent subprocess — credentials for
+        external MCP servers, which the agent reads at request time and this
+        process must therefore hold. It is a callable, not a dict, because the
+        client outlives many spawns: whatever it returns is read afresh each time
+        the process starts, so a changed credential takes effect on the restart
+        that every such change already triggers. (A callable also keeps this
+        module free of a settings import, which would be circular.)
+        """
         self._cwd: str = cwd
         self._vibe_home: Path = vibe_home
+        self._extra_env: Callable[[], Mapping[str, str]] | None = extra_env
         self.proc: asyncio.subprocess.Process | None = None
         self._next_id: int = 0
         self._pending: dict[int, asyncio.Future[JsonDict]] = {}
@@ -159,7 +175,11 @@ class VibeAcpClient:
                     stderr=None,  # inherit parent stderr so logs appear in terminal
                     limit=16 * 1024 * 1024,  # 16 MB; default 64 KB overflows with LLM responses
                     cwd=self._cwd,
-                    env={**os.environ, "VIBE_HOME": str(self._vibe_home)},
+                    env={
+                        **os.environ,
+                        "VIBE_HOME": str(self._vibe_home),
+                        **(self._extra_env() if self._extra_env else {}),
+                    },
                 )
                 self._reader_task = asyncio.create_task(self._read_loop())
                 resp = await self.request(

--- a/src/medmcp/server.py
+++ b/src/medmcp/server.py
@@ -153,7 +153,10 @@ app = FastAPI(title="MedMCP Workspace", lifespan=_lifespan)
 # One vibe-acp subprocess shared by every websocket connection. The subprocess
 # cwd must stay PROJECT_ROOT — `uv run` resolves the project from it; the
 # agent's working directory is set per session via session/new's cwd instead.
-_client: VibeAcpClient = VibeAcpClient()
+# The agent process is where an external server's credential is needed; this
+# process holds it so the operator does not have to plumb one into the
+# deployment by hand. Passed as a provider, re-read on every (re)start.
+_client: VibeAcpClient = VibeAcpClient(extra_env=settings.external_secret_env)
 
 # Live websocket connections, so a settings-triggered vibe restart can close
 # them (each client auto-reconnects into a fresh session on the new process).
@@ -608,6 +611,9 @@ class ExternalServerPayload(BaseModel):
     name: str
     transport: str
     url: str
+    # The token itself, stored by this process and handed to the agent. Mutually
+    # exclusive with api_key_env, which names a variable the deployment sets.
+    token: str = ""
     api_key_env: str = ""
     # Optional overrides for services that don't take a bearer token; empty means
     # vibe's `Authorization: Bearer {token}` default.
@@ -615,10 +621,11 @@ class ExternalServerPayload(BaseModel):
     api_key_format: str = ""
 
 
-class ExternalServerActivePayload(BaseModel):
-    """Request body for activating/deactivating one external server."""
+class ExternalServerPatchPayload(BaseModel):
+    """Request body for changing one external server: its state, its token, or both."""
 
-    active: bool
+    active: bool | None = None
+    token: str | None = None
 
 
 async def _apply_external_change() -> None:
@@ -633,16 +640,23 @@ async def get_external_mcp() -> JsonDict:
 
     def _state() -> JsonDict:
         state = settings.load_external_mcp()
-        # Presence of the named token variable, never its value. Without this the
-        # only symptom of a missing variable is the remote service's 401: vibe
-        # sends the request with no auth header rather than failing locally.
-        servers = [
-            {
-                **srv,
-                "token_present": settings.external_token_present(str(srv.get("api_key_env", ""))),
-            }
-            for srv in cast("list[JsonDict]", state["servers"])
-        ]
+        # Where each credential comes from, and whether it is actually there —
+        # never what it is. A stored token is held by this process and injected
+        # into the agent, so it is present by definition; a named variable has to
+        # exist in this environment, and when it does not the request goes out
+        # unauthenticated with the remote service's 401 as the only symptom.
+        secrets = settings.load_external_secrets()
+        servers: list[JsonDict] = []
+        for srv in cast("list[JsonDict]", state["servers"]):
+            managed = bool(secrets.get(str(srv.get("name", ""))))
+            servers.append(
+                {
+                    **srv,
+                    "token_managed": managed,
+                    "token_present": managed
+                    or settings.external_token_present(str(srv.get("api_key_env", ""))),
+                }
+            )
         return {
             "enabled": bool(state["enabled"]),
             "acknowledged": bool(state["acknowledged_at"]),
@@ -687,6 +701,7 @@ async def post_external_server(payload: ExternalServerPayload) -> JsonDict:
             True,
             payload.api_key_header,
             payload.api_key_format,
+            payload.token,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -696,15 +711,27 @@ async def post_external_server(payload: ExternalServerPayload) -> JsonDict:
 
 
 @app.patch("/api/external-mcp/servers/{name}")
-async def patch_external_server(name: str, payload: ExternalServerActivePayload) -> JsonDict:
-    """Activate or deactivate a single external server without deleting it."""
+async def patch_external_server(name: str, payload: ExternalServerPatchPayload) -> JsonDict:
+    """Activate/deactivate one external server, replace its token, or both."""
+    if payload.active is None and payload.token is None:
+        raise HTTPException(status_code=400, detail="nothing to change")
     try:
-        await asyncio.to_thread(settings.set_external_server_active, name, payload.active)
+        if payload.token is not None:
+            await asyncio.to_thread(settings.replace_external_token, name, payload.token)
+            # The value is deliberately absent from this line: the audit trail
+            # records that a credential changed, never what it changed to.
+            _audit.info("external MCP server token replaced: %s", name)
+        if payload.active is not None:
+            await asyncio.to_thread(settings.set_external_server_active, name, payload.active)
+            _audit.info(
+                "external MCP server %s: %s",
+                "activated" if payload.active else "deactivated",
+                name,
+            )
     except FileNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
-    _audit.info(
-        "external MCP server %s: %s", "activated" if payload.active else "deactivated", name
-    )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     await _apply_external_change()
     return {"ok": True, "restarted": True}
 

--- a/src/medmcp/server.py
+++ b/src/medmcp/server.py
@@ -590,6 +590,127 @@ def _workflow_detail(name: str) -> JsonDict:
     }
 
 
+# ── External MCP servers (advanced) ──────────────────────────────────────────
+# Every mutation here changes what the agent can reach, so all of them are
+# audit-logged and all of them re-sync the vibe config and restart the agent —
+# the same treatment a stack change gets, for the same reason.
+
+
+class ExternalMcpEnabledPayload(BaseModel):
+    """Request body for turning external MCP support on or off."""
+
+    enabled: bool
+
+
+class ExternalServerPayload(BaseModel):
+    """Request body for registering an external MCP server."""
+
+    name: str
+    transport: str
+    url: str
+    api_key_env: str = ""
+    # Optional overrides for services that don't take a bearer token; empty means
+    # vibe's `Authorization: Bearer {token}` default.
+    api_key_header: str = ""
+    api_key_format: str = ""
+
+
+class ExternalServerActivePayload(BaseModel):
+    """Request body for activating/deactivating one external server."""
+
+    active: bool
+
+
+async def _apply_external_change() -> None:
+    """Re-discover servers, re-sync the vibe config, and restart the agent."""
+    await asyncio.to_thread(_apply_stack_change)
+    await _restart_vibe()
+
+
+@app.get("/api/external-mcp")
+async def get_external_mcp() -> JsonDict:
+    """Return the external-MCP state: the toggle, the acknowledgement, the servers."""
+
+    def _state() -> JsonDict:
+        state = settings.load_external_mcp()
+        return {
+            "enabled": bool(state["enabled"]),
+            "acknowledged": bool(state["acknowledged_at"]),
+            "acknowledged_at": state["acknowledged_at"],
+            "transports": list(settings.EXTERNAL_MCP_TRANSPORTS),
+            "servers": state["servers"],
+        }
+
+    return await asyncio.to_thread(_state)
+
+
+@app.post("/api/external-mcp/acknowledge")
+async def post_external_mcp_acknowledge() -> JsonDict:
+    """Record that the operator accepted responsibility for external services."""
+    state = await asyncio.to_thread(settings.acknowledge_external_mcp)
+    _audit.info("external MCP acknowledged at %s", state["acknowledged_at"])
+    return {"ok": True, "acknowledged_at": state["acknowledged_at"]}
+
+
+@app.put("/api/external-mcp")
+async def put_external_mcp(payload: ExternalMcpEnabledPayload) -> JsonDict:
+    """Enable or disable external MCP support (enabling requires the acknowledgement)."""
+    try:
+        await asyncio.to_thread(settings.set_external_mcp_enabled, payload.enabled)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    _audit.info("external MCP %s", "enabled" if payload.enabled else "disabled")
+    await _apply_external_change()
+    return {"ok": True, "enabled": payload.enabled, "restarted": True}
+
+
+@app.post("/api/external-mcp/servers")
+async def post_external_server(payload: ExternalServerPayload) -> JsonDict:
+    """Register an external MCP server."""
+    try:
+        entry = await asyncio.to_thread(
+            settings.add_external_server,
+            payload.name,
+            payload.transport,
+            payload.url,
+            payload.api_key_env,
+            True,
+            payload.api_key_header,
+            payload.api_key_format,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    _audit.info("external MCP server added: %s -> %s", entry["name"], entry["url"])
+    await _apply_external_change()
+    return {"ok": True, "server": entry, "restarted": True}
+
+
+@app.patch("/api/external-mcp/servers/{name}")
+async def patch_external_server(name: str, payload: ExternalServerActivePayload) -> JsonDict:
+    """Activate or deactivate a single external server without deleting it."""
+    try:
+        await asyncio.to_thread(settings.set_external_server_active, name, payload.active)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    _audit.info(
+        "external MCP server %s: %s", "activated" if payload.active else "deactivated", name
+    )
+    await _apply_external_change()
+    return {"ok": True, "restarted": True}
+
+
+@app.delete("/api/external-mcp/servers/{name}")
+async def delete_external_server(name: str) -> JsonDict:
+    """Remove an external MCP server."""
+    try:
+        await asyncio.to_thread(settings.remove_external_server, name)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    _audit.info("external MCP server removed: %s", name)
+    await _apply_external_change()
+    return {"ok": True, "restarted": True}
+
+
 @app.get("/api/workflows")
 async def get_workflows() -> JsonDict:
     """List the personal workflows available to the replay engine."""

--- a/src/medmcp/server.py
+++ b/src/medmcp/server.py
@@ -633,12 +633,22 @@ async def get_external_mcp() -> JsonDict:
 
     def _state() -> JsonDict:
         state = settings.load_external_mcp()
+        # Presence of the named token variable, never its value. Without this the
+        # only symptom of a missing variable is the remote service's 401: vibe
+        # sends the request with no auth header rather than failing locally.
+        servers = [
+            {
+                **srv,
+                "token_present": settings.external_token_present(str(srv.get("api_key_env", ""))),
+            }
+            for srv in cast("list[JsonDict]", state["servers"])
+        ]
         return {
             "enabled": bool(state["enabled"]),
             "acknowledged": bool(state["acknowledged_at"]),
             "acknowledged_at": state["acknowledged_at"],
             "transports": list(settings.EXTERNAL_MCP_TRANSPORTS),
-            "servers": state["servers"],
+            "servers": servers,
         }
 
     return await asyncio.to_thread(_state)

--- a/src/medmcp/settings.py
+++ b/src/medmcp/settings.py
@@ -683,7 +683,12 @@ def external_mcp_enabled() -> bool:
 
 
 def acknowledge_external_mcp() -> JsonDict:
-    """Record that the operator accepted the risks; idempotent (first time wins)."""
+    """Record that the operator accepted the risks.
+
+    Idempotent within one activation (re-acknowledging keeps the original
+    timestamp). :func:`set_external_mcp_enabled` clears it again on disable, so
+    an acknowledgement covers the period it was given for and no longer.
+    """
     state = load_external_mcp()
     if not state["acknowledged_at"]:
         state["acknowledged_at"] = datetime.now(UTC).isoformat(timespec="seconds")
@@ -692,11 +697,20 @@ def acknowledge_external_mcp() -> JsonDict:
 
 
 def set_external_mcp_enabled(enabled: bool) -> JsonDict:
-    """Turn the feature on or off. Enabling without an acknowledgement is refused."""
+    """Turn the feature on or off; enabling requires a *current* acknowledgement.
+
+    Disabling clears the acknowledgement, so switching the feature back on has to
+    pass through the consent dialog again. A once-per-machine consent would mean
+    the one control that ends the on-premise guarantee could be re-armed in
+    silence — months later, or by someone who never saw what it says — and the
+    person turning it on would get no warning at the moment it matters.
+    """
     state = load_external_mcp()
     if enabled and not state["acknowledged_at"]:
         raise ValueError("external MCP must be acknowledged before it can be enabled")
     state["enabled"] = bool(enabled)
+    if not enabled:
+        state["acknowledged_at"] = None
     _save_external_mcp(state)
     return state
 

--- a/src/medmcp/settings.py
+++ b/src/medmcp/settings.py
@@ -672,6 +672,69 @@ def _save_external_mcp(state: JsonDict) -> None:
     _atomic_write_json(EXTERNAL_MCP_PATH, state)
 
 
+EXTERNAL_SECRETS_PATH: Path = VIBE_STATE_DIR / "external_secrets.json"
+# Prefix for the variables this process hands the agent. Namespaced so a stored
+# token can never take the name of an unrelated variable in the environment.
+EXTERNAL_SECRET_PREFIX: str = "MEDMCP_EXT_"
+
+
+def external_secret_env_var(server_name: str) -> str:
+    """Name of the variable that carries *server_name*'s stored token to the agent."""
+    return EXTERNAL_SECRET_PREFIX + server_name.upper().replace("-", "_")
+
+
+def load_external_secrets() -> dict[str, str]:
+    """Return ``{server_name: token}`` for tokens entered through the UI.
+
+    Kept out of ``external_mcp.json`` (which the API returns wholesale) and out of
+    ``config.toml`` (rewritten on every sync), so a token cannot reach a response
+    body or the agent's config by accident. Written 0600 by the atomic writer.
+    """
+    if not EXTERNAL_SECRETS_PATH.exists():
+        return {}
+    try:
+        data = cast("JsonDict", json.loads(EXTERNAL_SECRETS_PATH.read_text()))
+    except (json.JSONDecodeError, OSError) as exc:
+        log.warning("could not read %s; treating as empty: %s", EXTERNAL_SECRETS_PATH, exc)
+        return {}
+    return {str(k): str(v) for k, v in data.items() if isinstance(v, str) and v}
+
+
+def set_external_secret(server_name: str, token: str) -> None:
+    """Store *token* for *server_name*, replacing any previous one."""
+    secrets = load_external_secrets()
+    secrets[server_name] = token
+    _atomic_write_json(EXTERNAL_SECRETS_PATH, cast("JsonDict", secrets))
+
+
+def delete_external_secret(server_name: str) -> None:
+    """Forget *server_name*'s token; a no-op when there is none."""
+    secrets = load_external_secrets()
+    if secrets.pop(server_name, None) is None:
+        return
+    _atomic_write_json(EXTERNAL_SECRETS_PATH, cast("JsonDict", secrets))
+
+
+def external_secret_env() -> dict[str, str]:
+    """Token variables to put in the agent subprocess's environment.
+
+    Empty while the feature is gated off, and empty for a deactivated server: a
+    switch that is off must mean the agent process does not even hold the
+    credential, not merely that no server is configured to use it. Read afresh on
+    every spawn, which is why the client takes a callable rather than a dict —
+    every mutation here restarts the agent.
+    """
+    if not external_mcp_enabled():
+        return {}
+    secrets = load_external_secrets()
+    out: dict[str, str] = {}
+    for srv in cast("list[JsonDict]", load_external_mcp()["servers"]):
+        name = str(srv.get("name", ""))
+        if srv.get("active") and secrets.get(name):
+            out[external_secret_env_var(name)] = secrets[name]
+    return out
+
+
 def external_token_present(api_key_env: str) -> bool:
     """Whether the env var *api_key_env* holds a usable token in this process.
 
@@ -787,6 +850,7 @@ def add_external_server(
     active: bool = True,
     api_key_header: str = "",
     api_key_format: str = "",
+    token: str = "",
 ) -> JsonDict:
     """Register an external MCP server and return the stored entry.
 
@@ -796,9 +860,20 @@ def add_external_server(
     ``api_key_header``/``api_key_format`` are optional overrides for services that
     do not take a bearer token (``X-API-Key: <token>``, say); left empty, vibe's
     ``Authorization: Bearer {token}`` default applies.
+
+    A *token* is stored here and handed to the agent through a variable this
+    process owns, so the operator never has to plumb one into the deployment by
+    hand. Naming an existing variable in ``api_key_env`` instead still works, for
+    a deployment that already manages its own secrets — but not both at once,
+    since only one of them could win and the other would look effective while
+    doing nothing.
     """
     name, transport, url = name.strip(), transport.strip(), url.strip()
-    api_key_env = api_key_env.strip()
+    api_key_env, token = api_key_env.strip(), token.strip()
+    if token and api_key_env:
+        raise ValueError("give either a token or an environment variable name, not both")
+    if token:
+        api_key_env = external_secret_env_var(name)
     api_key_header, api_key_format = api_key_header.strip(), api_key_format.strip()
     _validate_external_server(name, transport, url, api_key_env, api_key_header, api_key_format)
 
@@ -818,6 +893,10 @@ def add_external_server(
         "api_key_format": api_key_format,
         "active": bool(active),
     }
+    # Secret first: a failure here must not leave a registered server pointing at
+    # a variable that was never written.
+    if token:
+        set_external_secret(name, token)
     cast("list[JsonDict]", state["servers"]).append(entry)
     _save_external_mcp(state)
 
@@ -839,6 +918,7 @@ def remove_external_server(name: str) -> None:
         raise FileNotFoundError(f"no external server named {name!r}")
     state["servers"] = remaining
     _save_external_mcp(state)
+    delete_external_secret(name)
 
 
 def set_external_server_active(name: str, active: bool) -> None:
@@ -847,6 +927,26 @@ def set_external_server_active(name: str, active: bool) -> None:
     for srv in cast("list[JsonDict]", state["servers"]):
         if str(srv.get("name")) == name:
             srv["active"] = bool(active)
+            _save_external_mcp(state)
+            return
+    raise FileNotFoundError(f"no external server named {name!r}")
+
+
+def replace_external_token(name: str, token: str) -> None:
+    """Store a new token for an existing server, adopting the managed variable.
+
+    A server first configured with a hand-plumbed variable can be switched to a
+    stored token this way; the entry's ``api_key_env`` moves to the managed name
+    so exactly one source is in play.
+    """
+    token = token.strip()
+    if not token:
+        raise ValueError("token must not be empty")
+    state = load_external_mcp()
+    for srv in cast("list[JsonDict]", state["servers"]):
+        if str(srv.get("name")) == name:
+            set_external_secret(name, token)
+            srv["api_key_env"] = external_secret_env_var(name)
             _save_external_mcp(state)
             return
     raise FileNotFoundError(f"no external server named {name!r}")

--- a/src/medmcp/settings.py
+++ b/src/medmcp/settings.py
@@ -672,6 +672,19 @@ def _save_external_mcp(state: JsonDict) -> None:
     _atomic_write_json(EXTERNAL_MCP_PATH, state)
 
 
+def external_token_present(api_key_env: str) -> bool:
+    """Whether the env var *api_key_env* holds a usable token in this process.
+
+    Only ever returns presence — never the value, which must not leave the
+    process. vibe attaches the auth header only when ``os.getenv`` is truthy, so
+    an empty variable counts as absent here for the same reason: with one, the
+    request goes out unauthenticated and the operator sees the remote service's
+    401 with nothing pointing at the real cause. vibe-acp inherits this process's
+    environment, so what is visible here is what it will see.
+    """
+    return bool(api_key_env) and bool(os.environ.get(api_key_env))
+
+
 def external_mcp_acknowledged() -> bool:
     """Whether the operator has accepted responsibility for external services."""
     return bool(load_external_mcp()["acknowledged_at"])

--- a/src/medmcp/settings.py
+++ b/src/medmcp/settings.py
@@ -634,7 +634,12 @@ def active_servers() -> list[JsonDict]:
 # Credentials are stored as the *name* of an environment variable, never a token:
 # `.vibe/config.toml` is rewritten on every sync and readable by anything in the
 # container, so it is the wrong place for a secret.
-EXTERNAL_MCP_PATH: Path = VIBE_HOME / "external_mcp.json"
+# A directory rather than a bare file, because in a container this state has to
+# survive an image update: a named volume can cover a subdirectory of .vibe,
+# but not a single file, and covering .vibe itself would shadow the baked
+# prompts and the config.toml the entrypoint writes.
+VIBE_STATE_DIR: Path = VIBE_HOME / "state"
+EXTERNAL_MCP_PATH: Path = VIBE_STATE_DIR / "external_mcp.json"
 EXTERNAL_MCP_TRANSPORTS: tuple[str, ...] = ("streamable-http", "http")
 _ENV_VAR_RE: re.Pattern[str] = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
 # RFC 7230 token characters — the same set vibe validates header names against.

--- a/src/medmcp/settings.py
+++ b/src/medmcp/settings.py
@@ -31,9 +31,12 @@ import tempfile
 import threading
 import tomllib
 from collections.abc import Callable
+from datetime import UTC, datetime
 from functools import lru_cache
 from pathlib import Path
+from string import Formatter
 from typing import Any, cast
+from urllib.parse import urlparse
 
 import httpx
 import tomli_w
@@ -545,12 +548,26 @@ def load_mcp_servers() -> list[JsonDict]:
             if command and Path(command).name == "docker":
                 log.debug("Skipping orphaned container-stack config.toml entry %r", name)
                 continue
+            # An HTTP entry here is one this sync wrote for an external server —
+            # source #4 owns those. Re-adopting it would strip it back to a stdio
+            # entry with an empty command, which is the feedback loop above in a
+            # different costume, and would survive the feature being switched off.
+            if str(srv.get("transport", "")) in EXTERNAL_MCP_TRANSPORTS or srv.get("url"):
+                log.debug("Skipping external-server config.toml entry %r", name)
+                continue
             servers[name] = {
                 "name": name,
                 "command": command,
                 "args": cast("list[Any]", srv.get("args", [])),
                 "env": {},
             }
+
+    # ── 4. External MCP servers (advanced; gated on an explicit acknowledgement)
+    # Last, and non-shadowing: a local stack of the same name always wins, so a
+    # remote entry can never displace an audited on-premise tool set.
+    for entry in external_servers():
+        if entry["name"] not in servers:
+            servers[entry["name"]] = entry
 
     return list(servers.values())
 
@@ -601,6 +618,301 @@ def active_servers() -> list[JsonDict]:
     """Return only the active subset of all discovered servers."""
     active_names = load_active_server_names()
     return [s for s in load_mcp_servers() if s["name"] in active_names]
+
+
+# ── External MCP servers (advanced, off by default) ──────────────────────────
+# Wiring the workspace to a third-party MCP service crosses the on-premise
+# boundary the rest of the product guarantees, so this is gated twice: the
+# operator must enable the feature *and* have acknowledged what it means. Nothing
+# is discovered until both hold, which is why `external_mcp_enabled()` — not the
+# stored `enabled` flag — is what discovery consults.
+#
+# Remote HTTP transports only. A stdio entry here would mean launching an
+# arbitrary binary on the host, which is a categorically larger hole than a
+# network call the permission flow already gates, so it is not offered.
+#
+# Credentials are stored as the *name* of an environment variable, never a token:
+# `.vibe/config.toml` is rewritten on every sync and readable by anything in the
+# container, so it is the wrong place for a secret.
+EXTERNAL_MCP_PATH: Path = VIBE_HOME / "external_mcp.json"
+EXTERNAL_MCP_TRANSPORTS: tuple[str, ...] = ("streamable-http", "http")
+_ENV_VAR_RE: re.Pattern[str] = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+# RFC 7230 token characters — the same set vibe validates header names against.
+_HEADER_NAME_RE: re.Pattern[str] = re.compile(r"[A-Za-z0-9!#$%&'*+.^_`|~-]+")
+
+
+def _default_external_state() -> JsonDict:
+    return {"enabled": False, "acknowledged_at": None, "servers": []}
+
+
+def load_external_mcp() -> JsonDict:
+    """Return the external-MCP state (``enabled``/``acknowledged_at``/``servers``)."""
+    if not EXTERNAL_MCP_PATH.exists():
+        return _default_external_state()
+    try:
+        data = cast("JsonDict", json.loads(EXTERNAL_MCP_PATH.read_text()))
+    except (json.JSONDecodeError, OSError) as exc:
+        log.warning("could not read %s; treating as disabled: %s", EXTERNAL_MCP_PATH, exc)
+        return _default_external_state()
+    state = _default_external_state()
+    state["enabled"] = bool(data.get("enabled"))
+    ack = data.get("acknowledged_at")
+    state["acknowledged_at"] = str(ack) if ack else None
+    servers = data.get("servers")
+    state["servers"] = list(cast("list[JsonDict]", servers)) if isinstance(servers, list) else []
+    return state
+
+
+def _save_external_mcp(state: JsonDict) -> None:
+    _atomic_write_json(EXTERNAL_MCP_PATH, state)
+
+
+def external_mcp_acknowledged() -> bool:
+    """Whether the operator has accepted responsibility for external services."""
+    return bool(load_external_mcp()["acknowledged_at"])
+
+
+def external_mcp_enabled() -> bool:
+    """Whether external MCP servers may be discovered at all.
+
+    Both the toggle and the acknowledgement are required — a state file that
+    somehow carries ``enabled`` without one is treated as off rather than trusted.
+    """
+    state = load_external_mcp()
+    return bool(state["enabled"]) and bool(state["acknowledged_at"])
+
+
+def acknowledge_external_mcp() -> JsonDict:
+    """Record that the operator accepted the risks; idempotent (first time wins)."""
+    state = load_external_mcp()
+    if not state["acknowledged_at"]:
+        state["acknowledged_at"] = datetime.now(UTC).isoformat(timespec="seconds")
+        _save_external_mcp(state)
+    return state
+
+
+def set_external_mcp_enabled(enabled: bool) -> JsonDict:
+    """Turn the feature on or off. Enabling without an acknowledgement is refused."""
+    state = load_external_mcp()
+    if enabled and not state["acknowledged_at"]:
+        raise ValueError("external MCP must be acknowledged before it can be enabled")
+    state["enabled"] = bool(enabled)
+    _save_external_mcp(state)
+    return state
+
+
+def _validate_api_key_format(fmt: str) -> None:
+    """Raise ``ValueError`` unless *fmt* is a format string using only ``{token}``.
+
+    Mirrors vibe's own check. Enumerating the replacement fields beats searching
+    for the ``{token}`` substring: ``{{token}}`` contains it but escapes to a
+    literal, and ``{token:>5}`` is valid without containing it.
+    """
+    try:
+        fields = [name for _, name, _, _ in Formatter().parse(fmt) if name is not None]
+    except ValueError as exc:
+        raise ValueError(f"invalid token format: {fmt!r} (not a valid format string)") from exc
+    if any(name != "token" for name in fields):
+        raise ValueError(f"invalid token format: {fmt!r} (may only reference {{token}})")
+    if "token" not in fields:
+        raise ValueError(f"invalid token format: {fmt!r} (must contain {{token}})")
+
+
+def _validate_external_server(
+    name: str,
+    transport: str,
+    url: str,
+    api_key_env: str,
+    api_key_header: str = "",
+    api_key_format: str = "",
+) -> None:
+    """Raise ``ValueError`` if any field of a proposed external server is unusable."""
+    if not _STACK_NAME_RE.fullmatch(name):
+        raise ValueError(f"invalid server name: {name!r} (lowercase letters, digits and '-')")
+    if transport not in EXTERNAL_MCP_TRANSPORTS:
+        allowed = ", ".join(EXTERNAL_MCP_TRANSPORTS)
+        raise ValueError(f"invalid transport: {transport!r} (allowed: {allowed})")
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        raise ValueError(f"invalid url: {url!r} (must be an http(s) URL)")
+    if api_key_env and not _ENV_VAR_RE.fullmatch(api_key_env):
+        raise ValueError(f"invalid environment variable name: {api_key_env!r}")
+    if api_key_header and not _HEADER_NAME_RE.fullmatch(api_key_header):
+        raise ValueError(f"invalid header name: {api_key_header!r}")
+    if api_key_format:
+        _validate_api_key_format(api_key_format)
+    # vibe ignores the header/format fields when no token is configured and warns
+    # about it; refuse up front rather than storing settings that do nothing.
+    if (api_key_header or api_key_format) and not api_key_env:
+        raise ValueError("a header or token format needs an environment variable to send")
+
+
+def add_external_server(
+    name: str,
+    transport: str,
+    url: str,
+    api_key_env: str = "",
+    active: bool = True,
+    api_key_header: str = "",
+    api_key_format: str = "",
+) -> JsonDict:
+    """Register an external MCP server and return the stored entry.
+
+    The name must not collide with a discovered stack: a duplicate would shadow a
+    local, audited tool set with a remote one of the operator's choosing.
+
+    ``api_key_header``/``api_key_format`` are optional overrides for services that
+    do not take a bearer token (``X-API-Key: <token>``, say); left empty, vibe's
+    ``Authorization: Bearer {token}`` default applies.
+    """
+    name, transport, url = name.strip(), transport.strip(), url.strip()
+    api_key_env = api_key_env.strip()
+    api_key_header, api_key_format = api_key_header.strip(), api_key_format.strip()
+    _validate_external_server(name, transport, url, api_key_env, api_key_header, api_key_format)
+
+    state = load_external_mcp()
+    if any(str(s.get("name")) == name for s in cast("list[JsonDict]", state["servers"])):
+        raise ValueError(f"an external server named {name!r} already exists")
+    local = {s["name"] for s in load_mcp_servers() if not s.get("external")}
+    if name in local:
+        raise ValueError(f"{name!r} is already the name of an installed stack")
+
+    entry: JsonDict = {
+        "name": name,
+        "transport": transport,
+        "url": url,
+        "api_key_env": api_key_env,
+        "api_key_header": api_key_header,
+        "api_key_format": api_key_format,
+        "active": bool(active),
+    }
+    cast("list[JsonDict]", state["servers"]).append(entry)
+    _save_external_mcp(state)
+
+    # A server the operator just added is meant to be on. Once written, the active
+    # set is an explicit list rather than "everything discovered", so without this
+    # the new entry would be discovered and then silently left out of the sync.
+    if active:
+        load_mcp_servers.cache_clear()
+        save_active_server_names(load_active_server_names() | {name})
+    return entry
+
+
+def remove_external_server(name: str) -> None:
+    """Delete an external server by name."""
+    state = load_external_mcp()
+    servers = cast("list[JsonDict]", state["servers"])
+    remaining = [s for s in servers if str(s.get("name")) != name]
+    if len(remaining) == len(servers):
+        raise FileNotFoundError(f"no external server named {name!r}")
+    state["servers"] = remaining
+    _save_external_mcp(state)
+
+
+def set_external_server_active(name: str, active: bool) -> None:
+    """Enable or disable a single external server without deleting it."""
+    state = load_external_mcp()
+    for srv in cast("list[JsonDict]", state["servers"]):
+        if str(srv.get("name")) == name:
+            srv["active"] = bool(active)
+            _save_external_mcp(state)
+            return
+    raise FileNotFoundError(f"no external server named {name!r}")
+
+
+def external_servers() -> list[JsonDict]:
+    """Return active external servers as server-config dicts, or [] when gated off."""
+    if not external_mcp_enabled():
+        return []
+    out: list[JsonDict] = []
+    for srv in cast("list[JsonDict]", load_external_mcp()["servers"]):
+        if not srv.get("active"):
+            continue
+        name, url = str(srv.get("name", "")), str(srv.get("url", ""))
+        transport = str(srv.get("transport", ""))
+        env_var = str(srv.get("api_key_env") or "")
+        header = str(srv.get("api_key_header") or "")
+        fmt = str(srv.get("api_key_format") or "")
+        try:
+            _validate_external_server(name, transport, url, env_var, header, fmt)
+        except ValueError as exc:
+            log.warning("skipping malformed external server %r: %s", name, exc)
+            continue
+        entry: JsonDict = {
+            "name": name,
+            "transport": transport,
+            "url": url,
+            "external": True,
+        }
+        if env_var:
+            # Shape fixed by vibe's MCPAuth: a discriminated union on ``type``
+            # whose members forbid extra keys, so a missing discriminator or a
+            # misspelled field is a hard validation error, not a silent no-op —
+            # the server would simply fail to load. ``test_generated_entry_*``
+            # validates what we write here against vibe's own model.
+            #
+            # vibe reads the token from the environment itself (defaulting to an
+            # ``Authorization: Bearer {token}`` header); the variable's name is
+            # all that is ever written to disk.
+            auth: JsonDict = {"type": "static", "api_key_env": env_var}
+            # Written only when overridden, so a server on the default scheme
+            # produces the same config it did before these fields existed.
+            if header:
+                auth["api_key_header"] = header
+            if fmt:
+                auth["api_key_format"] = fmt
+            entry["auth"] = auth
+        out.append(entry)
+    return out
+
+
+# The base prompt tells the agent it runs entirely on-premise and must never
+# suggest sending data to external services. With an external server wired up
+# that is no longer true, and an agent holding tools it has been told never to
+# use behaves erratically — it refuses them, or narrates the contradiction.
+#
+# vibe resolves `system_prompt_id` to exactly one file with no append hook, so
+# the enabled state needs its own prompt. It is *derived* from the base rather
+# than checked in beside it: two hand-maintained copies of a 70-line prompt drift,
+# and the drift is silent. The anchor below is asserted by a test, so editing it
+# out of the base prompt fails CI instead of quietly producing an identical file.
+BASE_SYSTEM_PROMPT_ID: str = "medmcp"
+EXTERNAL_SYSTEM_PROMPT_ID: str = "medmcp-external"
+ONPREM_RULE: str = "- You run entirely on-premise. Never suggest sending data to external services."
+EXTERNAL_RULE: str = (
+    "- Your tool stacks run on-premise. This workspace also has external MCP servers "
+    "configured; the operator enabled them and accepted responsibility for what they "
+    "receive, so use their tools when they fit the task."
+)
+
+
+def write_external_prompt_variant() -> bool:
+    """Derive the external-enabled system prompt next to the base one.
+
+    Returns ``False`` — leaving the base prompt in force — when the source is
+    missing or no longer carries the on-premise rule, so a prompt edit can never
+    silently hand the agent a variant identical to the one it was meant to relax.
+    """
+    prompts = VIBE_HOME / "prompts"
+    base = prompts / f"{BASE_SYSTEM_PROMPT_ID}.md"
+    try:
+        text = base.read_text()
+    except OSError as exc:
+        log.warning("cannot read %s; keeping the base system prompt: %s", base, exc)
+        return False
+    if ONPREM_RULE not in text:
+        log.warning(
+            "%s no longer contains the on-premise rule; keeping the base system prompt", base
+        )
+        return False
+    try:
+        (prompts / f"{EXTERNAL_SYSTEM_PROMPT_ID}.md").write_text(
+            text.replace(ONPREM_RULE, EXTERNAL_RULE)
+        )
+    except OSError as exc:
+        log.warning("could not write the external system prompt: %s", exc)
+        return False
+    return True
 
 
 # ── Container-stack install / uninstall (UI-driven) ──────────────────────────
@@ -1240,7 +1552,20 @@ def _sync_servers_to_vibe_config_locked(servers: list[JsonDict]) -> None:
     new_entries: list[JsonDict] = []
     for srv in servers:
         name = srv["name"]
-        if name in existing_by_name:
+        if srv.get("external"):
+            # An HTTP server has no command/args to preserve or overwrite, and
+            # nothing about it is owned by config.toml — the state file is the
+            # single source of truth, so it is rebuilt from scratch each sync.
+            # That also means disabling the feature removes these entries.
+            entry = {
+                "transport": srv["transport"],
+                "name": name,
+                "url": srv["url"],
+            }
+            if srv.get("auth"):
+                entry["auth"] = srv["auth"]
+            new_entries.append(entry)
+        elif name in existing_by_name:
             # Preserve vibe-acp-specific fields (timeouts, transport, etc.)
             # and overwrite discovery-owned fields (command, args).
             entry = dict(existing_by_name[name])
@@ -1292,14 +1617,29 @@ def _sync_servers_to_vibe_config_locked(servers: list[JsonDict]) -> None:
     # then spawns the cheap `medmcp-mcp-proxy <stack>` shim, which forwards to the
     # persistent BackendPool; the real launch specs go to backends.json. Disabled
     # is byte-for-byte the legacy behaviour, minus any stale proxy env keys.
+    # External servers are exempt: the pool exists to amortise process spawn and
+    # CUDA init for local stacks, and there is no such cost to amortise for an
+    # HTTP endpoint — routing one through a spawn-shim would only break it.
     if stack_pool_enabled():
-        _write_backend_registry(servers)
+        _write_backend_registry([s for s in servers if not s.get("external")])
         ws_root = os.environ.get("MEDMCP_WORKSPACE") or None
-        new_entries = [_proxied_entry(entry, ws_root) for entry in new_entries]
+        new_entries = [
+            entry if entry.get("url") else _proxied_entry(entry, ws_root) for entry in new_entries
+        ]
     else:
         _strip_pool_env(new_entries)
 
     cfg["mcp_servers"] = new_entries
+
+    # Point vibe at the prompt that matches the posture actually in force. Only a
+    # value this function owns is overwritten, so a hand-set custom prompt id is
+    # left alone rather than being reset on the next sync.
+    use_external = any(s.get("external") for s in servers) and write_external_prompt_variant()
+    owned_prompt_ids = ("", BASE_SYSTEM_PROMPT_ID, EXTERNAL_SYSTEM_PROMPT_ID)
+    if str(cfg.get("system_prompt_id", "")) in owned_prompt_ids:
+        cfg["system_prompt_id"] = (
+            EXTERNAL_SYSTEM_PROMPT_ID if use_external else BASE_SYSTEM_PROMPT_ID
+        )
 
     # Collect skills_path values from discovered servers and write them to
     # skill_paths so vibe-acp loads the bundled skill docs automatically.

--- a/tests/fake_external_server.py
+++ b/tests/fake_external_server.py
@@ -1,0 +1,134 @@
+r"""A stand-in *external* MCP server that demands a bearer token.
+
+`fake_stack_server.py` covers the local stdio case; this covers the other side of
+external MCP, which nothing else can: a remote HTTP server that rejects an
+unauthenticated request. It exists to answer one question end to end — does the
+token an operator typed into the workspace actually arrive at the service? — and
+to make the three interesting outcomes reproducible: right token, wrong token,
+no token at all.
+
+Run it beside a workspace container, on the same docker network, from the image
+that already has the `mcp` library::
+
+    docker run --rm -d --name mcp-authtest --network medmcp_default \\
+        --entrypoint python \\
+        -e EXPECTED_TOKEN=hunter2 -e MCP_TEST_PORT=9000 \\
+        -v "$PWD/tests/fake_external_server.py:/srv.py:ro" \\
+        medmcp-core:dev /srv.py
+
+``--entrypoint python`` matters: the image's own entrypoint ignores the command
+and starts the workspace server, which listens on 8100 and looks convincingly
+like this one having come up on the wrong port.
+
+Then add ``http://mcp-authtest:9000/mcp`` in Settings → Advanced with the same
+token, ask the agent to call ``whoami``, and read ``docker logs mcp-authtest``.
+
+The log prints the credential it received **in full** — that is the evidence the
+whole exercise is after, and this server is a throwaway holding a throwaway
+token. The tool's *reply* masks it instead: replies land in the chat transcript
+and the provenance record, which are kept.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import uvicorn
+from mcp.server.fastmcp import FastMCP
+from mcp.server.transport_security import TransportSecuritySettings
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+EXPECTED_TOKEN: str = os.environ.get("EXPECTED_TOKEN", "hunter2")
+HEADER: str = os.environ.get("EXPECTED_HEADER", "authorization")
+SCHEME: str = os.environ.get("EXPECTED_SCHEME", "Bearer ")
+# Deliberately not `PORT`: the image this runs in already sets that, and
+# inheriting it silently moves the server to another port.
+PORT: int = int(os.environ.get("MCP_TEST_PORT", "9000"))
+
+# FastMCP's DNS-rebinding guard allows only localhost by default, and this
+# server is reached by container name — without this every authenticated
+# request comes back 421 "Invalid Host header", which reads like an auth
+# failure and is not one.
+mcp: FastMCP = FastMCP(
+    "fake-external",
+    transport_security=TransportSecuritySettings(enable_dns_rebinding_protection=False),
+)
+
+_last_credential: str = ""
+
+
+@mcp.tool()
+def whoami() -> str:
+    """Report how this call was authenticated, without echoing the credential."""
+    if not _last_credential:
+        return "called with no credential"
+    return (
+        f"authenticated with a {len(_last_credential)}-character token "
+        f"ending {_last_credential[-4:]}"
+    )
+
+
+@mcp.tool()
+def echo(text: str) -> str:
+    """Return *text* unchanged, so the agent has something trivial to call."""
+    return text
+
+
+class RequireToken:
+    """Reject any MCP request that does not carry the expected credential.
+
+    A real service answers 401 and the agent surfaces it; that is the failure we
+    want reproducible, because it is what a wrong or missing token looks like
+    from the workspace and is otherwise indistinguishable from plumbing that
+    dropped the token silently.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        """Wrap *app*, checking every HTTP request before it reaches the MCP handler."""
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Pass the request through, or answer 401 when the credential is wrong."""
+        # One process serving one probe at a time, so a module global is enough
+        # to let `whoami` describe the call that reached it.
+        global _last_credential
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+        request = Request(scope, receive)
+        supplied = request.headers.get(HEADER, "")
+        # Full value to the log on purpose: this is the proof the test is for.
+        print(
+            f"[fake-external] {request.method} {request.url.path} {HEADER}={supplied!r}", flush=True
+        )
+        expected = f"{SCHEME}{EXPECTED_TOKEN}"
+        if supplied != expected:
+            print(f"[fake-external] REJECTED (expected {expected!r})", flush=True)
+            response = JSONResponse(
+                {"error": "unauthorized", "detail": f"expected {HEADER}: {SCHEME}<token>"},
+                status_code=401,
+            )
+            await response(scope, receive, send)
+            return
+        _last_credential = EXPECTED_TOKEN
+        await self.app(scope, receive, send)
+
+
+def main() -> None:
+    """Serve the MCP endpoint at ``/mcp`` with the credential check in front."""
+    app = mcp.streamable_http_app()
+    app.add_middleware(RequireToken)
+    print(
+        f"[fake-external] listening on :{PORT}/mcp; expecting {HEADER}: {SCHEME}{EXPECTED_TOKEN}",
+        file=sys.stderr,
+        flush=True,
+    )
+    # Bound wide on purpose: reached from a sibling container, never published.
+    uvicorn.run(app, host="0.0.0.0", port=PORT, log_level="warning")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_deploy_compose.py
+++ b/tests/test_deploy_compose.py
@@ -12,6 +12,9 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
+from typing import Any, cast
+
+import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -47,3 +50,28 @@ def test_inlined_base_model_matches_the_modelfile_from_line() -> None:
     )
     compose = (ROOT / "docker-compose.ghcr.yml").read_text()
     assert f"MEDMCP_BASE_MODEL:-{from_line}" in compose
+
+
+def _vibe_mounts(filename: str) -> set[str]:
+    """Return every ``name:/app/.vibe/<dir>`` volume entry in a compose file."""
+    doc = cast("dict[str, Any]", yaml.safe_load((ROOT / filename).read_text()))
+    services = cast("dict[str, Any]", doc["services"])
+    found: set[str] = set()
+    for service in services.values():
+        for entry in cast("list[Any]", cast("dict[str, Any]", service).get("volumes") or []):
+            if isinstance(entry, str) and ":/app/.vibe/" in entry:
+                found.add(entry)
+    return found
+
+
+def test_both_compose_files_persist_the_same_vibe_state() -> None:
+    """Whatever the local compose keeps across an image update, the published one keeps too.
+
+    ``.vibe`` otherwise lives in the container's writable layer, so a directory
+    mounted in one file and not the other means the documented install silently
+    loses state a developer keeps — settings, chat history, or a configured
+    external server and the consent that armed it.
+    """
+    local = _vibe_mounts("docker-compose.yml")
+    assert local, "no .vibe volumes found — did the mount format change?"
+    assert local == _vibe_mounts("docker-compose.ghcr.yml")

--- a/tests/test_external_mcp.py
+++ b/tests/test_external_mcp.py
@@ -95,6 +95,29 @@ def test_acknowledgement_is_idempotent() -> None:
     assert settings.acknowledge_external_mcp()["acknowledged_at"] == first
 
 
+def test_disabling_clears_the_acknowledgement() -> None:
+    """Consent covers one activation, so turning it off withdraws it."""
+    settings.acknowledge_external_mcp()
+    settings.set_external_mcp_enabled(True)
+    settings.set_external_mcp_enabled(False)
+    assert settings.external_mcp_acknowledged() is False
+    assert settings.load_external_mcp()["acknowledged_at"] is None
+
+
+def test_re_enabling_needs_fresh_consent() -> None:
+    """Off and on again must go through the dialog, not inherit the old decision."""
+    settings.acknowledge_external_mcp()
+    settings.set_external_mcp_enabled(True)
+    settings.set_external_mcp_enabled(False)
+    with pytest.raises(ValueError, match="acknowledged"):
+        settings.set_external_mcp_enabled(True)
+    assert settings.external_mcp_enabled() is False
+    # …and it works again once the operator has re-read and accepted it.
+    settings.acknowledge_external_mcp()
+    settings.set_external_mcp_enabled(True)
+    assert settings.external_mcp_enabled() is True
+
+
 def test_enabled_flag_alone_does_not_open_the_gate() -> None:
     """A hand-edited state file claiming enabled without an ack is still off."""
     settings.EXTERNAL_MCP_PATH.write_text(

--- a/tests/test_external_mcp.py
+++ b/tests/test_external_mcp.py
@@ -1,0 +1,398 @@
+"""Tests for external MCP servers — the double gate, validation, and sync output.
+
+This feature deliberately crosses the on-premise boundary the rest of the product
+guarantees, so most of what is asserted here is what does *not* happen: no
+discovery without an acknowledgement, no secret written to disk, no remote entry
+shadowing a local stack, and no relaxed system prompt unless one is actually in use.
+"""
+
+from __future__ import annotations
+
+import json
+import tomllib
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from medmcp import settings
+
+JsonDict = dict[str, Any]
+
+
+@pytest.fixture(autouse=True)
+def _isolate(  # pyright: ignore[reportUnusedFunction]  # autouse fixture, invoked by pytest
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Point every piece of on-disk state at a tmp dir."""
+    prompts = tmp_path / "prompts"
+    prompts.mkdir()
+    (prompts / "medmcp.md").write_text(
+        f"You are MedMCP.\n\n**Operational rules**\n{settings.ONPREM_RULE}\n- Other rule.\n"
+    )
+    monkeypatch.setattr(settings, "VIBE_HOME", tmp_path)
+    monkeypatch.setattr(settings, "EXTERNAL_MCP_PATH", tmp_path / "external_mcp.json")
+    monkeypatch.setattr(settings, "ACTIVE_STACKS_PATH", tmp_path / "active_stacks.json")
+    monkeypatch.setattr(settings, "STACKS_D_PATH", tmp_path / "absent-stacks.d")
+    # Source #1 too, or the machine's real uv-tool stacks turn up in discovery.
+    monkeypatch.setattr(settings, "get_uv_tool_dir", lambda: None)
+    monkeypatch.delenv("MEDMCP_STACK_POOL", raising=False)
+    settings.load_mcp_servers.cache_clear()
+
+
+def _entries(tmp_path: Path) -> dict[str, JsonDict]:
+    with (tmp_path / "config.toml").open("rb") as fh:
+        cfg = tomllib.load(fh)
+    return {str(e["name"]): e for e in cast("list[JsonDict]", cfg["mcp_servers"])}
+
+
+def _add(
+    name: str = "pubmed",
+    transport: str = "streamable-http",
+    url: str = "https://example.org/mcp",
+    api_key_env: str = "",
+    api_key_header: str = "",
+    api_key_format: str = "",
+) -> JsonDict:
+    return settings.add_external_server(
+        name,
+        transport,
+        url,
+        api_key_env,
+        True,
+        api_key_header,
+        api_key_format,
+    )
+
+
+# ── the double gate ──────────────────────────────────────────────────────────
+
+
+def test_default_state_is_off() -> None:
+    """Absent state file means disabled, unacknowledged, no servers."""
+    state = settings.load_external_mcp()
+    assert state == {"enabled": False, "acknowledged_at": None, "servers": []}
+    assert settings.external_mcp_enabled() is False
+
+
+def test_enable_without_acknowledgement_is_refused() -> None:
+    """The acknowledgement is a precondition, not a UI-only formality."""
+    with pytest.raises(ValueError, match="acknowledged"):
+        settings.set_external_mcp_enabled(True)
+    assert settings.external_mcp_enabled() is False
+
+
+def test_acknowledge_then_enable() -> None:
+    """With the acknowledgement recorded, the toggle takes effect."""
+    settings.acknowledge_external_mcp()
+    settings.set_external_mcp_enabled(True)
+    assert settings.external_mcp_enabled() is True
+
+
+def test_acknowledgement_is_idempotent() -> None:
+    """Re-acknowledging keeps the original timestamp rather than resetting it."""
+    first = settings.acknowledge_external_mcp()["acknowledged_at"]
+    assert settings.acknowledge_external_mcp()["acknowledged_at"] == first
+
+
+def test_enabled_flag_alone_does_not_open_the_gate() -> None:
+    """A hand-edited state file claiming enabled without an ack is still off."""
+    settings.EXTERNAL_MCP_PATH.write_text(
+        json.dumps(
+            {"enabled": True, "acknowledged_at": None, "servers": [{"name": "x", "active": True}]}
+        )
+    )
+    assert settings.external_mcp_enabled() is False
+    assert settings.external_servers() == []
+
+
+def test_servers_hidden_until_enabled() -> None:
+    """A configured, active server is not discovered while the feature is off."""
+    settings.acknowledge_external_mcp()
+    _add()
+    assert settings.external_servers() == []
+    settings.set_external_mcp_enabled(True)
+    assert [s["name"] for s in settings.external_servers()] == ["pubmed"]
+
+
+# ── validation ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"name": "Bad Name"}, "invalid server name"),
+        ({"transport": "stdio"}, "invalid transport"),
+        ({"url": "ftp://example.org"}, "invalid url"),
+        ({"url": "not-a-url"}, "invalid url"),
+        ({"api_key_env": "not valid!"}, "invalid environment variable"),
+    ],
+)
+def test_rejects_bad_input(kwargs: dict[str, Any], match: str) -> None:
+    """Each field is validated before anything is written."""
+    settings.acknowledge_external_mcp()
+    with pytest.raises(ValueError, match=match):
+        _add(**kwargs)
+    assert settings.load_external_mcp()["servers"] == []
+
+
+def test_stdio_is_not_an_allowed_transport() -> None:
+    """Stdio would mean launching an arbitrary binary on the host — not offered."""
+    assert "stdio" not in settings.EXTERNAL_MCP_TRANSPORTS
+
+
+def test_duplicate_name_rejected() -> None:
+    """Two servers cannot share a name."""
+    settings.acknowledge_external_mcp()
+    _add()
+    with pytest.raises(ValueError, match="already exists"):
+        _add()
+
+
+def test_cannot_shadow_an_installed_stack(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A remote entry must not be able to take an audited local stack's name."""
+    monkeypatch.setattr(
+        settings,
+        "load_mcp_servers",
+        lambda: [{"name": "medmcp-neuro", "command": "/bin/medmcp-neuro"}],
+    )
+    settings.acknowledge_external_mcp()
+    with pytest.raises(ValueError, match="already the name of an installed stack"):
+        _add("medmcp-neuro")
+
+
+# ── discovery + sync ─────────────────────────────────────────────────────────
+
+
+def test_sync_writes_http_entry_without_command(tmp_path: Path) -> None:
+    """The synced entry is an HTTP server: transport + url, and no command/args."""
+    settings.acknowledge_external_mcp()
+    settings.set_external_mcp_enabled(True)
+    _add(api_key_env="PUBMED_TOKEN")
+    settings.load_mcp_servers.cache_clear()
+
+    settings.sync_servers_to_vibe_config(settings.active_servers())
+    entry = _entries(tmp_path)["pubmed"]
+    assert entry["transport"] == "streamable-http"
+    assert entry["url"] == "https://example.org/mcp"
+    assert "command" not in entry
+    assert "args" not in entry
+    assert entry["auth"] == {"type": "static", "api_key_env": "PUBMED_TOKEN"}
+
+
+@pytest.mark.parametrize("env_var", ["", "PUBMED_TOKEN"])
+def test_generated_entry_validates_against_vibes_own_model(
+    tmp_path: Path, env_var: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """What we write must satisfy vibe's schema, not merely look plausible.
+
+    vibe's ``MCPAuth`` is a discriminated union whose members forbid extra keys,
+    so a missing ``type`` or a misspelled field is a hard validation error and the
+    server silently fails to load. Asserting our own dict shape cannot catch that
+    — only vibe's model can, so parse the real synced entry with it.
+    """
+    from vibe.core.config.models import (  # pyright: ignore[reportMissingTypeStubs]  # vibe ships no stubs
+        MCPStreamableHttp,
+    )
+
+    settings.acknowledge_external_mcp()
+    settings.set_external_mcp_enabled(True)
+    _add(api_key_env=env_var)
+    settings.load_mcp_servers.cache_clear()
+    settings.sync_servers_to_vibe_config(settings.active_servers())
+
+    parsed = MCPStreamableHttp.model_validate(_entries(tmp_path)["pubmed"])
+    assert parsed.url == "https://example.org/mcp"
+
+    # And the token actually reaches the wire, read from the environment at
+    # request time rather than from anything we stored.
+    if env_var:
+        monkeypatch.setenv(env_var, "s3cret")
+        assert parsed.http_headers() == {"Authorization": "Bearer s3cret"}
+    else:
+        assert parsed.http_headers() == {}
+
+
+def test_custom_header_and_format_reach_the_wire(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An API-key service (non-bearer) is configurable and sends the right header."""
+    from vibe.core.config.models import (  # pyright: ignore[reportMissingTypeStubs]  # vibe ships no stubs
+        MCPStreamableHttp,
+    )
+
+    settings.acknowledge_external_mcp()
+    settings.set_external_mcp_enabled(True)
+    _add(api_key_env="SVC_KEY", api_key_header="X-API-Key", api_key_format="{token}")
+    settings.load_mcp_servers.cache_clear()
+    settings.sync_servers_to_vibe_config(settings.active_servers())
+
+    monkeypatch.setenv("SVC_KEY", "abc123")
+    parsed = MCPStreamableHttp.model_validate(_entries(tmp_path)["pubmed"])
+    assert parsed.http_headers() == {"X-API-Key": "abc123"}
+
+
+def test_default_scheme_writes_no_override_keys(tmp_path: Path) -> None:
+    """A bearer-token server produces the same config it did before these fields."""
+    settings.acknowledge_external_mcp()
+    settings.set_external_mcp_enabled(True)
+    _add(api_key_env="TOK")
+    settings.load_mcp_servers.cache_clear()
+    settings.sync_servers_to_vibe_config(settings.active_servers())
+    assert _entries(tmp_path)["pubmed"]["auth"] == {"type": "static", "api_key_env": "TOK"}
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"api_key_env": "T", "api_key_header": "bad header"}, "invalid header name"),
+        ({"api_key_env": "T", "api_key_format": "Bearer"}, "must contain"),
+        ({"api_key_env": "T", "api_key_format": "{token} {other}"}, "may only reference"),
+        ({"api_key_env": "T", "api_key_format": "{{token}}"}, "must contain"),
+        ({"api_key_header": "X-API-Key"}, "needs an environment variable"),
+    ],
+)
+def test_rejects_bad_auth_scheme(kwargs: dict[str, Any], match: str) -> None:
+    """Header/format are validated the same way vibe validates them.
+
+    The last case matters most: vibe silently ignores these fields without a
+    token, so storing them would look configured and do nothing.
+    """
+    settings.acknowledge_external_mcp()
+    with pytest.raises(ValueError, match=match):
+        _add(**kwargs)
+
+
+def test_added_server_is_active_even_with_an_explicit_active_set() -> None:
+    """Once active_stacks.json exists it is an explicit list, so add must join it."""
+    settings.save_active_server_names({"medmcp-neuro"})
+    settings.acknowledge_external_mcp()
+    settings.set_external_mcp_enabled(True)
+    _add()
+    settings.load_mcp_servers.cache_clear()
+    assert "pubmed" in settings.load_active_server_names()
+    assert "pubmed" in [s["name"] for s in settings.active_servers()]
+
+
+def test_no_token_is_ever_written(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Only the env var *name* reaches disk — never the credential it holds.
+
+    Asserts on the secret's value rather than on field names, so it keeps testing
+    the actual property as the stored shape grows.
+    """
+    monkeypatch.setenv("PUBMED_TOKEN", "s3cret-do-not-persist")
+    settings.acknowledge_external_mcp()
+    settings.set_external_mcp_enabled(True)
+    _add(api_key_env="PUBMED_TOKEN")
+    settings.load_mcp_servers.cache_clear()
+    settings.sync_servers_to_vibe_config(settings.active_servers())
+
+    for path in (tmp_path / "external_mcp.json", tmp_path / "config.toml"):
+        text = path.read_text()
+        assert "PUBMED_TOKEN" in text  # the name is expected
+        assert "s3cret-do-not-persist" not in text  # the value must never be
+
+
+def test_disabling_removes_the_entries(tmp_path: Path) -> None:
+    """Turning the feature off takes the servers out of the vibe config."""
+    settings.acknowledge_external_mcp()
+    settings.set_external_mcp_enabled(True)
+    _add()
+    settings.load_mcp_servers.cache_clear()
+    settings.sync_servers_to_vibe_config(settings.active_servers())
+    assert "pubmed" in _entries(tmp_path)
+
+    settings.set_external_mcp_enabled(False)
+    settings.load_mcp_servers.cache_clear()
+    settings.sync_servers_to_vibe_config(settings.active_servers())
+    assert "pubmed" not in _entries(tmp_path)
+
+
+def test_synced_entry_is_not_readopted_as_a_stdio_stack(tmp_path: Path) -> None:
+    """Discovery must not pick its own HTTP output back up as a broken local stack."""
+    settings.acknowledge_external_mcp()
+    settings.set_external_mcp_enabled(True)
+    _add()
+    settings.load_mcp_servers.cache_clear()
+    settings.sync_servers_to_vibe_config(settings.active_servers())
+
+    settings.set_external_mcp_enabled(False)
+    settings.load_mcp_servers.cache_clear()
+    assert [s["name"] for s in settings.load_mcp_servers()] == []
+
+
+def test_deactivating_one_server_leaves_it_configured(tmp_path: Path) -> None:
+    """Deactivating hides a server from discovery without forgetting its settings."""
+    settings.acknowledge_external_mcp()
+    settings.set_external_mcp_enabled(True)
+    _add()
+    settings.set_external_server_active("pubmed", False)
+    assert settings.external_servers() == []
+    assert len(cast("list[JsonDict]", settings.load_external_mcp()["servers"])) == 1
+
+
+def test_remove_unknown_server_raises() -> None:
+    """Removing a name that was never registered is a 404, not a silent no-op."""
+    with pytest.raises(FileNotFoundError):
+        settings.remove_external_server("nope")
+
+
+# ── system prompt ────────────────────────────────────────────────────────────
+
+
+def test_prompt_switches_only_while_external_is_in_use(tmp_path: Path) -> None:
+    """The relaxed prompt applies when an external server is active, and not otherwise."""
+    settings.sync_servers_to_vibe_config([])
+    with (tmp_path / "config.toml").open("rb") as fh:
+        assert tomllib.load(fh)["system_prompt_id"] == settings.BASE_SYSTEM_PROMPT_ID
+
+    settings.acknowledge_external_mcp()
+    settings.set_external_mcp_enabled(True)
+    _add()
+    settings.load_mcp_servers.cache_clear()
+    settings.sync_servers_to_vibe_config(settings.active_servers())
+
+    with (tmp_path / "config.toml").open("rb") as fh:
+        assert tomllib.load(fh)["system_prompt_id"] == settings.EXTERNAL_SYSTEM_PROMPT_ID
+    variant = (tmp_path / "prompts" / f"{settings.EXTERNAL_SYSTEM_PROMPT_ID}.md").read_text()
+    assert settings.ONPREM_RULE not in variant
+    assert settings.EXTERNAL_RULE in variant
+
+    settings.set_external_mcp_enabled(False)
+    settings.load_mcp_servers.cache_clear()
+    settings.sync_servers_to_vibe_config(settings.active_servers())
+    with (tmp_path / "config.toml").open("rb") as fh:
+        assert tomllib.load(fh)["system_prompt_id"] == settings.BASE_SYSTEM_PROMPT_ID
+
+
+def test_custom_prompt_id_is_left_alone(tmp_path: Path) -> None:
+    """Only a prompt id this sync owns is rewritten."""
+    (tmp_path / "config.toml").write_text('system_prompt_id = "my-own"\n')
+    settings.sync_servers_to_vibe_config([])
+    with (tmp_path / "config.toml").open("rb") as fh:
+        assert tomllib.load(fh)["system_prompt_id"] == "my-own"
+
+
+def test_missing_anchor_keeps_the_base_prompt(tmp_path: Path) -> None:
+    """A prompt edit that drops the rule must not silently yield a no-op variant."""
+    (tmp_path / "prompts" / "medmcp.md").write_text("You are MedMCP.\n")
+    assert settings.write_external_prompt_variant() is False
+
+    settings.acknowledge_external_mcp()
+    settings.set_external_mcp_enabled(True)
+    _add()
+    settings.load_mcp_servers.cache_clear()
+    settings.sync_servers_to_vibe_config(settings.active_servers())
+    with (tmp_path / "config.toml").open("rb") as fh:
+        assert tomllib.load(fh)["system_prompt_id"] == settings.BASE_SYSTEM_PROMPT_ID
+
+
+def test_shipped_prompt_still_contains_the_anchor() -> None:
+    """Guards the real prompt against drift.
+
+    ``write_external_prompt_variant`` degrades to "keep the base prompt" when the
+    rule it rewrites is gone, which is the safe direction but also a silent one —
+    the feature would just stop relaxing the prompt. This fails loudly instead.
+    """
+    shipped = Path(__file__).resolve().parents[1] / ".vibe" / "prompts" / "medmcp.md"
+    assert settings.ONPREM_RULE in shipped.read_text()

--- a/tests/test_external_mcp.py
+++ b/tests/test_external_mcp.py
@@ -401,6 +401,43 @@ def test_the_off_switch_reaches_the_running_agent(monkeypatch: pytest.MonkeyPatc
     assert settings.external_mcp_enabled() is False
 
 
+def test_token_presence_is_reported_without_the_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The API says whether the named variable holds a token — never what it holds."""
+    settings.acknowledge_external_mcp()
+    settings.set_external_mcp_enabled(True)
+    _add("pubmed", api_key_env="PUBMED_TOKEN")
+    monkeypatch.setenv("PUBMED_TOKEN", "s3cret-value")
+
+    body = TestClient(server.app).get("/api/external-mcp").json()
+
+    server_entry = cast("list[JsonDict]", body["servers"])[0]
+    assert server_entry["token_present"] is True
+    assert "s3cret-value" not in json.dumps(body)
+
+
+def test_missing_token_variable_is_reported(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A named variable that does not exist is flagged, so the UI can say so.
+
+    Without this the only symptom is the remote service's 401 — vibe attaches the
+    header only when the variable is truthy, so the request goes out with no
+    credential rather than failing where the cause is visible.
+    """
+    settings.acknowledge_external_mcp()
+    settings.set_external_mcp_enabled(True)
+    _add("pubmed", api_key_env="PUBMED_TOKEN")
+    monkeypatch.delenv("PUBMED_TOKEN", raising=False)
+
+    body = TestClient(server.app).get("/api/external-mcp").json()
+    assert cast("list[JsonDict]", body["servers"])[0]["token_present"] is False
+
+
+def test_empty_token_variable_counts_as_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty variable is absent for our purposes, matching vibe's own check."""
+    monkeypatch.setenv("PUBMED_TOKEN", "")
+    assert settings.external_token_present("PUBMED_TOKEN") is False
+    assert settings.external_token_present("") is False
+
+
 def test_synced_entry_is_not_readopted_as_a_stdio_stack(tmp_path: Path) -> None:
     """Discovery must not pick its own HTTP output back up as a broken local stack."""
     settings.acknowledge_external_mcp()

--- a/tests/test_external_mcp.py
+++ b/tests/test_external_mcp.py
@@ -14,8 +14,10 @@ from pathlib import Path
 from typing import Any, cast
 
 import pytest
+from fastapi.testclient import TestClient
 
-from medmcp import settings
+# pyright: reportPrivateUsage=false
+from medmcp import server, settings
 
 JsonDict = dict[str, Any]
 
@@ -329,6 +331,74 @@ def test_disabling_removes_the_entries(tmp_path: Path) -> None:
     settings.load_mcp_servers.cache_clear()
     settings.sync_servers_to_vibe_config(settings.active_servers())
     assert "pubmed" not in _entries(tmp_path)
+
+
+def test_nothing_remote_survives_in_the_config(tmp_path: Path) -> None:
+    """After disabling, the written config holds no remote entry of any kind.
+
+    Asserting a known name is gone would miss an entry that lingers under another
+    key, so this asks the stronger question: does anything in the file still point
+    off this machine? The raw text is checked too — a URL surviving in a comment
+    or a stale table is still a thing a reader would have to explain away.
+    """
+    settings.acknowledge_external_mcp()
+    settings.set_external_mcp_enabled(True)
+    _add("pubmed", url="https://example.org/mcp")
+    _add("vendor", url="https://vendor.example/mcp")
+    settings.load_mcp_servers.cache_clear()
+    settings.sync_servers_to_vibe_config(settings.active_servers())
+    assert len(_entries(tmp_path)) == 2
+
+    settings.set_external_mcp_enabled(False)
+    settings.load_mcp_servers.cache_clear()
+    settings.sync_servers_to_vibe_config(settings.active_servers())
+
+    for name, entry in _entries(tmp_path).items():
+        assert "url" not in entry, name
+        assert "auth" not in entry, name
+        assert str(entry.get("transport", "")) not in settings.EXTERNAL_MCP_TRANSPORTS, name
+    raw = (tmp_path / "config.toml").read_text()
+    assert "example.org" not in raw
+    assert "vendor.example" not in raw
+
+
+def test_both_active_and_inactive_servers_are_dropped(tmp_path: Path) -> None:
+    """The switch is a master switch: per-server state does not survive it."""
+    settings.acknowledge_external_mcp()
+    settings.set_external_mcp_enabled(True)
+    _add("pubmed")
+    _add("vendor", url="https://vendor.example/mcp")
+    settings.set_external_server_active("vendor", False)
+
+    settings.set_external_mcp_enabled(False)
+    settings.load_mcp_servers.cache_clear()
+    settings.sync_servers_to_vibe_config(settings.active_servers())
+    assert _entries(tmp_path) == {}
+    assert settings.external_servers() == []
+
+
+def test_the_off_switch_reaches_the_running_agent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Disabling re-syncs the config *and* restarts vibe-acp.
+
+    Dropping the entries from config.toml is only half of it — the agent process
+    already running was started with them, so without the restart the live
+    session would keep talking to whatever it had connected.
+    """
+    calls: list[str] = []
+    monkeypatch.setattr(server, "_apply_stack_change", lambda: calls.append("sync"))
+
+    async def _restart() -> None:
+        calls.append("restart")
+
+    monkeypatch.setattr(server, "_restart_vibe", _restart)
+    settings.acknowledge_external_mcp()
+    settings.set_external_mcp_enabled(True)
+
+    resp = TestClient(server.app).put("/api/external-mcp", json={"enabled": False})
+
+    assert resp.status_code == 200
+    assert calls == ["sync", "restart"]
+    assert settings.external_mcp_enabled() is False
 
 
 def test_synced_entry_is_not_readopted_as_a_stdio_stack(tmp_path: Path) -> None:

--- a/tests/test_external_mcp.py
+++ b/tests/test_external_mcp.py
@@ -34,6 +34,7 @@ def _isolate(  # pyright: ignore[reportUnusedFunction]  # autouse fixture, invok
     )
     monkeypatch.setattr(settings, "VIBE_HOME", tmp_path)
     monkeypatch.setattr(settings, "EXTERNAL_MCP_PATH", tmp_path / "external_mcp.json")
+    monkeypatch.setattr(settings, "EXTERNAL_SECRETS_PATH", tmp_path / "external_secrets.json")
     monkeypatch.setattr(settings, "ACTIVE_STACKS_PATH", tmp_path / "active_stacks.json")
     monkeypatch.setattr(settings, "STACKS_D_PATH", tmp_path / "absent-stacks.d")
     # Source #1 too, or the machine's real uv-tool stacks turn up in discovery.
@@ -64,6 +65,12 @@ def _add(
         True,
         api_key_header,
         api_key_format,
+    )
+
+
+def _add_with_token(name: str, token: str) -> JsonDict:
+    return settings.add_external_server(
+        name, "streamable-http", "https://example.org/mcp", token=token
     )
 
 
@@ -436,6 +443,114 @@ def test_empty_token_variable_counts_as_missing(monkeypatch: pytest.MonkeyPatch)
     monkeypatch.setenv("PUBMED_TOKEN", "")
     assert settings.external_token_present("PUBMED_TOKEN") is False
     assert settings.external_token_present("") is False
+
+
+# ── tokens entered in the UI ─────────────────────────────────────────────────
+
+
+def test_stored_token_never_reaches_the_config(tmp_path: Path) -> None:
+    """A token typed into the UI is not written to the file vibe reads."""
+    settings.acknowledge_external_mcp()
+    settings.set_external_mcp_enabled(True)
+    _add_with_token("pubmed", "s3cret-value")
+    settings.load_mcp_servers.cache_clear()
+    settings.sync_servers_to_vibe_config(settings.active_servers())
+
+    raw = (tmp_path / "config.toml").read_text()
+    assert "s3cret-value" not in raw
+    assert "MEDMCP_EXT_PUBMED" in raw
+    entry = _entries(tmp_path)["pubmed"]
+    assert cast("JsonDict", entry["auth"])["api_key_env"] == "MEDMCP_EXT_PUBMED"
+
+
+def test_stored_token_never_appears_in_a_response() -> None:
+    """Neither the add response nor the state listing carries the value."""
+    settings.acknowledge_external_mcp()
+    settings.set_external_mcp_enabled(True)
+    client = TestClient(server.app)
+
+    added = client.post(
+        "/api/external-mcp/servers",
+        json={
+            "name": "pubmed",
+            "transport": "streamable-http",
+            "url": "https://example.org/mcp",
+            "token": "s3cret-value",
+        },
+    )
+    assert added.status_code == 200
+    assert "s3cret-value" not in added.text
+
+    listed = client.get("/api/external-mcp")
+    assert "s3cret-value" not in listed.text
+    entry = cast("list[JsonDict]", listed.json()["servers"])[0]
+    assert entry["token_managed"] is True
+    assert entry["token_present"] is True
+
+
+def test_stored_token_reaches_the_agent_environment() -> None:
+    """The token is handed to the agent subprocess under the managed name."""
+    settings.acknowledge_external_mcp()
+    settings.set_external_mcp_enabled(True)
+    _add_with_token("pubmed", "s3cret-value")
+    assert settings.external_secret_env() == {"MEDMCP_EXT_PUBMED": "s3cret-value"}
+
+
+def test_no_token_is_handed_over_while_the_feature_is_off() -> None:
+    """Off means the agent process does not even hold the credential."""
+    settings.acknowledge_external_mcp()
+    settings.set_external_mcp_enabled(True)
+    _add_with_token("pubmed", "s3cret-value")
+    settings.set_external_mcp_enabled(False)
+    assert settings.external_secret_env() == {}
+
+
+def test_no_token_is_handed_over_for_a_deactivated_server() -> None:
+    """A server switched off individually does not put its token in the agent."""
+    settings.acknowledge_external_mcp()
+    settings.set_external_mcp_enabled(True)
+    _add_with_token("pubmed", "s3cret-value")
+    settings.set_external_server_active("pubmed", False)
+    assert settings.external_secret_env() == {}
+
+
+def test_token_and_env_var_together_are_refused() -> None:
+    """Two sources would mean one silently loses; say so instead."""
+    with pytest.raises(ValueError, match="either a token or an environment variable"):
+        settings.add_external_server(
+            "pubmed",
+            "streamable-http",
+            "https://example.org/mcp",
+            api_key_env="PUBMED_TOKEN",
+            token="s3cret-value",
+        )
+
+
+def test_removing_a_server_forgets_its_token() -> None:
+    """Nothing is left behind that a later server of the same name would inherit."""
+    settings.acknowledge_external_mcp()
+    settings.set_external_mcp_enabled(True)
+    _add_with_token("pubmed", "s3cret-value")
+    settings.remove_external_server("pubmed")
+    assert settings.load_external_secrets() == {}
+
+
+def test_replacing_a_token_adopts_the_managed_variable() -> None:
+    """A hand-plumbed server can move to a stored token, with one source in play."""
+    settings.acknowledge_external_mcp()
+    settings.set_external_mcp_enabled(True)
+    _add("pubmed", api_key_env="PUBMED_TOKEN")
+    settings.replace_external_token("pubmed", "s3cret-value")
+
+    stored = cast("list[JsonDict]", settings.load_external_mcp()["servers"])[0]
+    assert stored["api_key_env"] == "MEDMCP_EXT_PUBMED"
+    assert settings.external_secret_env() == {"MEDMCP_EXT_PUBMED": "s3cret-value"}
+
+
+def test_secret_file_is_not_world_readable() -> None:
+    """The store holds real credentials; it must not be readable by anything else."""
+    settings.set_external_secret("pubmed", "s3cret-value")
+    assert settings.EXTERNAL_SECRETS_PATH.stat().st_mode & 0o077 == 0
 
 
 def test_synced_entry_is_not_readopted_as_a_stdio_stack(tmp_path: Path) -> None:

--- a/tests/test_stacks_install.py
+++ b/tests/test_stacks_install.py
@@ -22,6 +22,8 @@ LABEL = (
     '"skills_path": "/app/src/medmcp_foo/skills"}'
 )
 
+ROOT = Path(__file__).resolve().parents[1]
+
 
 def _fake_docker(label: str | None) -> Callable[..., subprocess.CompletedProcess[str]]:
     """Return a `_run_docker` stub: `inspect --format` yields *label* (or <no value>)."""
@@ -222,6 +224,69 @@ class TestCatalog:
             patch("medmcp.settings.CATALOG_URL", ""),
         ):
             assert settings.load_catalog() == []
+
+
+class TestCatalogParity:
+    """The two shipped catalogs must describe the same stacks.
+
+    ``catalog.json`` (bundled, ``:dev`` refs) is what a developer browses; the
+    core image also ships ``catalog.ghcr.json``, which ``MEDMCP_CATALOG_URL``
+    points at on deployments that pull from GHCR. Only the image ref may
+    legitimately differ. Both are hand-maintained, so a stack added — or a
+    description edited — in one file alone ships a deployed stack list that
+    disagrees with the dev one, and nothing else compares them. Same guard as
+    ``test_deploy_compose.py`` (the inlined Modelfile) and
+    ``test_security_posture.py`` (the two shipped configs).
+    """
+
+    @staticmethod
+    def _shipped(filename: str) -> list[dict[str, Any]]:
+        """Load a shipped catalog through the real loader, as the UI receives it."""
+        with (
+            patch("medmcp.settings.CATALOG_PATH", ROOT / filename),
+            patch("medmcp.settings.CATALOG_URL", ""),
+        ):
+            return settings.load_catalog()
+
+    def test_same_stacks_in_both(self) -> None:
+        """Both files offer the same stacks, in the same order."""
+        dev = self._shipped("catalog.json")
+        published = self._shipped("catalog.ghcr.json")
+        assert dev, "catalog.json parsed to no entries"
+        assert [e["name"] for e in dev] == [e["name"] for e in published]
+
+    def test_descriptions_and_gpu_match(self) -> None:
+        """The text a user reads and the flag the installer acts on are identical."""
+        published = {e["name"]: e for e in self._shipped("catalog.ghcr.json")}
+        for entry in self._shipped("catalog.json"):
+            other = published.get(entry["name"])
+            assert other is not None, f"{entry['name']} is missing from catalog.ghcr.json"
+            assert entry["description"] == other["description"], entry["name"]
+            assert entry["gpu"] == other["gpu"], entry["name"]
+
+    def test_image_refs_differ_only_by_registry(self) -> None:
+        """The dev ref is ``<repo>:dev``; the published one is that repo on GHCR at ``:main``."""
+        published = {e["name"]: e for e in self._shipped("catalog.ghcr.json")}
+        for entry in self._shipped("catalog.json"):
+            other = published.get(entry["name"])
+            assert other is not None, f"{entry['name']} is missing from catalog.ghcr.json"
+            dev_repo, _, dev_tag = str(entry["image"]).rpartition(":")
+            pub_image = str(other["image"])
+            pub_repo, _, pub_tag = pub_image.rpartition(":")
+            assert dev_tag == "dev", entry["image"]
+            assert pub_tag == "main", pub_image
+            expected = f"ghcr.io/medmcp/{dev_repo.removeprefix('medmcp-')}"
+            assert pub_repo == expected, entry["name"]
+
+    def test_every_entry_has_a_description(self) -> None:
+        """A misspelled or missing ``description`` key is not an error.
+
+        ``load_catalog`` defaults it to ``""``, so the stack still installs but
+        shows up in the marketplace with no text at all.
+        """
+        for filename in ("catalog.json", "catalog.ghcr.json"):
+            for entry in self._shipped(filename):
+                assert str(entry["description"]).strip(), f"{filename}: {entry['name']}"
 
 
 class TestStackIsolation:


### PR DESCRIPTION
## Summary

Adds **external MCP servers**: an advanced, off-by-default setting that lets the agent use MCP tool services hosted outside this machine — a literature search, a hospital system, a vendor API — alongside the local imaging stacks. Because this is the one control that ends the on-premise guarantee, it is gated behind an explicit consent dialog, announced in the interface for as long as it is on, and reversible in one click. Credentials are entered in the workspace and never written to the agent's configuration.

Also corrects stale copy in the TotalSegmentator catalog entry and adds a parity test pinning the two shipped catalogs together.

## Test plan

- [x] `just check` — 509 passed, 2 skipped (ruff, ruff format, pyright strict, pytest)
- [x] `npm run lint` and `tsc --noEmit` clean; production bundle builds
- [x] The generated `auth` block is validated against vibe's own `MCPAuth` model, not against an assertion about our dict shape — a missing discriminator or misspelled field is a hard validation error that would silently drop the server
- [x] Gate: a state file carrying `enabled` without an acknowledgement stays off; disabling clears the acknowledgement, so re-enabling passes through the dialog again
- [x] Off means off: after disabling, nothing in the written `config.toml` points off the machine — no `url`, no `auth`, no remote transport, and neither server URL appears in the file text; the master switch drops servers whatever their individual switches say; the disable endpoint re-syncs *and* restarts vibe-acp so a running process cannot keep a connection the config no longer describes. Each of these fails if the gate is removed.
- [x] Credentials: the token never appears in `config.toml`, in any response body (asserted against the value, not the field name), or in the audit trail; no token is handed to the agent while the feature is off or for a server switched off individually
- [x] Validation: stdio transports refused, external names cannot shadow an installed stack, a synced entry is never re-adopted as a stdio stack, header names restricted to RFC 7230 token characters, token format checked by enumerating replacement fields
- [x] Container: built and run from `docker-compose.yml`; feature state survives a container recreate on the new named volume
- [x] Remote path: exercised against `tests/fake_external_server.py` on the workspace network — 401 without a token, 401 with a wrong one, and a successful `initialize` with the right one, with the server logging the credential it received


## Security & data handling

This adds the only sanctioned path out of the on-premise boundary, so the properties below are the point of the change rather than incidental to it:

- **Double gate.** Discovery consults both the toggle *and* a recorded acknowledgement, never the stored flag alone. Disabling withdraws the acknowledgement, so the explanation cannot be skipped by a switch someone flipped months ago.
- **Remote HTTP transports only.** A stdio entry would mean launching an arbitrary binary on the host, which is categorically larger than a network call the permission flow already gates.
- **No credential in the agent's config.** `config.toml` is rewritten on every sync and readable by anything in the container, so only the *name* of an environment variable is written there. A token entered in the UI is stored 0600 in the state volume and injected into the agent subprocess under a variable this process owns; it is write-only across the API and absent from the audit trail, which records that a credential changed and never to what. A deployment that manages its own secrets can name its own variable instead — the two are mutually exclusive, since one would silently lose.
- **No name shadowing.** An external server may not take the name of an installed stack, or a remote server could stand in for an audited local tool set.
- **The system prompt changes with the posture.** The base prompt forbids sending data to external services; with a server wired up that is no longer true, and an agent holding tools it has been told never to use behaves erratically. The relaxed variant is derived from the base at sync time and applies only while an external server is actually in use.
- **Every tool call still requires approval.** No auto-approval path is added.
- **OAuth is deliberately not wired up.** vibe stores tokens in the OS keyring and the container has no backend; separately, its loopback callback binds container-local, which a host browser cannot reach. Static tokens cover the services this is for.

## Notes

- **Operational:** adds a `vibe-state` named volume to both compose files, mounted at `/app/.vibe/state`. Existing deployments pick it up on the next `up`; nothing needs migrating. A parity test now requires both compose files to persist the same `.vibe` state, so the published install cannot quietly keep less than the local one.
- **Secrets in the container install:** the compose `environment:` block is a fixed allowlist and cannot forward a variable it does not name, so both files carry an optional `env_file` (`${MEDMCP_ENV_FILE:-./medmcp.env}`, `required: false`) for deployments that prefer to supply their own variables. It is only needed for that path.
- **Catalog fix (unrelated to the feature):** the TotalSegmentator entry pointed readers at a settings location that does not exist, applied the CT structure count to MR, and stated a GPU is required although the stack documents a CPU fallback. `TestCatalogParity` now pins names, descriptions, GPU flags and the image-ref convention across `catalog.json` and `catalog.ghcr.json`.
- **Follow-up, pre-existing:** no state-changing endpoint validates `Origin`/`Sec-Fetch-Site`, and the WebSocket endpoints accept without an origin check. That is a property of the workspace server's documented "127.0.0.1, no auth" posture and is unchanged here, but it is worth closing app-wide in one middleware rather than per endpoint.
