### PR TITLE
feat(ui): give external MCP its own window and tidy the settings drawer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Notable, user-visible changes to MedMCP. Format follows
 
 ## Unreleased
 
+### Changed
+
+- **Settings is easier to read.** General and Advanced are now the same kind of
+  heading rather than a heading and a button, and everything inside Advanced is
+  visibly inside it. External MCP servers moved out of the drawer into a window
+  of their own, reached from Advanced or from the warning strip, so settings is a
+  short list of switches and the servers get room for their list, their tokens
+  and the consent text. Wording across the interface was cleaned up as well.
+
 ### Fixed
 
 - **Uninstalling a tool stack now removes it properly.** A stack could disappear

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { Group, Panel, Separator } from 'react-resizable-panels'
 import { Chat } from './components/Chat'
 import { ExternalMcpBanner } from './components/ExternalMcpBanner'
+import { ExternalMcpWindow } from './components/ExternalMcpWindow'
 import { FileExplorer } from './components/FileExplorer'
 import { StackMarketplace } from './components/StackMarketplace'
 import { SettingsDrawer } from './components/SettingsDrawer'
@@ -21,9 +22,10 @@ export default function App() {
   // Files multi-selected in the explorer — feeds the workflow batch editor.
   const [selectedPaths, setSelectedPaths] = useState<string[]>([])
   const [settingsOpen, setSettingsOpen] = useState(false)
-  // Set when the settings drawer is opened from the external-MCP warning, so it
-  // lands on the control the banner is talking about.
   const [settingsAdvanced, setSettingsAdvanced] = useState(false)
+  // The external-MCP window: reached from Advanced, or straight from the warning
+  // banner, which is about the thing the window manages.
+  const [externalOpen, setExternalOpen] = useState(false)
   // Bumped whenever external-MCP state may have changed, so the standing
   // warning re-reads it instead of waiting for a reload.
   const [externalVersion, setExternalVersion] = useState(0)
@@ -110,10 +112,7 @@ export default function App() {
       </header>
       <ExternalMcpBanner
         refreshSignal={externalVersion}
-        onReview={() => {
-          setSettingsAdvanced(true)
-          setSettingsOpen(true)
-        }}
+        onReview={() => setExternalOpen(true)}
       />
       <SettingsDrawer
         open={settingsOpen}
@@ -123,7 +122,13 @@ export default function App() {
         }}
         advancedOpen={settingsAdvanced}
         onAdvancedToggle={setSettingsAdvanced}
-        onExternalChanged={notifyExternalChanged}
+        onManageExternal={() => setExternalOpen(true)}
+        externalVersion={externalVersion}
+      />
+      <ExternalMcpWindow
+        open={externalOpen}
+        onClose={() => setExternalOpen(false)}
+        onChanged={notifyExternalChanged}
       />
       <StackMarketplace open={marketOpen} onClose={() => setMarketOpen(false)} />
       <Group

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -14,7 +14,7 @@ import type {
   ToolCallState,
 } from '../types'
 import { ChatsMenu } from './ChatsMenu'
-import { ShieldIcon } from './icons'
+import { PlusIcon, ShieldIcon } from './icons'
 
 // vibe-acp >= 2.14 sends a tool call's rawInput as a JSON-encoded *string*
 // (read/edit/write tools) rather than an object. Parse it back so the card
@@ -312,7 +312,7 @@ function PermissionCard({
                   // What sits where the file was expected. Usually the intended
                   // path is right here, so it reads as the answer, not a dump.
                   <span className="path-siblings">
-                    {' — '}
+                    {' · '}
                     <code>{p.nearest === '.' ? 'workspace' : p.nearest}</code> contains{' '}
                     {p.entries.join(', ')}
                     {p.entry_total > p.entries.length &&
@@ -703,7 +703,8 @@ export const Chat = memo(function Chat({
           <span>Chat</span>
           {onNewChat && (
             <button className="btn-plain chat-new-btn" onClick={onNewChat} title="Start a new chat">
-              ＋ New chat
+              <PlusIcon size={12} />
+              New chat
             </button>
           )}
           {onSelectSession && (

--- a/frontend/src/components/ChatsMenu.tsx
+++ b/frontend/src/components/ChatsMenu.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { archiveSession, deleteSession, fetchSessions, forkSession, renameSession } from '../api'
 import type { SessionInfo } from '../types'
-import { ArchiveIcon, BranchIcon, PencilIcon, TrashIcon } from './icons'
+import { ArchiveIcon, BranchIcon, ChevronRightIcon, PencilIcon, TrashIcon } from './icons'
 
 interface ChatsMenuProps {
   /** The session the chat is currently showing (highlighted in the list). */
@@ -202,7 +202,8 @@ export function ChatsMenu({ currentSessionId, onSelectSession, onCurrentDeleted 
         title="Open a previous chat"
         onClick={() => setOpen((v) => !v)}
       >
-        Chats ▾
+        Chats
+        <ChevronRightIcon size={11} className="chats-caret" />
       </button>
       {open && (
         <>

--- a/frontend/src/components/ExternalMcpBanner.tsx
+++ b/frontend/src/components/ExternalMcpBanner.tsx
@@ -63,7 +63,7 @@ export function ExternalMcpBanner({ refreshSignal, onReview }: ExternalMcpBanner
         <strong>
           {active.length} external MCP server{plural} enabled.
         </strong>{' '}
-        What the agent sends {active.length === 1 ? 'it' : 'them'} leaves this machine.
+        Anything the agent sends to an external server leaves this machine.
       </span>
       <span className="ext-banner-names" title="Enabled external servers">
         {active.map((s) => s.name).join(', ')}

--- a/frontend/src/components/ExternalMcpSection.tsx
+++ b/frontend/src/components/ExternalMcpSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import {
   acknowledgeExternalMcp,
@@ -13,7 +13,7 @@ import type { ExternalMcpState, ExternalServer } from '../types'
 import { Row, Toggle } from './SettingsControls'
 
 /**
- * Advanced-settings section for wiring third-party MCP services into the
+ * The body of the external-MCP window: wiring third-party MCP services into the
  * workspace.
  *
  * The whole product guarantees that data stays on-premise, and this is the one
@@ -31,7 +31,13 @@ interface ExternalMcpSectionProps {
 export function ExternalMcpSection({ onChanged }: ExternalMcpSectionProps) {
   const [state, setState] = useState<ExternalMcpState | null>(null)
   const [error, setError] = useState<string | null>(null)
-  const [busy, setBusy] = useState(false)
+  // How many changes are in flight or queued. Every one of them stops the agent
+  // and waits for it to exit, which takes about a second and a half, so this is
+  // long enough to be felt.
+  const [inFlight, setInFlight] = useState(0)
+  // Changes are chained rather than run concurrently: two overlapping restarts
+  // would race, and dropping the second click is worse than making it wait.
+  const queue = useRef<Promise<unknown>>(Promise.resolve())
   const [consenting, setConsenting] = useState(false)
   const [understood, setUnderstood] = useState(false)
   const [adding, setAdding] = useState(false)
@@ -48,19 +54,34 @@ export function ExternalMcpSection({ onChanged }: ExternalMcpSectionProps) {
       .catch((e: unknown) => setError(String(e)))
   }, [])
 
-  /** Run a mutation, then refetch — every one of them restarts the agent. */
+  /**
+   * Apply a change: queue it, refetch, tell the caller.
+   *
+   * *optimistic* moves the control now rather than a second and a half later,
+   * when the refetch lands. Without it a click looks ignored for the whole
+   * restart, which is exactly as long as it takes to doubt the click. The
+   * refetch is the authority either way, including after a failure, so a
+   * rejected change snaps back rather than lingering as a lie.
+   */
   const run = useCallback(
-    (action: () => Promise<void>) => {
-      setBusy(true)
+    (action: () => Promise<void>, optimistic?: (s: ExternalMcpState) => ExternalMcpState) => {
       setError(null)
-      action()
+      if (optimistic) setState((s) => (s ? optimistic(s) : s))
+      setInFlight((n) => n + 1)
+      queue.current = queue.current
+        .then(action)
         .then(reload)
         .then(() => onChanged?.())
-        .catch((e: unknown) => setError(e instanceof Error ? e.message : String(e)))
-        .finally(() => setBusy(false))
+        .catch((e: unknown) => {
+          setError(e instanceof Error ? e.message : String(e))
+          return reload().catch(() => undefined)
+        })
+        .finally(() => setInFlight((n) => n - 1))
     },
     [reload, onChanged],
   )
+
+  const busy = inFlight > 0
 
   if (!state) return null
 
@@ -73,7 +94,10 @@ export function ExternalMcpSection({ onChanged }: ExternalMcpSectionProps) {
       setConsenting(true)
       return
     }
-    run(() => setExternalMcpEnabled(next))
+    run(
+      () => setExternalMcpEnabled(next),
+      (s) => ({ ...s, enabled: next, acknowledged: next && s.acknowledged }),
+    )
   }
 
   const accept = () =>
@@ -86,26 +110,38 @@ export function ExternalMcpSection({ onChanged }: ExternalMcpSectionProps) {
   return (
     <>
       <Row
-        label="External MCP servers"
-        hint="Lets the agent use tools hosted outside this machine. Off by default — anything sent to such a server leaves your infrastructure."
+        label="Allow external servers"
+        hint="Lets the agent use tools hosted outside this machine. Off by default, because anything sent to such a server leaves your infrastructure."
         checked={state.enabled}
         onChange={onToggle}
-        disabled={busy}
       />
 
       {error && <div className="panel-error">{error}</div>}
 
-      {/* Someone who turns this off to be sure nothing is leaving gets told so.
-          An empty space is not an answer to that question. */}
-      {!state.enabled && state.servers.length > 0 && (
-        <div className="settings-row-hint ext-mcp-disconnected">
-          {state.servers.length} server{state.servers.length === 1 ? '' : 's'} configured, none
-          enabled. Nothing is sent outside this machine while this is off.
+      {/* Says why a change takes a moment. The agent is stopped and restarted
+          for every one of these, so the panel is briefly out of date rather
+          than broken. */}
+      {busy && (
+        <div className="settings-row-hint ext-mcp-applying">
+          Applying. The agent restarts, so open chats reconnect.
         </div>
       )}
 
-      {state.enabled && (
-        <div className="ext-mcp">
+      {/* Someone who turns this off to be sure nothing is leaving gets told so.
+          An empty space is not an answer to that question. */}
+      {!state.enabled && (
+        <div className="settings-row-hint ext-mcp-disconnected">
+          Off. Nothing is sent outside this machine.
+          {state.servers.length > 0 && ' The servers below stay configured until you remove them.'}
+        </div>
+      )}
+
+      {/* The list is shown whether or not the feature is on: the switch governs
+          whether the agent may use these servers, not whether their owner may
+          manage them. Turning it off to stop the traffic and then being unable
+          to remove the server that caused it is the wrong way round. */}
+      {(state.enabled || state.servers.length > 0) && (
+        <div className={`ext-mcp${state.enabled ? '' : ' is-off'}`}>
           {state.servers.length === 0 && (
             <div className="settings-row-hint ext-mcp-empty">No external servers yet.</div>
           )}
@@ -124,9 +160,9 @@ export function ExternalMcpSection({ onChanged }: ExternalMcpSectionProps) {
                     unauthenticated rather than failing where the cause is. */}
                 {s.api_key_env && s.token_present === false && (
                   <div className="settings-row-hint ext-mcp-missing-token">
-                    ${s.api_key_env} is not set where the agent runs — requests go out with no
-                    credential. Add it to medmcp.env and restart, or replace it with a stored
-                    token.
+                    ${s.api_key_env} is not set where the agent runs, so requests go out with
+                    no credential. Add it to medmcp.env and restart, or store a token here
+                    instead.
                   </div>
                 )}
                 {replacing === s.name ? (
@@ -152,13 +188,30 @@ export function ExternalMcpSection({ onChanged }: ExternalMcpSectionProps) {
               <div className="ext-mcp-server-actions">
                 <Toggle
                   checked={s.active}
-                  disabled={busy}
-                  onChange={(v) => run(() => setExternalServerActive(s.name, v))}
+                  onChange={(v) =>
+                    run(
+                      () => setExternalServerActive(s.name, v),
+                      (prev) => ({
+                        ...prev,
+                        servers: prev.servers.map((x) =>
+                          x.name === s.name ? { ...x, active: v } : x,
+                        ),
+                      }),
+                    )
+                  }
                 />
                 <button
                   className="btn-text"
                   disabled={busy}
-                  onClick={() => run(() => removeExternalServer(s.name))}
+                  onClick={() =>
+                    run(
+                      () => removeExternalServer(s.name),
+                      (prev) => ({
+                        ...prev,
+                        servers: prev.servers.filter((x) => x.name !== s.name),
+                      }),
+                    )
+                  }
                 >
                   Remove
                 </button>
@@ -186,13 +239,17 @@ export function ExternalMcpSection({ onChanged }: ExternalMcpSectionProps) {
         </div>
       )}
 
-      {/* Portalled to the body: this section renders inside .drawer, which is a
-          stacking context (position: fixed + z-index), so a backdrop rendered in
-          place cannot paint above the drawer no matter how high its z-index —
-          the settings behind the dialog would stay visible and clickable. */}
+      {/* Portalled to the body: this section renders inside the external-MCP
+          window, which is a stacking context (position: fixed with a z-index),
+          so a backdrop rendered in place could not paint above that window at
+          any z-index and the list behind the dialog would stay clickable.
+          `over-window` lifts the pair above the window that opened it. */}
       {consenting &&
         createPortal(
-          <div className="modal-backdrop" onClick={() => setConsenting(false)}>
+          <div
+            className="modal-backdrop over-window"
+            onClick={() => setConsenting(false)}
+          >
             <div
               className="modal ext-mcp-consent"
               role="dialog"
@@ -208,8 +265,8 @@ export function ExternalMcpSection({ onChanged }: ExternalMcpSectionProps) {
               </p>
               <ul>
                 <li>
-                  Anything the agent passes to an external tool — file contents, paths, patient
-                  identifiers, results — is sent to whoever operates that server.
+                  Anything the agent passes to an external tool is sent to whoever operates
+                  that server: file contents, paths, patient identifiers, results.
                 </li>
                 <li>
                   You are responsible for what those services receive, for their terms and security,
@@ -384,7 +441,7 @@ function AddServerForm({
             onChange={(e) => setEnvVar(e.target.value)}
           />
           <span className="settings-row-hint">
-            The name of a variable already set where the agent runs — for a deployment that
+            The name of a variable already set where the agent runs, for a deployment that
             manages its own secrets. In the container install that means an entry in{' '}
             <code>medmcp.env</code> and a restart.
           </span>

--- a/frontend/src/components/ExternalMcpWindow.tsx
+++ b/frontend/src/components/ExternalMcpWindow.tsx
@@ -1,0 +1,42 @@
+import { ExternalMcpSection } from './ExternalMcpSection'
+import { XIcon } from './icons'
+
+interface ExternalMcpWindowProps {
+  open: boolean
+  onClose: () => void
+  /** Called when the connected set changed, so the standing warning catches up. */
+  onChanged?: () => void
+}
+
+/**
+ * Connect and manage MCP services hosted outside this machine.
+ *
+ * A window rather than a settings section, for the reason the stacks browser is
+ * one: this is a list with per-item state and an add form, and a narrow column
+ * of switches is the wrong shape for it. Settings keeps the switches and points
+ * here, so the drawer stays a short list of one-line choices.
+ *
+ * The window is also where the space for the consent text is, which matters:
+ * the decision it asks for is the one that ends the on-premise guarantee.
+ */
+export function ExternalMcpWindow({ open, onClose, onChanged }: ExternalMcpWindowProps) {
+  if (!open) return null
+  return (
+    <>
+      <div className="modal-backdrop" onClick={onClose} />
+      <div className="extwin" role="dialog" aria-label="External MCP servers">
+        <div className="panel-header">
+          <span>External MCP servers</span>
+          <span className="panel-actions">
+            <button className="btn-icon" title="Close" onClick={onClose}>
+              <XIcon />
+            </button>
+          </span>
+        </div>
+        <div className="extwin-body">
+          <ExternalMcpSection onChanged={onChanged} />
+        </div>
+      </div>
+    </>
+  )
+}

--- a/frontend/src/components/FileExplorer.tsx
+++ b/frontend/src/components/FileExplorer.tsx
@@ -317,6 +317,13 @@ export const FileExplorer = memo(function FileExplorer({
       </div>
       {error && <div className="panel-error">{error}</div>}
       <div className="panel-body" ref={containerRef}>
+        {/* Every other panel says what to do when it is empty; this one showed
+            a blank rectangle, which reads as a failure to load. */}
+        {data.length === 0 && !error && (
+          <div className="viewer-message">
+            This workspace is empty. Upload a file, or drop one here.
+          </div>
+        )}
         <Tree<TreeNode>
           data={data}
           width={size.width}

--- a/frontend/src/components/SettingsDrawer.tsx
+++ b/frontend/src/components/SettingsDrawer.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react'
-import { fetchGpus, fetchSettings, saveSettings } from '../api'
-import type { GpuInfo, SettingsState } from '../types'
-import { ExternalMcpSection } from './ExternalMcpSection'
+import { fetchExternalMcp, fetchGpus, fetchSettings, saveSettings } from '../api'
+import type { ExternalMcpState, GpuInfo, SettingsState } from '../types'
 import { Row } from './SettingsControls'
 import { ChevronRightIcon, XIcon } from './icons'
 
@@ -13,8 +12,10 @@ interface SettingsDrawerProps {
   advancedOpen: boolean
   /** Expand or collapse Advanced. */
   onAdvancedToggle: (open: boolean) => void
-  /** Called when external-MCP state changed, so the banner can catch up. */
-  onExternalChanged?: () => void
+  /** Open the external-MCP window. */
+  onManageExternal: () => void
+  /** Bumped when external-MCP state changed, so the summary re-reads it. */
+  externalVersion: number
 }
 
 /**
@@ -27,10 +28,14 @@ export function SettingsDrawer({
   onClose,
   advancedOpen,
   onAdvancedToggle,
-  onExternalChanged,
+  onManageExternal,
+  externalVersion,
 }: SettingsDrawerProps) {
   const [state, setState] = useState<SettingsState | null>(null)
   const [gpus, setGpus] = useState<GpuInfo[]>([])
+  // Just enough external-MCP state to say what is connected; the window owns
+  // the rest.
+  const [external, setExternal] = useState<ExternalMcpState | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [notice, setNotice] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
@@ -61,17 +66,36 @@ export function SettingsDrawer({
       .catch(() => setGpus([])) // best-effort: the field falls back to free text
   }, [open])
 
+  useEffect(() => {
+    if (!open) return
+    fetchExternalMcp()
+      .then(setExternal)
+      .catch(() => setExternal(null)) // summary hides rather than guesses
+  }, [open, externalVersion])
+
   const apply = (next: SettingsState) => {
     setState(next)
     setSaving(true)
     saveSettings(next)
       .then((restarted) => {
         setError(null)
-        setNotice(restarted ? 'Agent restarted — the chat starts a fresh session.' : null)
+        setNotice(restarted ? 'Agent restarted. The chat starts a fresh session.' : null)
       })
       .catch((e: unknown) => setError(String(e)))
       .finally(() => setSaving(false))
   }
+
+  // What the row says at rest. "Connected" counts servers the agent can actually
+  // reach: the feature on and the server switched on.
+  const connectedServers = external?.enabled ? external.servers.filter((s) => s.active) : []
+  const connected = connectedServers.length > 0
+  const externalSummary = !external
+    ? 'Tools hosted outside this machine.'
+    : connected
+      ? `${connectedServers.length} connected: ${connectedServers.map((s) => s.name).join(', ')}`
+      : external.enabled
+        ? 'On, with nothing connected.'
+        : 'Off. Nothing is sent outside this machine.'
 
   if (!open) return null
 
@@ -104,7 +128,7 @@ export function SettingsDrawer({
               <div className="settings-row">
                 <div className="settings-row-text">
                   <div className="settings-row-label">GPU</div>
-                  <div className="settings-row-hint">Imaging stacks; chat model set at startup.</div>
+                  <div className="settings-row-hint">Used by imaging stacks. The chat model is set at startup.</div>
                 </div>
                 <select
                   className="wf-input gpu-select"
@@ -129,29 +153,43 @@ export function SettingsDrawer({
                   that needs it, one disclosure away from being reached by accident. */}
               <button
                 type="button"
-                className="settings-advanced-toggle"
+                className={`settings-advanced-toggle${advancedOpen ? ' open' : ''}`}
+                aria-expanded={advancedOpen}
                 onClick={() => onAdvancedToggle(!advancedOpen)}
               >
+                Advanced
                 <ChevronRightIcon
                   size={12}
                   className={advancedOpen ? 'settings-chevron open' : 'settings-chevron'}
                 />
-                Advanced
+                {!advancedOpen && (
+                  <span className="settings-advanced-peek">provenance, external servers</span>
+                )}
               </button>
               {advancedOpen && (
-                <>
+                <div className="settings-advanced-body">
                   <Row
                     label="Record provenance"
-                    hint="Keeps a replayable record of what each chat did (manifest, tool log, permissions). Turning this off means a chat leaves no audit trail and cannot be distilled into a workflow."
+                    hint="Keeps a record of what each chat did, so you can review it later or turn it into a workflow. With this off, a chat leaves no trail."
                     checked={state.record_provenance}
                     onChange={(v) => apply({ ...state, record_provenance: v })}
                   />
-                  <ExternalMcpSection onChanged={onExternalChanged} />
-                </>
+                  <div className="settings-row">
+                    <div className="settings-row-text">
+                      <div className="settings-row-label">External MCP servers</div>
+                      <div className={`settings-row-hint${connected ? ' ext-summary-on' : ''}`}>
+                        {externalSummary}
+                      </div>
+                    </div>
+                    <button className="btn-plain" onClick={onManageExternal}>
+                      Manage…
+                    </button>
+                  </div>
+                </div>
               )}
 
               <div className="drawer-footnote">
-                Stack and GPU changes restart the agent; open chats reconnect into a fresh session.
+                GPU and external server changes restart the agent. Open chats reconnect into a fresh session.
                 {saving ? ' Saving…' : ''}
               </div>
             </>

--- a/frontend/src/components/StackMarketplace.tsx
+++ b/frontend/src/components/StackMarketplace.tsx
@@ -224,7 +224,7 @@ export function StackMarketplace({ open, onClose }: StackMarketplaceProps) {
       if (m.type === 'done') {
         after?.()
         reload()
-          .then(() => setNotice(`Installed ${m.name} — the agent restarted.`))
+          .then(() => setNotice(`Installed ${m.name}. The agent restarted.`))
           .catch((e: unknown) => setError(String(e)))
       } else {
         setError(m.message ?? 'install failed')
@@ -245,7 +245,7 @@ export function StackMarketplace({ open, onClose }: StackMarketplaceProps) {
     uninstallStack(name)
       .then(async () => {
         await reload()
-        setNotice(`Uninstalled ${name} — the agent restarted.`)
+        setNotice(`Uninstalled ${name}. The agent restarted.`)
       })
       .catch((e: unknown) => setError(String(e)))
       .finally(() => setBusy(false))
@@ -261,7 +261,7 @@ export function StackMarketplace({ open, onClose }: StackMarketplaceProps) {
     saveSettings(next)
       .then((restarted) => {
         setError(null)
-        if (restarted) setNotice('Agent restarted — the chat starts a fresh session.')
+        if (restarted) setNotice('Agent restarted. The chat starts a fresh session.')
       })
       .catch((e: unknown) => setError(String(e)))
   }
@@ -425,7 +425,7 @@ export function StackMarketplace({ open, onClose }: StackMarketplaceProps) {
               <p>
                 Most stacks run with networking switched off: they see the files you point them at
                 and nothing else. This one asks for network access, and your workspace is available
-                to it — so it is able to send what it reads to whoever runs the service it talks to.
+                to it, so it can send what it reads to whoever runs the service it talks to.
               </p>
               <p>
                 Install it only if you know why it needs that. You can remove it at any time, and

--- a/frontend/src/components/Viewer.tsx
+++ b/frontend/src/components/Viewer.tsx
@@ -590,7 +590,10 @@ export const Viewer = memo(function Viewer({
         <div className="panel-header">
           <span>Viewer</span>
         </div>
-        <div className="panel-body viewer-body">
+        {/* Black is the right ground for an image and the wrong one for an
+            empty panel, where it reads as a hole in the app. The layout stays,
+            only the colour changes. */}
+        <div className="panel-body viewer-body is-empty">
           <div className="viewer-message">Select a file in the explorer to view it here.</div>
         </div>
       </div>

--- a/frontend/src/components/WorkflowPanel.tsx
+++ b/frontend/src/components/WorkflowPanel.tsx
@@ -118,7 +118,7 @@ function inputOptionLabel(i: Input): string {
   const bits: string[] = []
   if (i.description) bits.push(i.description)
   if (i.example) bits.push(`e.g. ${basename(i.example)}`)
-  return bits.length > 0 ? `${i.name} — ${bits.join(' · ')}` : i.name
+  return bits.length > 0 ? `${i.name}: ${bits.join(' · ')}` : i.name
 }
 
 /** The file basenames of a run's input values, joined (e.g. "subjA.nii + atlas.nii"). */
@@ -277,7 +277,7 @@ function Requirements({ requires }: { requires: StackRequirement[] }) {
       {mismatched.length > 0 && (
         <div className="wf-req-warn">
           A different version of {mismatched.map((r) => r.stack).join(', ')} is installed than this
-          workflow was built with — results may not reproduce exactly.
+          workflow was built with. Results may not reproduce exactly.
         </div>
       )}
     </div>
@@ -605,7 +605,7 @@ export const WorkflowPanel = memo(function WorkflowPanel({
       }
       setPlanSkipped(res.skipped)
       if (res.runs.length === 0) {
-        setError('no ready (ok) items in the plan — resolve the flagged rows first')
+        setError('No ready items in the plan. Resolve the flagged rows first.')
         return
       }
       setMode((m) =>
@@ -753,7 +753,7 @@ export const WorkflowPanel = memo(function WorkflowPanel({
         {m.items.length < m.total ? (
           m.total > 1 ? (
             <span>
-              Processing <strong>{itemLabel(m.runs, m.items.length)}</strong> — item{' '}
+              Processing <strong>{itemLabel(m.runs, m.items.length)}</strong>, item{' '}
               {m.items.length + 1} of {m.total} · step {currentStep(m)} of {m.stepsPerItem}
             </span>
           ) : (
@@ -818,8 +818,8 @@ export const WorkflowPanel = memo(function WorkflowPanel({
         {m.ok ? (
           <div className="wf-result ok">
             {m.total > 1
-              ? `Batch complete — all ${m.items.length} item(s) succeeded in ${formatDuration(duration)}.`
-              : `Replay complete in ${formatDuration(duration)} — ${m.log.length} step(s) ran.`}
+              ? `Batch complete. All ${m.items.length} item(s) succeeded in ${formatDuration(duration)}.`
+              : `Replay complete in ${formatDuration(duration)}. ${m.log.length} step(s) ran.`}
             {m.total === 1 && m.items.some((it) => it.outputs.length > 0) && (
               <div className="wf-outputs">
                 Outputs:
@@ -830,7 +830,7 @@ export const WorkflowPanel = memo(function WorkflowPanel({
         ) : (
           <div className="wf-result fail">
             {m.total > 1 && succeeded > 0
-              ? `${succeeded} of ${m.total} item(s) succeeded — ${retryRuns.length} need a retry.`
+              ? `${succeeded} of ${m.total} item(s) succeeded. ${retryRuns.length} need a retry.`
               : `Replay failed. ${m.error ?? ''}`}
           </div>
         )}
@@ -861,7 +861,7 @@ export const WorkflowPanel = memo(function WorkflowPanel({
             <StepList steps={d.steps} />
           ) : (
             <div className="wf-notice">
-              This chat produced no replayable tool steps — the workflow is empty.
+              This chat produced no replayable tool steps, so the workflow is empty.
             </div>
           )}
           {!d.replayable && d.replay_error && d.steps.length > 0 && (
@@ -870,7 +870,7 @@ export const WorkflowPanel = memo(function WorkflowPanel({
           <Requirements requires={d.requires} />
           {d.manual_steps.length > 0 && (
             <div className="wf-notice">
-              Includes manual step(s) replay can't run — do these by hand:
+              Includes manual step(s) replay can't run. Do these by hand:
               <ul className="wf-manual-list">
                 {d.manual_steps.map((m, i) => (
                   <li key={i}>
@@ -886,7 +886,7 @@ export const WorkflowPanel = memo(function WorkflowPanel({
               disabled={!d.replayable}
               title={
                 d.replayable
-                  ? 'Replay these exact steps on new inputs — no LLM involved'
+                  ? 'Replay these exact steps on new inputs. No LLM involved.'
                   : (d.replay_error ?? '')
               }
               onClick={() => beginRun(d)}
@@ -1064,7 +1064,7 @@ export const WorkflowPanel = memo(function WorkflowPanel({
               {!m.batch ? (
                 <>
                   <div className="wf-hint">
-                    Provide a value for each input — select a file in the explorer to fill it, or
+                    Provide a value for each input. Select a file in the explorer to fill it, or
                     type / drag a path.
                   </div>
                   {requiredInputs.map((i) => (
@@ -1111,7 +1111,7 @@ export const WorkflowPanel = memo(function WorkflowPanel({
               ) : (
                 <>
                   <div className="wf-hint">
-                    One row per run — each runs the whole workflow on its own inputs. Drag a file
+                    One row per run. Each runs the whole workflow on its own inputs. Drag a file
                     into any cell, or select files in the explorer and “Add from selection” (every{' '}
                     {requiredInputs.length} selected file{requiredInputs.length === 1 ? '' : 's'}{' '}
                     fill one row).
@@ -1214,7 +1214,7 @@ export const WorkflowPanel = memo(function WorkflowPanel({
                   </div>
                   {planSkipped && planSkipped.length > 0 && (
                     <div className="wf-hint wf-plan-skipped">
-                      {planSkipped.length} item(s) flagged and left out — resolve them in the plan,
+                      {planSkipped.length} item(s) flagged and left out. Resolve them in the plan,
                       then re-fill:
                       <ul className="wf-manual-list">
                         {planSkipped.map((s, i) => (
@@ -1223,7 +1223,7 @@ export const WorkflowPanel = memo(function WorkflowPanel({
                               {s.subject}
                               {s.session ? `/${s.session}` : ''}
                             </code>{' '}
-                            — {s.status}: {s.reason}
+                            · {s.status}: {s.reason}
                           </li>
                         ))}
                       </ul>
@@ -1260,12 +1260,12 @@ export const WorkflowPanel = memo(function WorkflowPanel({
       {mode.kind === 'preview' && (
         <div className="wf-form">
           <div className="wf-hint">
-            Replay will run these exact steps — no LLM, no permission prompts. Review before
+            Replay will run these exact steps. No LLM, no permission prompts. Review before
             running.
           </div>
           {mode.runs.length > 1 && (
             <div className="wf-hint">
-              Batch: {mode.runs.length} runs — the steps below show the first. All runs:
+              Batch: {mode.runs.length} runs. The steps below show the first. All runs:
               <span className="wf-batch-chips">
                 {mode.runs.map((_run, i) => (
                   <code key={i}>{itemLabel(mode.runs, i)}</code>

--- a/frontend/src/components/icons.tsx
+++ b/frontend/src/components/icons.tsx
@@ -172,6 +172,14 @@ export function BookmarkPlusIcon(props: IconProps) {
   )
 }
 
+export function PlusIcon(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <path d="M12 5v14M5 12h14" />
+    </Icon>
+  )
+}
+
 export function ChevronRightIcon(props: IconProps) {
   return (
     <Icon {...props}>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -15,8 +15,8 @@
   --card2: #1e2333;
   --border: rgba(255, 255, 255, 0.07);
   --border2: rgba(255, 255, 255, 0.12);
-  --muted: #8a92a6;
-  --muted2: #bcc3d4;
+  --muted: #99a1b4;
+  --muted2: #c6ccdb;
   --text: #e4e8f0;
   --ok: #4ade80;
   --warn: #fbbf24;
@@ -239,7 +239,13 @@ button:hover {
   gap: 10px;
 }
 
-.chat-new-btn {
+/* Icon and label aligned as boxes, not on the text baseline: an inline icon
+   next to 11px text sits a pixel or two off however the glyph is drawn. */
+.chat-new-btn,
+.chats-menu-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
   text-transform: none;
   letter-spacing: 0;
   font-size: 11px;
@@ -380,6 +386,10 @@ button:hover {
   align-items: stretch;
   justify-content: stretch;
   background: #000;
+}
+
+.viewer-body.is-empty {
+  background: var(--dark);
 }
 
 .viewer-title {
@@ -1476,28 +1486,73 @@ button:hover {
 
 /* Disclosure for settings that should be reachable but not browsed past. Mirrors
    the viewer settings popover's own Advanced row (.vs-advanced-toggle). */
+/* Same family as .settings-section so the two read as peers, but not the same
+   thing: General is a label, this one opens. Closed, it is muted with the
+   chevron beside the word and a whisper of what is inside; open, it takes the
+   section colour, because by then it is acting as a section heading. */
 .settings-advanced-toggle {
   display: flex;
   align-items: center;
   gap: 6px;
   width: 100%;
-  margin-top: 20px;
-  padding: 10px 0 4px;
+  margin-top: 22px;
+  padding: 12px 0 4px;
   background: none;
   border: none;
   border-top: 1px solid var(--border);
   color: var(--muted);
-  font-size: 12px;
-  font-weight: 500;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
   cursor: pointer;
+  transition: color 0.15s;
+}
+
+.settings-advanced-toggle.open {
+  color: var(--blue-l);
 }
 
 .settings-advanced-toggle:hover {
-  /* Neutralize the global button:hover fade, as .vs-advanced-toggle does: on a
-     full-width, border-top-only row it reads as a shimmer. */
+  /* Neutralize the global button:hover fade: on a full-width, border-top-only
+     row it reads as a shimmer rather than a hover. */
   background: none;
   border-color: var(--border);
   color: var(--text);
+}
+
+/* Beside the label rather than at the far edge: at the edge it is too far from
+   the word to read as its affordance, which is what made the row look like a
+   static header. */
+.settings-advanced-toggle .settings-chevron {
+  flex-shrink: 0;
+}
+
+/* The chats menu used a text arrow while every other disclosure in the app uses
+   the chevron icon; rotated down, since the menu opens downward. */
+.chats-caret {
+  transform: rotate(90deg);
+  transform-origin: center;
+}
+
+/* Says what is behind the disclosure, so it is not a door with no sign on it.
+   Body face, lowercase: a description, not part of the heading. */
+.settings-advanced-peek {
+  margin-left: 2px;
+  font-size: 11px;
+  font-weight: 400;
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--muted);
+}
+
+.settings-advanced-toggle:hover .settings-advanced-peek {
+  color: var(--muted2);
+}
+
+.settings-advanced-body {
+  margin-top: 2px;
+  padding-left: 12px;
 }
 
 .settings-chevron {
@@ -1508,28 +1563,38 @@ button:hover {
   transform: rotate(90deg);
 }
 
+/* No rule between rows. Two or three rows to a section is few enough that space
+   separates them, and once Advanced indents its own rows the lines no longer
+   share a left edge, which reads as clutter rather than structure. The only
+   rules left in the drawer are the section boundaries. */
 .settings-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  padding: 9px 0;
-  border-bottom: 1px solid var(--border);
+  padding: 10px 0;
 }
 
 .settings-row.disabled {
   opacity: 0.45;
 }
 
+/* Whole-pixel line boxes. With `normal` (≈1.2 → 15.6px) and 11.5px × 1.5
+   (17.25px), rows land on fractional offsets, and a switch that starts at
+   y.75 rasterises its track edges and its round knob unevenly: the geometry is
+   centred, the pixels are not. */
 .settings-row-label {
   font-size: 13px;
   font-weight: 500;
+  line-height: 16px;
 }
 
 .settings-row-hint {
   font-size: 11.5px;
-  color: var(--muted);
-  line-height: 1.5;
+  /* Hints carry real instructions, not decoration, so they sit a step above the
+     general muted grey. */
+  color: var(--muted2);
+  line-height: 17px;
   margin-top: 2px;
 }
 
@@ -1627,13 +1692,7 @@ button:hover {
   display: inline-flex;
 }
 
-.chats-menu-trigger {
-  text-transform: none;
-  letter-spacing: 0;
-  font-size: 11px;
-  font-weight: 600;
-  padding: 2px 8px;
-}
+
 
 .chats-menu-backdrop {
   position: fixed;
@@ -1793,7 +1852,10 @@ button:hover {
 .toggle {
   position: relative;
   width: 34px;
-  height: 19px;
+  /* Even, deliberately: an odd-height track centred in an even-height row lands
+     on a half pixel, and the knob's bottom edge then antialiases away, leaving
+     it visibly one row low. Even track, even knob, whole-pixel gaps. */
+  height: 20px;
   border-radius: 999px;
   border: 1px solid var(--border2);
   background: rgba(255, 255, 255, 0.04);
@@ -1810,12 +1872,16 @@ button:hover {
   background: rgba(255, 255, 255, 0.06);
 }
 
+/* Centred against the track rather than offset from its top edge: with a 1px
+   border and a 3px gap, fractional display scaling (1.25x, 1.5x) rounds the two
+   gaps differently and the knob visibly sinks. */
 .toggle-knob {
   position: absolute;
-  top: 2px;
+  top: 50%;
   left: 2px;
-  width: 13px;
-  height: 13px;
+  transform: translateY(-50%);
+  width: 14px;
+  height: 14px;
   border-radius: 50%;
   background: var(--muted);
   transition:
@@ -1830,7 +1896,8 @@ button:hover {
 }
 
 .toggle.on .toggle-knob {
-  transform: translateX(15px);
+  /* inner width 32 - knob 14 - the 2px gap at each end */
+  transform: translate(14px, -50%);
   background: #fff;
 }
 
@@ -2464,6 +2531,47 @@ textarea.wf-input {
   z-index: 40;
 }
 
+/* A dialog opened *from* a window (.market, .extwin, both z-index 41) needs to
+   clear it, or the window it came from stays visible and clickable behind the
+   thing asking for a decision. */
+.modal-backdrop.over-window {
+  z-index: 50;
+}
+
+.modal-backdrop.over-window > .modal {
+  z-index: 51;
+}
+
+/* The external-MCP window. Narrower than the stacks browser: a list of a few
+   servers and a form, not a grid to scan. */
+.extwin {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 620px;
+  max-width: 92vw;
+  max-height: 86vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--dark2);
+  border: 1px solid var(--border2);
+  border-radius: 14px;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.5);
+  z-index: 41;
+  overflow: hidden;
+}
+
+.extwin-body {
+  padding: 14px 18px 18px;
+  overflow-y: auto;
+}
+
+/* The summary row in Advanced, when something is actually reachable. */
+.ext-summary-on {
+  color: var(--red-tint);
+}
+
 .market {
   position: fixed;
   top: 50%;
@@ -2946,22 +3054,49 @@ textarea.wf-input {
   cursor: pointer;
 }
 
+/* The list with the feature off: still legible, still operable, visibly not in
+   use. Opacity would take the text below the contrast the rest of the panel
+   holds, so only the accent recedes. */
+.ext-mcp.is-off .settings-row-label {
+  color: var(--muted2);
+}
+
+/* A per-server switch still shows its own state while the feature is off, but
+   in grey: brand blue on a switch that nothing is currently going through reads
+   as a live connection. */
+.ext-mcp.is-off .toggle.on {
+  background: var(--border2);
+}
+
+/* The one line that says a change is in progress. Amber rather than red: this
+   is a wait, not a problem. */
+.ext-mcp-applying {
+  color: var(--warn);
+  margin: 6px 0 0;
+}
+
+/* No indent rule: this list used to be nested under a switch in the settings
+   drawer, where a left border showed what it belonged to. In its own window it
+   is the content, so it sits at the window's own margin like everything else. */
 .ext-mcp {
   display: flex;
   flex-direction: column;
   gap: 10px;
-  padding: 4px 0 10px 12px;
-  border-left: 1px solid var(--border);
-  margin-left: 4px;
+  padding: 12px 0 4px;
+  border-top: 1px solid var(--border);
+  margin-top: 4px;
 }
 
 .ext-mcp-empty {
   font-style: italic;
 }
 
+/* The switch and Remove sit against the middle of the entry, not its first
+   line: a server is four lines (name, url, transport, token), and pinning the
+   controls to the top left them floating above everything they act on. */
 .ext-mcp-server {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
   gap: 12px;
 }


### PR DESCRIPTION
## Summary

Settings was one section plus a stray control: General was a heading, Advanced was a button that looked almost the same, and behind it sat both a single toggle and the whole external-MCP subsystem. External MCP moves into a window of its own, Advanced becomes something that visibly opens, and a handful of read and behaviour problems found across the interface are fixed with it.

## Test plan

- [x] `just check` — 546 passed, 2 skipped; `npm run lint`, `tsc --noEmit`, production bundle build
- [x] Settings drawer: General and Advanced read as heading and control; Advanced shows what is behind it when closed and takes the section colour when open; `aria-expanded` reflects the state
- [x] External MCP window: opens from Advanced and from the warning strip; the consent dialog appears above it with its own backdrop, so the list behind cannot be clicked
- [x] Servers can be switched off, retyped and removed while the feature itself is off, and the panel says nothing is being sent
- [x] Changing one server no longer disables the rest: the control moves at once, the change is queued, and a line explains the wait; a rejected change snaps back to the server's answer
- [x] Switch knob centring verified by decoding rendered screenshots at 1x, 1.25x, 1.5x and 2x (3/3, 4/4, 5/5, 6/6 pixels above and below)
- [x] Empty states present in all four panels; chat header icons align with their labels

**Verified against stubbed API data in a headless browser**, plus a build deployed against a live workspace. The add-server form and the consent dialog were exercised by hand in the deployed build.

## Notes

- **No API or server change.** This is entirely `frontend/`; the endpoints, their payloads and the permission model are untouched.
- **Behaviour worth knowing about:** changing anything under External MCP restarts the agent, which takes roughly a second and a half when a chat is open, because the running process is stopped and waited for. The panel now queues changes rather than blocking, but the wait itself is inherent — deactivating a server has to stop the agent using it before the change reports success.
- **The switch is 1px taller** (20px, with a 14px knob). Odd-height controls centred in even-height rows land on half pixels, and the knob's bottom edge then antialiases away; the even sizes make the gaps rasterise equally.
- **Wording:** em dashes are gone from user-visible strings in favour of plainer sentences, and the GPU and provenance hints are rewritten. Both were written in shorthand that assumed knowledge of the system.
- **Follow-up:** the same disclosure pattern exists in the viewer settings popover (`.vs-advanced-toggle`) and was left alone here; it should probably follow.
