### PR TITLE
fix(security): refuse cross-origin browser access, gate stack egress, confine replay inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ Notable, user-visible changes to MedMCP. Format follows
 
 ## Unreleased
 
+### Security
+
+- **A website you visit can no longer reach the workspace.** The workspace
+  listens on your machine only, but a browser will still let any page send
+  requests to it — and a chat connection is not covered by the browser's usual
+  same-site protection at all, so a page could open one, ask the agent to read
+  your files and receive the contents, without any approval prompt appearing.
+  Requests and connections that do not come from the workspace's own page are
+  now refused, as are requests aimed at it under another name (a technique that
+  otherwise gets around the first check). If you reach MedMCP through a
+  hostname of your own — a reverse proxy, say — list it in
+  `MEDMCP_ALLOWED_HOSTS` / `MEDMCP_ALLOWED_ORIGINS`; anything unlisted is
+  refused.
+
 ### Added
 
 - **TotalSegmentator stack**, installable from the Tool stacks window. Segments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Notable, user-visible changes to MedMCP. Format follows
 
 ## Unreleased
 
+### Fixed
+
+- **Uninstalling a tool stack now removes it properly.** A stack could disappear
+  from the stacks window while still showing in settings, and on an installation
+  that had never changed which stacks are switched on, it could come back
+  entirely — the agent kept being told to launch something you had removed.
+
 ### Security
 
 - **A tool stack can no longer get internet access without you agreeing to it.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ Notable, user-visible changes to MedMCP. Format follows
 
 ### Security
 
+- **A tool stack can no longer get internet access without you agreeing to it.**
+  Stacks normally run with networking switched off — they see the files you point
+  them at and nothing else — but an image can ask for network access, and your
+  workspace is available to it, so it could send what it reads elsewhere. That
+  request now stops the install and asks you first, and any stack that has it is
+  marked **internet** in the stacks window for as long as it is installed.
+- **Saved workflows can only touch your workspace.** A workflow runs its recorded
+  tool calls without asking for approval each time, so a file it names is now
+  required to be inside the workspace — including by way of a shortcut that
+  points out of it. Anything else is refused before the first step runs.
+
 - **A website you visit can no longer reach the workspace.** The workspace
   listens on your machine only, but a browser will still let any page send
   requests to it — and a chat connection is not covered by the browser's usual

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,6 +27,29 @@ Out of scope:
 - Issues that only apply to clinical use (MedMCP is not approved for it — see the warning in the README)
 - Denial of service on deliberately malformed inputs where the fix is "don't feed it malformed inputs"
 
+## Network posture
+
+The workspace server listens on loopback and has **no authentication**. Do not
+expose the port. In a container it binds `0.0.0.0`, and compose publishes it only
+to the host's loopback (`127.0.0.1:8100:8100`) — keep it that way.
+
+Binding loopback does not by itself keep a browser out: any page you visit can
+send requests to `127.0.0.1`, and a WebSocket upgrade is exempt from the
+same-origin policy entirely. The server therefore refuses requests and
+connections whose `Origin` is not the workspace's own page, and requests whose
+`Host` is not a loopback address (which is what stops DNS rebinding, where a
+hostname the attacker controls resolves to `127.0.0.1`).
+
+If you front MedMCP with a reverse proxy or reach it by a hostname, list it:
+
+```
+MEDMCP_ALLOWED_HOSTS=medmcp.example.internal
+MEDMCP_ALLOWED_ORIGINS=https://medmcp.example.internal
+```
+
+Both default to empty — unlisted means refused. Neither replaces authentication,
+which the workspace does not have; they keep a browser from acting as one.
+
 ## Patient data
 
 If a security issue only reproduces with data you cannot share, describe the file characteristics (modality, vendor, transfer syntax, dimensions) and we will reproduce with synthetic data. **Never** attach PHI to emails, logs, or issues.

--- a/frontend/src/components/StackMarketplace.tsx
+++ b/frontend/src/components/StackMarketplace.tsx
@@ -22,6 +22,9 @@ interface StackItem {
   image: string
   description: string
   gpu: boolean
+  /** Runs with network egress. The workspace is mounted into every stack, so
+   *  this separates a stack that can read your data from one that can send it. */
+  network: boolean
   installed: boolean
   /** Enabled for the agent. Only meaningful once installed. */
   active: boolean
@@ -66,6 +69,9 @@ export function StackMarketplace({ open, onClose }: StackMarketplaceProps) {
   const [state, setState] = useState<SettingsState | null>(null)
   const [catalog, setCatalog] = useState<CatalogEntry[]>([])
   const [containerNames, setContainerNames] = useState<Set<string>>(new Set())
+  // Installed stacks that run with egress, so the badge is right for stacks
+  // installed before this was surfaced (and for off-catalogue ones).
+  const [networkNames, setNetworkNames] = useState<Set<string>>(new Set())
   const [query, setQuery] = useState('')
   const [filter, setFilter] = useState<Filter>('all')
   const [busy, setBusy] = useState(false)
@@ -73,6 +79,12 @@ export function StackMarketplace({ open, onClose }: StackMarketplaceProps) {
   const [progress, setProgress] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [notice, setNotice] = useState<string | null>(null)
+  // Set when an install stopped to ask about network access.
+  const [consent, setConsent] = useState<{
+    image: string
+    name: string
+    after?: () => void
+  } | null>(null)
   const [manualImage, setManualImage] = useState('')
 
   const reload = async () => {
@@ -83,6 +95,7 @@ export function StackMarketplace({ open, onClose }: StackMarketplaceProps) {
     ])
     setState(s)
     setContainerNames(new Set(inst.map((i) => i.name)))
+    setNetworkNames(new Set(inst.filter((i) => i.network).map((i) => i.name)))
     setCatalog(cat)
   }
 
@@ -94,6 +107,7 @@ export function StackMarketplace({ open, onClose }: StackMarketplaceProps) {
         if (cancelled) return
         setState(s)
         setContainerNames(new Set(inst.map((i) => i.name)))
+        setNetworkNames(new Set(inst.filter((i) => i.network).map((i) => i.name)))
         setCatalog(cat)
         setError(null)
       })
@@ -132,6 +146,7 @@ export function StackMarketplace({ open, onClose }: StackMarketplaceProps) {
         image: c.image,
         description: c.description,
         gpu: c.gpu,
+        network: c.network || networkNames.has(c.name),
         installed: c.installed,
         active: false,
         offCatalog: false,
@@ -149,6 +164,7 @@ export function StackMarketplace({ open, onClose }: StackMarketplaceProps) {
           image: containerNames.has(s.name) ? 'container image' : '',
           description: '',
           gpu: false,
+          network: networkNames.has(s.name),
           installed: true,
           active: s.active,
           version: s.version,
@@ -157,7 +173,7 @@ export function StackMarketplace({ open, onClose }: StackMarketplaceProps) {
       }
     }
     return [...byName.values()].sort((a, b) => a.name.localeCompare(b.name))
-  }, [catalog, state, containerNames])
+  }, [catalog, state, containerNames, networkNames])
 
   const visible = useMemo(() => {
     const q = query.trim().toLowerCase()
@@ -174,7 +190,7 @@ export function StackMarketplace({ open, onClose }: StackMarketplaceProps) {
     })
   }, [items, query, filter])
 
-  const install = (image: string, after?: () => void) => {
+  const install = (image: string, after?: () => void, acceptNetwork = false) => {
     if (!image || busy) return
     setBusy(true)
     setInstallingImage(image)
@@ -182,12 +198,13 @@ export function StackMarketplace({ open, onClose }: StackMarketplaceProps) {
     setProgress('Starting…')
     const proto = location.protocol === 'https:' ? 'wss' : 'ws'
     const ws = new WebSocket(`${proto}://${location.host}/ws/stacks/install`)
-    ws.onopen = () => ws.send(JSON.stringify({ image }))
+    ws.onopen = () => ws.send(JSON.stringify({ image, accept_network: acceptNetwork }))
     ws.onmessage = (ev: MessageEvent<string>) => {
       const m = JSON.parse(ev.data) as {
-        type: 'progress' | 'done' | 'error'
+        type: 'progress' | 'done' | 'error' | 'needs_network_consent'
         line?: string
         name?: string
+        image?: string
         message?: string
       }
       if (m.type === 'progress') {
@@ -198,6 +215,12 @@ export function StackMarketplace({ open, onClose }: StackMarketplaceProps) {
       setBusy(false)
       setInstallingImage(null)
       setProgress(null)
+      if (m.type === 'needs_network_consent') {
+        // The image asked for egress. Nothing is installed until the operator
+        // has seen what that means and said yes.
+        setConsent({ image, name: m.name ?? image, after })
+        return
+      }
       if (m.type === 'done') {
         after?.()
         reload()
@@ -303,6 +326,9 @@ export function StackMarketplace({ open, onClose }: StackMarketplaceProps) {
                   <div className="market-card-head">
                     <span className="market-name">{i.name}</span>
                     {i.gpu && <span className="stack-badge">GPU</span>}
+                    {/* Not a feature badge: this is the one stack capability
+                        the sandbox around it cannot take back. */}
+                    {i.network && <span className="stack-badge egress">internet</span>}
                     {i.installed && (
                       <span className={`market-state${i.active ? ' on' : ''}`}>
                         {i.active ? 'enabled' : 'disabled'}
@@ -382,6 +408,46 @@ export function StackMarketplace({ open, onClose }: StackMarketplaceProps) {
         {notice && (
           <div className="drawer-toast" role="status">
             {notice}
+          </div>
+        )}
+        {/* The image asked for network access. It has been pulled and inspected
+            by now, never run, and nothing is registered until this is accepted. */}
+        {consent && (
+          <div className="modal-backdrop" onClick={() => setConsent(null)}>
+            <div
+              className="modal ext-mcp-consent"
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="stack-egress-title"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <h3 id="stack-egress-title">Let {consent.name} reach the internet?</h3>
+              <p>
+                Most stacks run with networking switched off: they see the files you point them at
+                and nothing else. This one asks for network access, and your workspace is available
+                to it — so it is able to send what it reads to whoever runs the service it talks to.
+              </p>
+              <p>
+                Install it only if you know why it needs that. You can remove it at any time, and
+                it will be marked <strong>internet</strong> in this list for as long as it is
+                installed.
+              </p>
+              <div className="modal-actions">
+                <button className="btn-text" onClick={() => setConsent(null)}>
+                  Cancel
+                </button>
+                <button
+                  className="btn"
+                  onClick={() => {
+                    const pending = consent
+                    setConsent(null)
+                    install(pending.image, pending.after, true)
+                  }}
+                >
+                  Install with network access
+                </button>
+              </div>
+            </div>
           </div>
         )}
       </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2807,6 +2807,14 @@ textarea.wf-input {
   color: var(--red-tint);
 }
 
+/* A capability badge that is a warning, not a feature: a stack with egress can
+   send what it reads off this machine. Red rather than the neutral badge grey. */
+.stack-badge.egress {
+  color: var(--red-tint);
+  border-color: rgba(210, 34, 41, 0.45);
+  background: rgba(210, 34, 41, 0.12);
+}
+
 /* ── External MCP: the standing connection warning ───────────────────────── */
 
 /* A strip under the header, up for exactly as long as external servers are

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -96,6 +96,10 @@ export interface InstalledStack {
   name: string
   image: string
   gpu: boolean
+  /** Whether this stack runs with network egress. The workspace is mounted into
+   *  every stack, so this is the difference between a stack that can read your
+   *  data and one that can also send it somewhere. */
+  network: boolean
 }
 
 /** One catalog entry (from GET /api/catalog): an installable stack. */
@@ -104,6 +108,8 @@ export interface CatalogEntry {
   image: string
   description: string
   gpu: boolean
+  /** Declared egress — known before the pull, so the warning precedes the install. */
+  network: boolean
   installed: boolean
 }
 

--- a/src/medmcp/backend_broker.py
+++ b/src/medmcp/backend_broker.py
@@ -34,6 +34,7 @@ import asyncio
 import contextlib
 import json
 import logging
+import os
 from pathlib import Path
 from typing import Any, cast
 
@@ -76,6 +77,13 @@ class BackendBroker:
         self._server = await asyncio.start_unix_server(
             self._handle, path=str(self._socket_path), limit=STREAM_LIMIT
         )
+        # Whoever can connect here can invoke any installed stack's tools on the
+        # workspace, below the permission flow entirely — so the mode is set
+        # rather than inherited. Connecting needs write permission, which the
+        # usual 022 umask already withholds from others, but the umask is a
+        # property of how the process was launched (a unit file with UMask=0000
+        # yields 0777) and not something this code should depend on.
+        os.chmod(self._socket_path, 0o600)
         log.info("backend broker listening at %s", self._socket_path)
 
     async def aclose(self) -> None:

--- a/src/medmcp/origincheck.py
+++ b/src/medmcp/origincheck.py
@@ -1,0 +1,113 @@
+"""Decide whether a browser request reached the workspace from its own page.
+
+The workspace server binds loopback and has no authentication, which is safe
+against the network but not against the *browser*: a page on any site the
+operator visits can issue cross-origin requests to ``127.0.0.1``, and a
+WebSocket upgrade is not covered by the same-origin policy at all — the browser
+connects and the server is the only thing that can refuse. Since ``read_file``
+and ``grep`` need no approval, an unrefused socket is enough to have the agent
+read workspace files and stream them back to that page, with no dialog ever
+shown. ``/ws/replay`` is worse: it runs a saved workflow with no permission flow
+at all.
+
+Two headers settle it, and both are needed:
+
+``Origin``
+    Names the page making the request. Browsers always send it on WebSocket
+    upgrades and on cross-origin requests, and cannot be made to forge it.
+``Host``
+    Names the address the request was sent to. This is what stops DNS
+    rebinding, where ``evil.example`` resolves to ``127.0.0.1`` so the page's
+    own origin becomes the target and the ``Origin`` check has nothing to catch.
+
+Both must name a loopback address. Anything else is refused unless the operator
+listed it in ``MEDMCP_ALLOWED_ORIGINS`` / ``MEDMCP_ALLOWED_HOSTS`` (a deployment
+behind a reverse proxy, say) — the default is closed, and a deployment that
+needs otherwise says so explicitly.
+
+Loopback is deliberately allowed on *any* port rather than only the server's:
+the dev frontend runs on its own port and proxies here, and a page already
+served from the operator's own loopback is not the threat this defends against.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+
+# The only *name* that means "this machine". Addresses are parsed, not matched
+# as strings: "127.0.0.1.evil.example" is a domain an attacker can register, and
+# any prefix test on "127." accepts it.
+_LOOPBACK_NAMES: frozenset[str] = frozenset({"localhost"})
+
+
+def _split_host(value: str) -> str:
+    """Return the hostname part of a ``host[:port]`` value, without brackets.
+
+    IPv6 literals arrive bracketed (``[::1]:8100``), so the last colon is only a
+    port separator when it follows the closing bracket or the value holds one
+    colon at most.
+    """
+    value = value.strip()
+    if value.startswith("["):
+        end = value.find("]")
+        return value[1:end] if end != -1 else value
+    return value.rsplit(":", 1)[0] if value.count(":") == 1 else value
+
+
+def _origin_host(origin: str) -> str:
+    """Return the host of an ``Origin`` value, or ``""`` when it has none.
+
+    ``null`` (a sandboxed iframe, a ``file://`` page) has no host and is never
+    equal to a loopback name, so it falls through to refusal.
+    """
+    origin = origin.strip()
+    if "://" not in origin:
+        return ""
+    return _split_host(origin.split("://", 1)[1])
+
+
+def is_loopback(hostname: str) -> bool:
+    """Whether *hostname* names this machine.
+
+    An address is parsed and asked whether it is loopback, which covers all of
+    127.0.0.0/8 and ``::1`` without string matching. A name is accepted only
+    when it is exactly ``localhost``: anything longer is a registrable domain,
+    and a prefix or suffix test on it is how lookalikes get through.
+    """
+    hostname = hostname.strip().lower().rstrip(".")
+    if hostname in _LOOPBACK_NAMES:
+        return True
+    try:
+        return ipaddress.ip_address(hostname).is_loopback
+    except ValueError:
+        return False
+
+
+def _configured(var: str) -> frozenset[str]:
+    """Read a comma-separated allowlist from the environment, lowercased."""
+    raw = os.environ.get(var, "")
+    return frozenset(item.strip().lower() for item in raw.split(",") if item.strip())
+
+
+def reject_reason(host: str, origin: str) -> str | None:
+    """Return why this request must be refused, or ``None`` to let it through.
+
+    *host* and *origin* are the raw header values (empty string when absent).
+    A missing ``Origin`` is not a refusal: non-browser clients (the container
+    healthcheck, ``curl``, the CLI) send none, and a browser that omits it is
+    making a same-origin top-level request. A missing ``Host`` is likewise let
+    through — HTTP/1.1 requires it, so its absence means a client that is not a
+    browser.
+    """
+    if host:
+        hostname = _split_host(host).lower()
+        if not is_loopback(hostname) and hostname not in _configured("MEDMCP_ALLOWED_HOSTS"):
+            return f"unexpected Host {host!r}"
+    if origin:
+        if origin.strip().lower() in _configured("MEDMCP_ALLOWED_ORIGINS"):
+            return None
+        origin_host = _origin_host(origin)
+        if not origin_host or not is_loopback(origin_host):
+            return f"cross-origin request from {origin!r}"
+    return None

--- a/src/medmcp/server.py
+++ b/src/medmcp/server.py
@@ -48,11 +48,13 @@ from fastapi import FastAPI, HTTPException, UploadFile, WebSocket, WebSocketDisc
 from fastapi.responses import FileResponse, JSONResponse, Response
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 from medmcp import (
     batchplan,
     distill,
     explain,
+    origincheck,
     pathcheck,
     pathguard,
     provenance,
@@ -148,7 +150,49 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None]:
         _pool = None
 
 
+class OriginGuard:
+    """Refuse browser requests that did not originate from the workspace's page.
+
+    A pure-ASGI middleware rather than ``@app.middleware("http")`` because the
+    exposure that matters most is the WebSocket one, which the HTTP decorator
+    never sees: ``/ws/chat`` hands out a live agent session and ``/ws/replay``
+    runs a workflow with no permission flow, and the same-origin policy does not
+    apply to either — a page on any site can open them, and the server is the
+    only thing that can say no. The upgrade is refused *before* ``accept``, so
+    the handshake fails and no session is created.
+
+    See :mod:`medmcp.origincheck` for what counts as acceptable and why the
+    ``Host`` header is checked alongside ``Origin`` (DNS rebinding).
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        """Wrap *app*, vetting every HTTP request and WebSocket upgrade."""
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Pass the request through, or refuse it without reaching the route."""
+        if scope["type"] not in ("http", "websocket"):
+            await self.app(scope, receive, send)
+            return
+        headers = {k.decode("latin-1").lower(): v.decode("latin-1") for k, v in scope["headers"]}
+        reason = origincheck.reject_reason(headers.get("host", ""), headers.get("origin", ""))
+        if reason is None:
+            await self.app(scope, receive, send)
+            return
+        _audit.warning("refused %s %s: %s", scope["type"], scope.get("path", ""), reason)
+        if scope["type"] == "websocket":
+            # The connect message has to be consumed before the close is sent;
+            # closing before accept makes the handshake itself fail.
+            await receive()
+            await send({"type": "websocket.close", "code": 1008})
+            return
+        response = JSONResponse({"detail": reason}, status_code=403)
+        await response(scope, receive, send)
+
+
 app = FastAPI(title="MedMCP Workspace", lifespan=_lifespan)
+# Outermost, so a refused request never reaches a route or a static file.
+app.add_middleware(OriginGuard)
 
 # One vibe-acp subprocess shared by every websocket connection. The subprocess
 # cwd must stay PROJECT_ROOT — `uv run` resolves the project from it; the

--- a/src/medmcp/server.py
+++ b/src/medmcp/server.py
@@ -444,6 +444,8 @@ class StackInstallPayload(BaseModel):
     """Request body for installing a container stack from an image."""
 
     image: str
+    # Set once the operator has been told the stack can reach off this machine.
+    accept_network: bool = False
 
 
 class StackUninstallPayload(BaseModel):
@@ -496,7 +498,17 @@ async def post_stack_install(payload: StackInstallPayload) -> JsonDict:
     is available. The image is inspected, never executed, to read the label.
     """
     try:
-        name = await asyncio.to_thread(settings.install_stack_image, payload.image)
+        name = await asyncio.to_thread(
+            partial(settings.install_stack_image, accept_network=payload.accept_network),
+            payload.image,
+        )
+    except settings.NetworkConsentRequiredError as exc:
+        # 409, not 400: the request is well-formed and becomes valid once the
+        # operator has seen what they are agreeing to.
+        raise HTTPException(
+            status_code=409,
+            detail={"needs_network_consent": True, "name": exc.name, "image": exc.image},
+        ) from exc
     except FileNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except ValueError as exc:
@@ -528,10 +540,15 @@ async def post_stack_uninstall(payload: StackUninstallPayload) -> JsonDict:
 async def ws_stack_install(ws: WebSocket) -> None:
     """Install a stack with streamed progress.
 
-    First client message: ``{"image": "..."}``. Streams
+    First client message: ``{"image": "...", "accept_network": bool}``. Streams
     ``{"type":"progress","line":...}`` frames during the pull/extract, then a
     final ``{"type":"done","name":...}`` or ``{"type":"error","message":...}``.
     On success it reloads discovery and restarts vibe-acp (same as the POST path).
+
+    An image that declares network egress ends the run with
+    ``{"type":"needs_network_consent","name":...}`` instead of installing, so
+    the client can put that to the operator and re-issue with consent. The
+    image has been pulled and inspected by then, never executed.
     """
     await ws.accept()
     try:
@@ -539,6 +556,7 @@ async def ws_stack_install(ws: WebSocket) -> None:
     except WebSocketDisconnect:
         return
     image = str(first.get("image", "")).strip()
+    accept_network = bool(first.get("accept_network"))
     loop = asyncio.get_running_loop()
     queue: asyncio.Queue[JsonDict] = asyncio.Queue()
 
@@ -548,11 +566,17 @@ async def ws_stack_install(ws: WebSocket) -> None:
 
     async def run() -> None:
         try:
-            name = await asyncio.to_thread(settings.install_stack_image, image, on_progress)
+            name = await asyncio.to_thread(
+                partial(settings.install_stack_image, accept_network=accept_network),
+                image,
+                on_progress,
+            )
             await asyncio.to_thread(_apply_stack_change)
             _audit.info("stack installed: %s (%s)", name, image)
             await _restart_vibe()
             await queue.put({"type": "done", "name": name})
+        except settings.NetworkConsentRequiredError as exc:
+            await queue.put({"type": "needs_network_consent", "name": exc.name, "image": exc.image})
         except Exception as exc:  # relayed to the client as an error frame
             await queue.put({"type": "error", "message": str(exc)})
 
@@ -561,7 +585,7 @@ async def ws_stack_install(ws: WebSocket) -> None:
         while True:
             frame = await queue.get()
             await ws.send_json(frame)
-            if frame["type"] in ("done", "error"):
+            if frame["type"] in ("done", "error", "needs_network_consent"):
                 break
     except WebSocketDisconnect:
         pass
@@ -951,9 +975,42 @@ def _resolve_input_path(value: str) -> str:
     return value
 
 
-def _resolve_input_paths(inputs: dict[str, str]) -> dict[str, str]:
-    """Apply :func:`_resolve_input_path` to every value of a replay input binding."""
-    return {key: _resolve_input_path(value) for key, value in inputs.items()}
+def _confined_input_path(value: str) -> str:
+    """Resolve a replay input, refusing anything that leaves the workspace.
+
+    Replay calls stack tools directly, with no permission prompt between the
+    binding and the call, so an input naming a path outside the workspace is
+    either a mistake or an attempt to have a tool read something it should not.
+    The container deployment already limits the damage — only the workspace is
+    mounted into a stack — but a host-native stack runs as the operator and can
+    read anything they can, so the confinement belongs here rather than in the
+    deployment.
+
+    Symlinks resolve before the check, so a link inside the workspace pointing
+    out of it is refused too. Values that are not paths at all (``"cuda"``,
+    ``"fast"``) pass through untouched, as does a path that does not exist yet —
+    an output directory, or a genuinely missing scan that should surface as the
+    tool's own error.
+
+    Raises:
+        ValueError: the value resolves outside :data:`WORKSPACE_ROOT`.
+    """
+    if not value:
+        return value
+    if Path(value).is_absolute():
+        resolved = Path(value).resolve()
+        if not resolved.is_relative_to(WORKSPACE_ROOT):
+            raise ValueError(f"input path is outside the workspace: {value!r}")
+        return str(resolved)
+    candidate = (WORKSPACE_ROOT / value).resolve()
+    if not candidate.is_relative_to(WORKSPACE_ROOT):
+        raise ValueError(f"input path escapes the workspace: {value!r}")
+    return str(candidate) if candidate.exists() else value
+
+
+def _confined_input_paths(inputs: dict[str, str]) -> dict[str, str]:
+    """Apply :func:`_confined_input_path` to every value of a replay binding."""
+    return {key: _confined_input_path(value) for key, value in inputs.items()}
 
 
 class ReplayPreviewPayload(BaseModel):
@@ -975,7 +1032,7 @@ async def post_replay_preview(name: str, payload: ReplayPreviewPayload) -> JsonD
         if d is None:
             raise FileNotFoundError(f"no workflow named {name!r}")
         recipe = distill.load_recipe(d)
-        inputs = _resolve_input_paths(dict(payload.inputs))
+        inputs = _confined_input_paths(dict(payload.inputs))
         error = replay.validate(recipe, inputs, settings.active_servers())
         if error is not None:
             return {"ok": False, "error": error, "steps": []}
@@ -997,6 +1054,8 @@ async def post_replay_preview(name: str, payload: ReplayPreviewPayload) -> JsonD
         return await asyncio.to_thread(_preview)
     except FileNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:  # an input pointing outside the workspace
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 class BatchFromPlanPayload(BaseModel):
@@ -1022,7 +1081,7 @@ async def post_batch_from_plan(name: str, payload: BatchFromPlanPayload) -> Json
             raise FileNotFoundError(f"no workflow named {name!r}")
         recipe = distill.load_recipe(d)
         try:
-            rows = batchplan.read_manifest(_resolve_input_path(payload.plan_csv))
+            rows = batchplan.read_manifest(_confined_input_path(payload.plan_csv))
         except OSError as exc:
             return {"ok": False, "error": f"cannot read plan: {exc}", "runs": [], "skipped": []}
         try:
@@ -1032,7 +1091,7 @@ async def post_batch_from_plan(name: str, payload: BatchFromPlanPayload) -> Json
         return {
             "ok": True,
             "error": None,
-            "runs": [_resolve_input_paths(r) for r in binding.runs],
+            "runs": [_confined_input_paths(r) for r in binding.runs],
             "skipped": binding.skipped,
             "column_map": binding.column_map,
         }
@@ -1041,6 +1100,8 @@ async def post_batch_from_plan(name: str, payload: BatchFromPlanPayload) -> Json
         return await asyncio.to_thread(_build)
     except FileNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:  # a plan or binding pointing outside the workspace
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @app.websocket("/ws/replay")
@@ -1062,16 +1123,24 @@ async def ws_replay(ws: WebSocket) -> None:
     SECURITY: the replay engine calls MCP tools directly, bypassing the
     vibe-acp permission flow — the client must show the resolved-steps preview
     (``/replay-preview``) and get an explicit confirmation before connecting.
+    Inputs are confined to the workspace here regardless (see
+    :func:`_confined_input_path`), since a binding arriving on this socket has
+    had no permission prompt between it and the tool call.
     """
     await ws.accept()
     try:
         first = cast("JsonDict", await ws.receive_json())
         name = str(first.get("name") or "")
-        runs = [
-            _resolve_input_paths({str(k): str(v) for k, v in cast("JsonDict", r).items()})
-            for r in cast("list[object]", first.get("runs") or [])
-            if isinstance(r, dict)
-        ]
+        try:
+            runs = [
+                _confined_input_paths({str(k): str(v) for k, v in cast("JsonDict", r).items()})
+                for r in cast("list[object]", first.get("runs") or [])
+                if isinstance(r, dict)
+            ]
+        except ValueError as exc:
+            _audit.warning("replay refused: %s", exc)
+            await ws.send_json({"type": "result", "ok": False, "error": str(exc)})
+            return
         d = _workflow_dir(name)
         if d is None or not runs:
             error = f"no workflow named {name!r}" if d is None else "no inputs to run"

--- a/src/medmcp/settings.py
+++ b/src/medmcp/settings.py
@@ -324,6 +324,31 @@ def _stack_run_hardening() -> tuple[tuple[str, tuple[str, ...]], ...]:
     )
 
 
+class NetworkConsentRequiredError(Exception):
+    """A stack asked for network egress and the caller has not accepted it.
+
+    Egress is the one stack capability that cannot be undone by the sandbox
+    around it: the workspace is bind-mounted into every stack, so a stack that
+    can reach the internet can send the data there. It is declared by the image
+    itself, which is exactly why installing one has to be an explicit decision
+    rather than a label the operator never sees.
+    """
+
+    def __init__(self, name: str, image: str) -> None:
+        """Name the stack and image that need the decision."""
+        super().__init__(f"{name!r} requests network access")
+        self.name = name
+        self.image = image
+
+
+def stack_has_network(args: list[str]) -> bool:
+    """Whether a manifest's ``docker run`` args leave the stack with egress."""
+    if "--network" not in args:
+        return False
+    index = args.index("--network") + 1
+    return index < len(args) and args[index] != "none"
+
+
 def _harden_stack_run_args(args: list[str]) -> list[str]:
     """Insert container-isolation flags into a ``docker run`` argument list.
 
@@ -1260,14 +1285,19 @@ def _write_stack_manifest(name: str, entry: JsonDict) -> None:
         raise
 
 
-def install_stack_image(image: str, on_progress: ProgressFn | None = None) -> str:
+def install_stack_image(
+    image: str, on_progress: ProgressFn | None = None, *, accept_network: bool = False
+) -> str:
     """Install a container stack from *image* and return its name.
 
     Pulls the image if absent (streaming progress to *on_progress*), reads its
     ``org.medmcp.stack`` label, extracts its skills next to the manifest, writes
     ``stacks.d/<name>.toml`` (the launch recipe), and marks the stack active.
-    Idempotent — re-installing overwrites. Raises as :func:`read_stack_label`
-    plus ValueError for a bad name in the label.
+    Idempotent — re-installing overwrites. Raises as :func:`read_stack_label`,
+    ValueError for a bad name in the label, and
+    :class:`NetworkConsentRequiredError` when the image declares egress and
+    *accept_network* was not set — the caller has to have put that to the
+    operator first.
     """
 
     def report(msg: str) -> None:
@@ -1292,6 +1322,9 @@ def install_stack_image(image: str, on_progress: ProgressFn | None = None) -> st
     name = str(meta["name"]).strip()
     if not _STACK_NAME_RE.fullmatch(name):
         raise ValueError(f"invalid stack name in label: {name!r}")
+
+    if meta.get("network") and not accept_network:
+        raise NetworkConsentRequiredError(name, image)
 
     args: list[str] = ["run", "--rm", "-i"]
     if meta.get("gpu"):
@@ -1365,6 +1398,9 @@ def list_installed_stacks() -> list[JsonDict]:
                 "name": m["name"],
                 "image": args[-1] if args else "",
                 "gpu": "--device" in args,
+                # Reported so the UI can show which stacks can reach off-machine;
+                # a stack with egress must not look like one without.
+                "network": stack_has_network(args),
             }
         )
     return out
@@ -1417,6 +1453,7 @@ def load_catalog() -> list[JsonDict]:
                 "image": image,
                 "description": str(e.get("description", "")),
                 "gpu": bool(e.get("gpu", False)),
+                "network": bool(e.get("network", False)),
             }
         )
     return out

--- a/src/medmcp/settings.py
+++ b/src/medmcp/settings.py
@@ -566,12 +566,21 @@ def load_mcp_servers() -> list[JsonDict]:
                     "Skipping stale config.toml entry %r (command not found: %s)", name, command
                 )
                 continue
-            # A container-stack entry (command "docker") reaching here is an orphan:
-            # a present stacks.d manifest would have claimed its name in source #2, so
-            # this is a leftover written into config.toml by a prior sync before the
-            # stack was uninstalled. Drop it so uninstalls actually take effect.
-            if command and Path(command).name == "docker":
-                log.debug("Skipping orphaned container-stack config.toml entry %r", name)
+            # A stack entry reaching here is an orphan: a present stacks.d manifest
+            # would have claimed its name in source #2, so this is a leftover written
+            # into config.toml by a prior sync before the stack was uninstalled. Drop
+            # it so uninstalls actually take effect.
+            #
+            # Both spellings of the command have to be recognised. "docker" is what a
+            # manifest launches directly; PROXY_COMMAND is what the sync writes in its
+            # place when the backend pool is in the picture, and it is an absolute path
+            # to a file that *does* exist — so neither the stale-path check above nor a
+            # docker-only test catches it, and the uninstalled stack came back as a
+            # manual entry (invisible on the stacks list, present in settings, and
+            # re-synced into the config on the next write when no explicit active set
+            # narrows it away).
+            if command and Path(command).name in ("docker", PROXY_COMMAND):
+                log.debug("Skipping orphaned stack config.toml entry %r", name)
                 continue
             # An HTTP entry here is one this sync wrote for an external server —
             # source #4 owns those. Re-adopting it would strip it back to a stdio

--- a/tests/test_backend_broker.py
+++ b/tests/test_backend_broker.py
@@ -71,6 +71,20 @@ async def _roundtrip(socket_path: Path, request: JsonDict) -> JsonDict:
 
 
 @pytest.mark.asyncio
+async def test_socket_is_only_reachable_by_its_owner(tmp_path: Path) -> None:
+    """The broker socket's mode is set, not inherited from the process umask.
+
+    Connecting to it means invoking any installed stack's tools on the workspace,
+    below the permission flow entirely. Connect(2) needs write permission, which
+    a 022 umask already withholds from others — but the umask belongs to whoever
+    launched the process (a unit file with UMask=0000 would produce 0777), so the
+    mode is asserted here rather than assumed.
+    """
+    async with _broker(tmp_path) as sock:
+        assert sock.stat().st_mode & 0o077 == 0
+
+
+@pytest.mark.asyncio
 async def test_list_tools_over_socket(tmp_path: Path) -> None:
     """list_tools returns the stack's tools through the broker."""
     async with _broker(tmp_path) as sock:

--- a/tests/test_deploy_compose.py
+++ b/tests/test_deploy_compose.py
@@ -52,26 +52,37 @@ def test_inlined_base_model_matches_the_modelfile_from_line() -> None:
     assert f"MEDMCP_BASE_MODEL:-{from_line}" in compose
 
 
-def _vibe_mounts(filename: str) -> set[str]:
-    """Return every ``name:/app/.vibe/<dir>`` volume entry in a compose file."""
+def _persisted_paths(filename: str) -> set[str]:
+    """Return the in-container paths under ``/app`` that survive a recreate.
+
+    The *target* path, not the whole mount: the local compose bind-mounts the
+    repo's ``stacks.d`` so a developer can see what the UI wrote, while the
+    published one uses a named volume for the same directory. Both persist it,
+    which is what matters — comparing mount syntax would forbid that difference
+    while catching nothing extra.
+    """
     doc = cast("dict[str, Any]", yaml.safe_load((ROOT / filename).read_text()))
     services = cast("dict[str, Any]", doc["services"])
     found: set[str] = set()
     for service in services.values():
         for entry in cast("list[Any]", cast("dict[str, Any]", service).get("volumes") or []):
-            if isinstance(entry, str) and ":/app/.vibe/" in entry:
-                found.add(entry)
+            if not isinstance(entry, str):
+                continue
+            _, _, target = entry.partition(":")
+            target = target.split(":")[0]
+            if target.startswith("/app/"):
+                found.add(target)
     return found
 
 
-def test_both_compose_files_persist_the_same_vibe_state() -> None:
+def test_both_compose_files_persist_the_same_paths() -> None:
     """Whatever the local compose keeps across an image update, the published one keeps too.
 
-    ``.vibe`` otherwise lives in the container's writable layer, so a directory
-    mounted in one file and not the other means the documented install silently
-    loses state a developer keeps — settings, chat history, or a configured
-    external server and the consent that armed it.
+    Everything under ``/app`` otherwise lives in the container's writable layer,
+    so a directory persisted in one file and not the other means one install
+    silently loses what the other keeps — installed stacks, chat history, or a
+    configured external server and the consent that armed it.
     """
-    local = _vibe_mounts("docker-compose.yml")
-    assert local, "no .vibe volumes found — did the mount format change?"
-    assert local == _vibe_mounts("docker-compose.ghcr.yml")
+    local = _persisted_paths("docker-compose.yml")
+    assert local, "no /app mounts found — did the mount format change?"
+    assert local == _persisted_paths("docker-compose.ghcr.yml")

--- a/tests/test_external_mcp.py
+++ b/tests/test_external_mcp.py
@@ -401,7 +401,9 @@ def test_the_off_switch_reaches_the_running_agent(monkeypatch: pytest.MonkeyPatc
     settings.acknowledge_external_mcp()
     settings.set_external_mcp_enabled(True)
 
-    resp = TestClient(server.app).put("/api/external-mcp", json={"enabled": False})
+    resp = TestClient(server.app, base_url="http://127.0.0.1:8100").put(
+        "/api/external-mcp", json={"enabled": False}
+    )
 
     assert resp.status_code == 200
     assert calls == ["sync", "restart"]
@@ -415,7 +417,7 @@ def test_token_presence_is_reported_without_the_value(monkeypatch: pytest.Monkey
     _add("pubmed", api_key_env="PUBMED_TOKEN")
     monkeypatch.setenv("PUBMED_TOKEN", "s3cret-value")
 
-    body = TestClient(server.app).get("/api/external-mcp").json()
+    body = TestClient(server.app, base_url="http://127.0.0.1:8100").get("/api/external-mcp").json()
 
     server_entry = cast("list[JsonDict]", body["servers"])[0]
     assert server_entry["token_present"] is True
@@ -434,7 +436,7 @@ def test_missing_token_variable_is_reported(monkeypatch: pytest.MonkeyPatch) -> 
     _add("pubmed", api_key_env="PUBMED_TOKEN")
     monkeypatch.delenv("PUBMED_TOKEN", raising=False)
 
-    body = TestClient(server.app).get("/api/external-mcp").json()
+    body = TestClient(server.app, base_url="http://127.0.0.1:8100").get("/api/external-mcp").json()
     assert cast("list[JsonDict]", body["servers"])[0]["token_present"] is False
 
 
@@ -467,7 +469,7 @@ def test_stored_token_never_appears_in_a_response() -> None:
     """Neither the add response nor the state listing carries the value."""
     settings.acknowledge_external_mcp()
     settings.set_external_mcp_enabled(True)
-    client = TestClient(server.app)
+    client = TestClient(server.app, base_url="http://127.0.0.1:8100")
 
     added = client.post(
         "/api/external-mcp/servers",

--- a/tests/test_load_mcp_servers.py
+++ b/tests/test_load_mcp_servers.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
+from medmcp import settings
 from medmcp.settings import load_mcp_servers
 
 JsonDict = dict[str, Any]
@@ -257,6 +258,44 @@ class TestConfigTomlFallback:
             servers = load_mcp_servers()
 
         assert servers == []
+
+    def test_orphaned_proxy_entry_dropped(self, tmp_path: Path) -> None:
+        """The same leftover, spelled the way the sync actually writes it.
+
+        When the backend pool is in the picture the sync writes the stack's command
+        as an absolute path to the ``medmcp-mcp-proxy`` shim, not ``docker``. That
+        path exists, so neither the stale-path check nor a docker-only test drops
+        it, and an uninstalled stack came back as a manual entry: gone from the
+        stacks list, still present in settings, and re-synced into the config on the
+        next write when no explicit active set narrowed it away.
+        """
+        proxy = tmp_path / "bin" / settings.PROXY_COMMAND
+        proxy.parent.mkdir(parents=True)
+        proxy.touch()
+        cfg = tmp_path / "config.toml"
+        cfg.write_text(
+            f'[[mcp_servers]]\nname = "medmcp-neuro"\n'
+            f'command = "{proxy}"\nargs = ["medmcp-neuro"]\n'
+        )
+        with (
+            patch("medmcp.settings.get_uv_tool_dir", return_value=None),
+            patch("medmcp.settings.VIBE_HOME", tmp_path),
+        ):
+            servers = load_mcp_servers()
+
+        assert servers == []
+
+    def test_a_genuine_manual_entry_still_loads(self, tmp_path: Path) -> None:
+        """The orphan rule must not swallow a hand-written server."""
+        cfg = tmp_path / "config.toml"
+        cfg.write_text('[[mcp_servers]]\nname = "my-own-tool"\ncommand = "my-server"\nargs = []\n')
+        with (
+            patch("medmcp.settings.get_uv_tool_dir", return_value=None),
+            patch("medmcp.settings.VIBE_HOME", tmp_path),
+        ):
+            servers = load_mcp_servers()
+
+        assert [s["name"] for s in servers] == ["my-own-tool"]
 
     def test_no_tools_no_config_returns_empty(self, tmp_path: Path) -> None:
         """Nothing installed and no config → empty list."""

--- a/tests/test_origincheck.py
+++ b/tests/test_origincheck.py
@@ -1,0 +1,122 @@
+"""Tests for the browser-origin guard on the workspace server.
+
+The server binds loopback with no authentication, which is safe against the
+network and not against the browser: any page the operator visits can reach
+``127.0.0.1``, and a WebSocket upgrade is exempt from the same-origin policy
+entirely. Since ``read_file`` needs no approval, an unrefused socket is enough
+to have the agent read the workspace and stream it back to that page — so what
+is asserted here is mostly what does *not* get through.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+# pyright: reportPrivateUsage=false
+from medmcp import origincheck, server
+
+
+class TestRejectReason:
+    """The header rules, independent of any server."""
+
+    @pytest.mark.parametrize(
+        "host",
+        ["127.0.0.1:8100", "localhost:8100", "[::1]:8100", "127.0.0.1", "localhost", "127.1.2.3"],
+    )
+    def test_loopback_hosts_pass(self, host: str) -> None:
+        """Every spelling of "this machine" is accepted, on any port."""
+        assert origincheck.reject_reason(host, "") is None
+
+    @pytest.mark.parametrize("host", ["evil.example", "evil.example:8100", "10.0.0.5:8100"])
+    def test_foreign_host_is_refused(self, host: str) -> None:
+        """A non-loopback Host means DNS rebinding: the name resolved here."""
+        assert origincheck.reject_reason(host, "") is not None
+
+    @pytest.mark.parametrize(
+        "origin",
+        ["http://localhost:5173", "http://127.0.0.1:8100", "https://localhost", "http://[::1]:80"],
+    )
+    def test_loopback_origins_pass(self, origin: str) -> None:
+        """The page's own origin, and the dev server that proxies to it."""
+        assert origincheck.reject_reason("127.0.0.1:8100", origin) is None
+
+    @pytest.mark.parametrize(
+        "origin",
+        [
+            "https://evil.example",
+            "http://evil.example:8100",
+            "null",
+            "https://127.0.0.1.evil.example",
+            "https://evil.example/?x=http://localhost",
+        ],
+    )
+    def test_foreign_origins_are_refused(self, origin: str) -> None:
+        """Including the near-misses: a suffix, a sandboxed frame, a lookalike path."""
+        assert origincheck.reject_reason("127.0.0.1:8100", origin) is not None
+
+    def test_absent_headers_pass(self) -> None:
+        """No Origin means a non-browser client; HTTP/1.1 guarantees a Host."""
+        assert origincheck.reject_reason("", "") is None
+
+    def test_operator_can_allow_a_deployment_origin(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A deployment behind a proxy says so explicitly; the default is closed."""
+        assert origincheck.reject_reason("medmcp.hospital.example", "") is not None
+        monkeypatch.setenv("MEDMCP_ALLOWED_HOSTS", "medmcp.hospital.example")
+        monkeypatch.setenv("MEDMCP_ALLOWED_ORIGINS", "https://medmcp.hospital.example")
+        assert (
+            origincheck.reject_reason("medmcp.hospital.example", "https://medmcp.hospital.example")
+            is None
+        )
+
+
+class TestGuardOnTheApp:
+    """The middleware, against the real routes."""
+
+    def test_same_origin_request_is_served(self) -> None:
+        """The workspace's own page keeps working."""
+        client = TestClient(server.app, base_url="http://127.0.0.1:8100")
+        assert (
+            client.get("/healthz", headers={"Origin": "http://127.0.0.1:8100"}).status_code == 200
+        )
+
+    def test_healthcheck_without_an_origin_is_served(self) -> None:
+        """The container healthcheck sends no Origin and must not be refused."""
+        client = TestClient(server.app, base_url="http://127.0.0.1:8100")
+        assert client.get("/healthz").status_code == 200
+
+    def test_cross_origin_http_is_refused(self) -> None:
+        """A page on another site cannot reach the API at all."""
+        client = TestClient(server.app, base_url="http://127.0.0.1:8100")
+        resp = client.get("/api/external-mcp", headers={"Origin": "https://evil.example"})
+        assert resp.status_code == 403
+
+    def test_rebound_host_is_refused(self) -> None:
+        """A name resolved to 127.0.0.1 is caught by the Host check."""
+        client = TestClient(server.app, base_url="http://127.0.0.1:8100")
+        resp = client.get("/healthz", headers={"Host": "evil.example"})
+        assert resp.status_code == 403
+
+    def test_cross_origin_websocket_never_reaches_the_agent(self) -> None:
+        """The upgrade fails before `accept`, so no session is created.
+
+        This is the one that mattered: `/ws/chat` handed a live agent session to
+        any origin, and `read_file` needs no approval, so the page could have
+        the workspace read out to it with no dialog shown.
+        """
+        client = TestClient(server.app, base_url="http://127.0.0.1:8100")
+        with (
+            pytest.raises(WebSocketDisconnect),
+            client.websocket_connect("/ws/chat", headers={"Origin": "https://evil.example"}),
+        ):
+            pass  # pragma: no cover — the connect itself raises
+
+    def test_cross_origin_replay_socket_is_refused(self) -> None:
+        """`/ws/replay` runs workflows with no permission flow; same door, same lock."""
+        client = TestClient(server.app, base_url="http://127.0.0.1:8100")
+        with (
+            pytest.raises(WebSocketDisconnect),
+            client.websocket_connect("/ws/replay", headers={"Origin": "https://evil.example"}),
+        ):
+            pass  # pragma: no cover — the connect itself raises

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -145,15 +145,62 @@ class TestResolveInputPath:
         """An empty value is returned untouched (not joined to the root)."""
         assert server._resolve_input_path("") == ""
 
-    def test_resolve_input_paths_maps_every_value(self, root: Path) -> None:
+    def test_confined_input_paths_maps_every_value(self, root: Path) -> None:
         """The dict helper resolves each binding value independently."""
         scan = root / "patient_01" / "visit_02" / "t1n_3d.nii.gz"
         scan.parent.mkdir(parents=True)
         scan.touch()
-        resolved = server._resolve_input_paths(
+        resolved = server._confined_input_paths(
             {"in_1": "patient_01/visit_02/t1n_3d.nii.gz", "in_2": "cuda"}
         )
         assert resolved == {"in_1": str(scan), "in_2": "cuda"}
+
+
+class TestConfinedInputPath:
+    """Replay inputs may not name anything outside the workspace.
+
+    Replay calls stack tools directly, with no permission prompt between the
+    binding and the call, so a path leaving the workspace is either a mistake or
+    an attempt to have a tool read something it should not. In the containerized
+    deployment only the workspace is mounted into a stack, but a host-native
+    stack runs as the operator — so the confinement belongs in the server.
+    """
+
+    @pytest.fixture
+    def root(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+        """Point the server's workspace root at a temp dir (resolved, no symlinks)."""
+        resolved = tmp_path.resolve()
+        monkeypatch.setattr(server, "WORKSPACE_ROOT", resolved)
+        return resolved
+
+    def test_absolute_path_inside_is_kept(self, root: Path) -> None:
+        """Path parity means an absolute workspace path is the normal case."""
+        scan = root / "patient_01" / "scan.nii.gz"
+        scan.parent.mkdir(parents=True)
+        scan.touch()
+        assert server._confined_input_path(str(scan)) == str(scan)
+
+    def test_absolute_path_outside_is_refused(self, root: Path) -> None:
+        """The case that mattered: a tool pointed at the operator's own files."""
+        with pytest.raises(ValueError, match="outside the workspace"):
+            server._confined_input_path("/etc/passwd")
+
+    def test_relative_escape_is_refused(self, root: Path) -> None:
+        """`..` is not a way around the same rule."""
+        with pytest.raises(ValueError, match="escapes the workspace"):
+            server._confined_input_path("../../etc/passwd")
+
+    def test_symlink_out_of_the_workspace_is_refused(self, root: Path) -> None:
+        """Resolution happens before the check, so a link inside is not a loophole."""
+        link = root / "escape"
+        link.symlink_to("/etc")
+        with pytest.raises(ValueError, match="workspace"):
+            server._confined_input_path("escape/passwd")
+
+    def test_non_path_and_missing_values_pass_through(self, root: Path) -> None:
+        """Device strings and not-yet-created outputs are not paths to refuse."""
+        assert server._confined_input_path("cuda") == "cuda"
+        assert server._confined_input_path("out/derivatives") == "out/derivatives"
 
 
 # ── _workspace_note: the viewer-context note handed to the agent ─────────────

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -257,7 +257,7 @@ class TestSettingsMerge:
 
     def test_preserves_entry_unknown_to_the_drawer(self, harness: dict[str, set[str]]) -> None:
         """A stack the drawer never listed stays active after a save."""
-        client = TestClient(server.app)
+        client = TestClient(server.app, base_url="http://127.0.0.1:8100")
         result = self._put(client, stacks=[{"name": "alpha", "active": True}])
         # "beta" was unknown to this drawer payload, so it is kept; nothing changed.
         assert harness["stacks"] == {"alpha", "beta"}
@@ -265,7 +265,7 @@ class TestSettingsMerge:
 
     def test_deactivates_a_known_entry(self, harness: dict[str, set[str]]) -> None:
         """Turning a listed stack off removes it and triggers a restart."""
-        client = TestClient(server.app)
+        client = TestClient(server.app, base_url="http://127.0.0.1:8100")
         result = self._put(
             client,
             stacks=[{"name": "alpha", "active": False}, {"name": "beta", "active": True}],
@@ -275,7 +275,7 @@ class TestSettingsMerge:
 
     def test_no_restart_when_nothing_changes(self, harness: dict[str, set[str]]) -> None:
         """Re-submitting the current state is a no-op restart-wise."""
-        client = TestClient(server.app)
+        client = TestClient(server.app, base_url="http://127.0.0.1:8100")
         result = self._put(
             client,
             stacks=[{"name": "alpha", "active": True}, {"name": "beta", "active": True}],
@@ -316,7 +316,7 @@ class TestWorkflowShareEndpoints:
 
     def test_import_then_export_round_trip(self, vibe_home: Path) -> None:
         """A valid envelope imports as a draft and exports back as a YAML download."""
-        client = TestClient(server.app)
+        client = TestClient(server.app, base_url="http://127.0.0.1:8100")
         resp = client.post("/api/workflows/import", json={"content": self._envelope()})
         assert resp.status_code == 200
         assert resp.json()["name"] == "demo-flow"
@@ -328,13 +328,13 @@ class TestWorkflowShareEndpoints:
 
     def test_import_malformed_returns_400(self, vibe_home: Path) -> None:
         """A payload that isn't a workflow envelope maps to HTTP 400."""
-        client = TestClient(server.app)
+        client = TestClient(server.app, base_url="http://127.0.0.1:8100")
         resp = client.post("/api/workflows/import", json={"content": "- not a mapping"})
         assert resp.status_code == 400
 
     def test_export_missing_returns_404(self, vibe_home: Path) -> None:
         """Exporting an unknown workflow maps to HTTP 404."""
-        client = TestClient(server.app)
+        client = TestClient(server.app, base_url="http://127.0.0.1:8100")
         assert client.get("/api/workflows/nope/export").status_code == 404
 
 
@@ -654,7 +654,7 @@ class TestSessionsApi:
                 }
             },
         )
-        client = TestClient(server.app)
+        client = TestClient(server.app, base_url="http://127.0.0.1:8100")
         resp = client.get("/api/sessions")
         assert resp.status_code == 200
         sessions = resp.json()["sessions"]
@@ -667,7 +667,7 @@ class TestSessionsApi:
     def test_vibe_error_maps_to_502(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """A vibe-acp error surfaces as a 502, not a 500."""
         self._stub_client(monkeypatch, {"error": {"message": "boom"}})
-        client = TestClient(server.app)
+        client = TestClient(server.app, base_url="http://127.0.0.1:8100")
         resp = client.get("/api/sessions")
         assert resp.status_code == 502
 
@@ -698,7 +698,7 @@ class TestSessionsApi:
         monkeypatch.setattr(sessions, "load_registry", _registry)
         monkeypatch.setattr(provenance, "provenance_dir", _prov_dir)
 
-        client = TestClient(server.app)
+        client = TestClient(server.app, base_url="http://127.0.0.1:8100")
         rows = {s["id"]: s for s in client.get("/api/sessions").json()["sessions"]}
         assert rows["s1"]["title"] == "My name"  # override wins over vibe's title
         assert rows["s1"]["archived"] is False
@@ -726,7 +726,7 @@ class TestSessionsApi:
         monkeypatch.setattr(sessions, "load_registry", dict)
         monkeypatch.setattr(provenance, "vibe_session_parents", lambda: {"cont": "root"})
         monkeypatch.setattr(provenance, "provenance_dir", _prov_dir_in(tmp_path))
-        client = TestClient(server.app)
+        client = TestClient(server.app, base_url="http://127.0.0.1:8100")
         rows = client.get("/api/sessions").json()["sessions"]
         assert [s["id"] for s in rows] == ["root", "other"]
         assert rows[0]["updatedAt"] == "t9"
@@ -751,7 +751,7 @@ class TestSessionsApi:
         monkeypatch.setattr(sessions, "load_registry", dict)
         monkeypatch.setattr(provenance, "vibe_session_parents", lambda: {"c1": "root", "c2": "c1"})
         monkeypatch.setattr(provenance, "provenance_dir", _prov_dir_in(tmp_path))
-        client = TestClient(server.app)
+        client = TestClient(server.app, base_url="http://127.0.0.1:8100")
         rows = client.get("/api/sessions").json()["sessions"]
         assert [s["id"] for s in rows] == ["root"]
         assert rows[0]["updatedAt"] == "t9"
@@ -774,7 +774,7 @@ class TestSessionsApi:
         monkeypatch.setattr(sessions, "load_registry", lambda: {"fork": {"title": "My branch"}})
         monkeypatch.setattr(provenance, "vibe_session_parents", lambda: {"fork": "root"})
         monkeypatch.setattr(provenance, "provenance_dir", _prov_dir_in(tmp_path))
-        client = TestClient(server.app)
+        client = TestClient(server.app, base_url="http://127.0.0.1:8100")
         rows = client.get("/api/sessions").json()["sessions"]
         assert [s["id"] for s in rows] == ["root", "fork"]
         assert rows[0]["updatedAt"] == "t1"  # nothing folded into the root
@@ -791,7 +791,7 @@ class TestSessionsApi:
         monkeypatch.setattr(sessions, "load_registry", dict)
         monkeypatch.setattr(provenance, "vibe_session_parents", lambda: {"c1": "elsewhere"})
         monkeypatch.setattr(provenance, "provenance_dir", _prov_dir_in(tmp_path))
-        client = TestClient(server.app)
+        client = TestClient(server.app, base_url="http://127.0.0.1:8100")
         rows = client.get("/api/sessions").json()["sessions"]
         assert [s["id"] for s in rows] == ["c1"]
 
@@ -803,7 +803,7 @@ class TestSessionsApi:
             captured["rename"] = (session_id, title)
 
         monkeypatch.setattr(sessions, "set_title", _set_title)
-        client = TestClient(server.app)
+        client = TestClient(server.app, base_url="http://127.0.0.1:8100")
         resp = client.post("/api/sessions/abc/rename", json={"title": "New name"})
         assert resp.status_code == 200
         assert captured["rename"] == ("abc", "New name")
@@ -816,7 +816,7 @@ class TestSessionsApi:
             captured["archive"] = (session_id, archived)
 
         monkeypatch.setattr(sessions, "set_archived", _set_archived)
-        client = TestClient(server.app)
+        client = TestClient(server.app, base_url="http://127.0.0.1:8100")
         resp = client.post("/api/sessions/abc/archive", json={"archived": True})
         assert resp.status_code == 200
         assert captured["archive"] == ("abc", True)
@@ -834,7 +834,7 @@ class TestSessionsApi:
 
         monkeypatch.setattr(provenance, "purge_session", _purge)
         monkeypatch.setattr(sessions, "remove", _remove)
-        client = TestClient(server.app)
+        client = TestClient(server.app, base_url="http://127.0.0.1:8100")
         resp = client.delete("/api/sessions/abc")
         assert resp.status_code == 200
         assert calls == [("purge", "abc"), ("remove", "abc")]

--- a/tests/test_stacks_install.py
+++ b/tests/test_stacks_install.py
@@ -194,7 +194,7 @@ class TestListInstalled:
         ):
             settings.install_stack_image("ghcr.io/x/foo:dev")
         assert settings.list_installed_stacks() == [
-            {"name": "medmcp-foo", "image": "ghcr.io/x/foo:dev", "gpu": False}
+            {"name": "medmcp-foo", "image": "ghcr.io/x/foo:dev", "gpu": False, "network": False}
         ]
 
 
@@ -214,7 +214,13 @@ class TestCatalog:
         ):
             entries = settings.load_catalog()
         assert entries == [
-            {"name": "medmcp-foo", "image": "img:dev", "description": "d", "gpu": True}
+            {
+                "name": "medmcp-foo",
+                "image": "img:dev",
+                "description": "d",
+                "gpu": True,
+                "network": False,
+            }
         ]
 
     def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
@@ -330,12 +336,50 @@ class TestStackIsolation:
             patch("medmcp.settings._image_present", _always_present),
             patch("medmcp.settings._extract_image_skills", _fake_extract),
         ):
-            settings.install_stack_image("img:tag")
+            settings.install_stack_image("img:tag", accept_network=True)
         args = _read_manifest(stacks_dir, "medmcp-net")["args"]
         assert args[args.index("--network") + 1] == "bridge"
         assert "none" not in args
         # Opting into egress must not opt out of the rest.
         assert "--cap-drop" in args and "no-new-privileges" in args
+
+    def test_egress_needs_consent(self, stacks_dir: Path) -> None:
+        """A stack cannot arrive with network access unless someone accepted it.
+
+        The workspace is mounted into every stack, so egress is the difference
+        between "can read your data" and "can send it somewhere". The image
+        declares it, which is why it must not install silently.
+        """
+        label = '{"name": "medmcp-net", "gpu": false, "network": true}'
+        with (
+            patch("medmcp.settings._run_docker", _fake_docker(label)),
+            patch("medmcp.settings._image_present", _always_present),
+            patch("medmcp.settings._extract_image_skills", _fake_extract),
+            pytest.raises(settings.NetworkConsentRequiredError),
+        ):
+            settings.install_stack_image("img:tag")
+        assert not (stacks_dir / "medmcp-net.toml").exists()
+
+    def test_egress_is_disclosed_on_the_installed_list(self, stacks_dir: Path) -> None:
+        """A stack with egress must not look like one without it."""
+        label = '{"name": "medmcp-net", "gpu": false, "network": true}'
+        with (
+            patch("medmcp.settings._run_docker", _fake_docker(label)),
+            patch("medmcp.settings._image_present", _always_present),
+            patch("medmcp.settings._extract_image_skills", _fake_extract),
+        ):
+            settings.install_stack_image("img:tag", accept_network=True)
+        assert settings.list_installed_stacks()[0]["network"] is True
+
+    def test_a_sandboxed_stack_reports_no_egress(self, stacks_dir: Path) -> None:
+        """The default install is `--network none`, and says so."""
+        with (
+            patch("medmcp.settings._run_docker", _fake_docker(LABEL)),
+            patch("medmcp.settings._image_present", _always_present),
+            patch("medmcp.settings._extract_image_skills", _fake_extract),
+        ):
+            settings.install_stack_image("img:tag")
+        assert settings.list_installed_stacks()[0]["network"] is False
 
     def test_legacy_manifest_is_hardened_on_load(self, stacks_dir: Path) -> None:
         """A manifest written before this existed is isolated without a reinstall.


### PR DESCRIPTION
## Summary

Closes the ways the workspace could act on someone's data without them having agreed to it, found in a security review of the server: a page on any website could open a chat socket and have the agent read the workspace back to it, and a tool stack could grant itself internet access with nothing in the interface saying so. Also fixes an uninstall that did not stick.

## Test plan

- [x] `just check` — 546 passed, 2 skipped (ruff, ruff format, pyright strict, pytest)
- [x] `npm run lint`, `tsc --noEmit`, production bundle build
- [x] Cross-origin refusal, against a running instance and with the probe that succeeded before the change: `/ws/chat` and `/ws/replay` upgrades rejected at the handshake from a foreign `Origin`, cross-origin HTTP `403`, a rebound `Host` `403`, while same-origin requests, the container healthcheck (no `Origin`) and non-browser clients keep working
- [x] Stack egress consent: installing an image whose label declares `network: true` returns `409 {"needs_network_consent": true, …}` and writes no manifest; with consent it installs and is reported `network: true` by `/api/stacks`; a normal stack reports `false`
- [x] Replay confinement: an absolute path outside the workspace, a `..` escape and a symlink pointing out are each refused before any step runs; device strings and not-yet-created output directories still pass through
- [x] Uninstall: install → uninstall now leaves both `/api/stacks` and `/api/settings` empty (previously the stack stayed in settings until a restart)
- [x] Broker socket: mode is `srw-------` after the change, the owning process still gets served, a different uid is refused at `connect()`
- [x] Each new guard was re-run with its check removed, to confirm the tests fail when the property does

## Security & data handling

- **Browser origin guard** (`origincheck.py` + an ASGI middleware). The server binds loopback and has no authentication, which is safe against the network but not against the browser: any page can send requests to `127.0.0.1`, and a WebSocket upgrade is exempt from the same-origin policy entirely — the browser connects and only the server can refuse. `read_file` and `grep` need no approval, so an unrefused socket was enough to have the agent read the workspace and stream it back to that page with no dialog shown; `/ws/replay` runs a saved workflow with no permission flow at all. Requests and upgrades are now refused unless the `Origin` is the workspace's own page, and unless the `Host` names a loopback address — the second check is what stops DNS rebinding, where the attacker's hostname resolves to `127.0.0.1` and the origin check has nothing to catch. Upgrades are refused *before* `accept`, so no session is created, and every refusal is audit-logged. Addresses are parsed rather than string-matched (`127.0.0.1.evil.example` is a registrable domain). A deployment reached through its own hostname lists it in `MEDMCP_ALLOWED_HOSTS` / `MEDMCP_ALLOWED_ORIGINS`; both default to empty, so unlisted is refused.
- **Stack network egress is now consented to, and disclosed.** An image can declare `network: true` in its `org.medmcp.stack` label, which installs it with `--network bridge`; since the workspace is bind-mounted into every stack, that is the difference between a stack that can read the data and one that can also send it. Nothing surfaced it — the installed list reported name, image and GPU only, and the catalog had no such field. Installing one now requires an explicit `accept_network`, enforced on both the REST and streamed install paths so the dialog is not the only gate, and any stack that has it is badged in the window. The image is inspected to learn this, never executed.
- **Replay inputs are confined to the workspace.** The replay engine calls MCP tools directly with no permission prompt between the binding and the call, and absolute paths were passed through untouched. Paths resolving outside `WORKSPACE_ROOT` — including via `..` or a symlink inside the workspace — are refused at every entry point. The containerized deployment already limited this by mounting only the workspace, but a host-native stack runs as the operator.
- **Broker socket mode** is set to `0600` rather than inherited from the process umask. Connecting to it means invoking any installed stack's tools below the permission flow; the usual umask already denied others, so this is defence in depth against a launcher that sets a permissive one.
- No change to the approval model: no tool gains an auto-approval path.

## Notes

- **Existing deployments:** no migration. A deployment reached at `127.0.0.1` or `localhost` needs no configuration; one behind a reverse proxy or a hostname must set `MEDMCP_ALLOWED_HOSTS` / `MEDMCP_ALLOWED_ORIGINS` or it will refuse requests. `SECURITY.md` gains a "Network posture" section covering this.
- **`TestClient` base URLs:** the guard refuses `Host: testserver`, so tests that build a client now pass `base_url="http://127.0.0.1:8100"`. That makes them exercise a realistic host rather than weakening the rule.
- **Compose parity test** now compares the in-container paths that survive a recreate rather than mount syntax, so it covers `stacks.d` (installed stacks) as well as `.vibe` state, and allows the local compose to bind-mount what the published one keeps in a named volume.
- **Follow-ups, both pre-existing:** approving a `bash` call grants the agent everything the operator can reach, including the mounted docker socket — worth stating in `SECURITY.md`, though a command denylist would not hold. And the stack repositories' DICOM/NIfTI parsing was not part of this review, which is the surface `SECURITY.md` names first.
