### PR TITLE
ci(release): publish versioned releases from v* tags

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -6,6 +6,8 @@ name: Images
 # arch — so the README quickstart works unchanged on amd64 nodes and on aarch64
 # boxes, which previously pulled an unrunnable amd64 image.
 # On pull_request: build + smoke test only — no login, no push, no merge.
+# Releases are NOT built here: pushing a v* tag runs release.yml, which
+# publishes the immutable :vX.Y.Z tags and moves :latest.
 # Plain `docker build` on the runner's daemon so core can FROM the just-built base
 # without a registry round-trip. Each arch builds natively because QEMU is far too
 # slow for the CUDA/torch compiles — do NOT collapse this into a single buildx
@@ -60,7 +62,8 @@ jobs:
       - name: Build base + core
         run: |
           docker build -f Dockerfile.base --build-arg CUDA_TAG="${CUDA_TAG}" -t medmcp-base:ci .
-          docker build --build-arg BASE_IMAGE=medmcp-base:ci -t medmcp-core:ci .
+          docker build --build-arg BASE_IMAGE=medmcp-base:ci \
+            --build-arg MEDMCP_BUILD="${GITHUB_SHA}" -t medmcp-core:ci .
       - name: Smoke test (entrypoint sanitizer + server boots)
         run: |
           # A host-like docker config carrying the leaked context + a credential

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,257 @@
+name: Release
+
+# Cut a release by pushing a tag: `git tag v0.2.0 && git push origin v0.2.0`.
+# Publishes immutable `:v0.2.0` images and compose artifact, moves `:latest` to
+# them, and opens the GitHub Release with that version's CHANGELOG section as
+# the notes. `main` keeps meaning "rolling dev" and is published by images.yml.
+#
+# Tags published here: `vX.Y.Z` (immutable — pin here for a reproducible fleet)
+# and `latest` (newest release). images.yml owns `:main` and `:<sha>`.
+#
+# The version lives in pyproject.toml and nowhere else — medmcp.__version__
+# reads it back from the installed distribution. While on 0.x: patch for
+# Fixed/Security only; minor for anything under Added, or a break in the compose
+# env contract, the .vibe volume layout, or the org.medmcp.stack label schema.
+#
+# To release: move CHANGELOG's Unreleased under `## X.Y.Z — <date>`, bump
+# pyproject AND uv.lock (which records the project's own version — the image
+# build runs `uv sync --frozen` and fails on a mismatch), commit to main,
+# push the tag. A pre-release tag (`v0.3.0-rc1`)
+# publishes under its own tag and does not move `:latest`; it is checked against
+# its base version, so pyproject stays at the plain `X.Y.Z`.
+#
+# Rollback — release tags are never overwritten, so latest can always go back:
+#   docker buildx imagetools create -t ghcr.io/medmcp/core:latest \
+#     ghcr.io/medmcp/core:vX.Y.Z
+#
+# Two things this deliberately does not do. The README still installs
+# `compose:main`: switch it to `:latest` once the first release has published,
+# not before, or it points at a tag that is not there yet. And
+# catalog.ghcr.json points at `:main` stack images, so a release installs
+# rolling stacks — stacks version independently, so pin them in the release
+# commit once their repos are tagged. `verify` warns rather than failing.
+#
+# The build/merge steps deliberately mirror images.yml (native per-arch builds,
+# then manifest lists — do NOT collapse into one buildx --platform build, QEMU
+# is far too slow for the CUDA/torch compiles). Keep the two in sync when either
+# changes; they are separate files because their triggers and tags differ.
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write # create the GitHub Release
+  packages: write
+
+# Never let two releases interleave: they both move :latest, and the loser would
+# silently win the tag.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CUDA_TAG: "12.8.1"
+
+jobs:
+  # Everything that can reject a release before an image exists. A tag is
+  # effectively permanent once images carry it, so the checks are up front.
+  verify:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.check.outputs.version }}
+      prerelease: ${{ steps.check.outputs.prerelease }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - id: check
+        name: Tag, version and changelog must agree
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          version="${tag#v}"
+          # A pre-release tag (v0.3.0-rc1) releases the same code as v0.3.0 will,
+          # so it is checked against the base version — pyproject is not churned
+          # for release candidates, and the notes come from the 0.3.0 section.
+          base="${version%%-*}"
+
+          declared=$(grep -m1 '^version = ' pyproject.toml | cut -d'"' -f2)
+          if [ "$base" != "$declared" ]; then
+            echo "::error::tag $tag does not match pyproject.toml version $declared"
+            exit 1
+          fi
+
+          # Release notes come from the changelog; an empty or missing section
+          # must stop the release, not produce a release with no notes.
+          python3 scripts/changelog_section.py "$base" > /dev/null
+
+          # A tag off a branch that never landed would publish code no CI run on
+          # main ever saw.
+          git fetch --quiet origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "::error::$tag is not an ancestor of origin/main"
+            exit 1
+          fi
+
+          # A pre-release (v0.3.0-rc1) publishes under its own tag but must not
+          # move :latest, which is what the README tells people to install.
+          prerelease=false
+          case "$version" in *-*) prerelease=true ;; esac
+
+          echo "version=$base" >> "$GITHUB_OUTPUT"
+          echo "prerelease=$prerelease" >> "$GITHUB_OUTPUT"
+          echo "releasing $tag (prerelease=$prerelease)"
+      - name: Check the stack catalog is pinned
+        run: |
+          # A released core shipping a catalog of :main stack images means the
+          # stacks it installs keep changing under the release. Not fatal — the
+          # stack repos are versioned independently and may not be tagged yet.
+          if grep -q 'ghcr.io/medmcp/[^"]*:main' catalog.ghcr.json; then
+            echo "::warning::catalog.ghcr.json points at :main stack images; this release installs rolling stacks (see this file's header)"
+          fi
+
+  build:
+    needs: verify
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v7
+      - name: Build base + core
+        run: |
+          docker build -f Dockerfile.base --build-arg CUDA_TAG="${CUDA_TAG}" -t medmcp-base:ci .
+          docker build --build-arg BASE_IMAGE=medmcp-base:ci \
+            --build-arg MEDMCP_BUILD="${GITHUB_REF_NAME}" -t medmcp-core:ci .
+      - name: Smoke test (entrypoint sanitizer + server boots + reports version)
+        env:
+          VERSION: ${{ needs.verify.outputs.version }}
+        run: |
+          printf '{"auths":{"ghcr.io":{"auth":"dGVzdA=="}},"currentContext":"rootless","credsStore":"pass"}' \
+            > /tmp/host-docker-config.json
+          docker run -d --name medmcp-smoke \
+            -v /tmp/host-docker-config.json:/run/host-docker-config.json:ro \
+            -e MEDMCP_GPU=all \
+            medmcp-core:ci
+          ok=
+          for _ in $(seq 1 30); do
+            if docker exec medmcp-smoke python3 -c \
+              "import urllib.request; urllib.request.urlopen('http://localhost:8100/healthz')" 2>/dev/null; then
+              ok=1; break
+            fi
+            sleep 2
+          done
+          [ "$ok" = 1 ] || { echo "::error::server never became healthy"; docker logs medmcp-smoke; exit 1; }
+          keys=$(docker exec medmcp-smoke python3 -c \
+            "import json; print(sorted(json.load(open('/root/.docker/config.json')).keys()))")
+          [ "$keys" = "['auths']" ] || { echo "::error::config not sanitized: $keys"; exit 1; }
+          # The image must know what it is — this is the whole point of tagging.
+          reported=$(docker exec medmcp-smoke python3 -c \
+            "import json,urllib.request; print(json.load(urllib.request.urlopen('http://localhost:8100/healthz'))['version'])")
+          [ "$reported" = "$VERSION" ] \
+            || { echo "::error::image reports version $reported, releasing $VERSION"; exit 1; }
+          echo "smoke test passed (version $reported)"
+      - name: Smoke test cleanup
+        if: always()
+        run: docker rm -f medmcp-smoke 2>/dev/null || true
+      - name: Push arch-suffixed tags to GHCR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRERELEASE: ${{ needs.verify.outputs.prerelease }}
+        run: |
+          echo "$GH_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          tags="${GITHUB_REF_NAME}"
+          [ "$PRERELEASE" = "true" ] || tags="$tags latest"
+          # Suffixed tags are an internal handoff to the merge job; nothing
+          # outside this workflow should consume one.
+          for img in base core; do
+            for tag in $tags; do
+              docker tag "medmcp-$img:ci" "ghcr.io/medmcp/$img:$tag-${{ matrix.arch }}"
+              docker push "ghcr.io/medmcp/$img:$tag-${{ matrix.arch }}"
+            done
+          done
+
+  publish:
+    needs: [verify, build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Log in to GHCR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "$GH_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+      - name: Merge arch tags into multi-arch manifest lists
+        env:
+          PRERELEASE: ${{ needs.verify.outputs.prerelease }}
+        run: |
+          tags="${GITHUB_REF_NAME}"
+          [ "$PRERELEASE" = "true" ] || tags="$tags latest"
+          for img in base core; do
+            for tag in $tags; do
+              docker buildx imagetools create -t "ghcr.io/medmcp/$img:$tag" \
+                "ghcr.io/medmcp/$img:$tag-amd64" \
+                "ghcr.io/medmcp/$img:$tag-arm64"
+            done
+          done
+      - name: Verify both platforms resolve
+        run: |
+          for img in base core; do
+            insp=$(docker buildx imagetools inspect "ghcr.io/medmcp/$img:${GITHUB_REF_NAME}")
+            for plat in linux/amd64 linux/arm64; do
+              echo "$insp" | grep -q "$plat" \
+                || { echo "::error::ghcr.io/medmcp/$img:${GITHUB_REF_NAME} is missing $plat"; exit 1; }
+            done
+          done
+          echo "both platforms present on base + core"
+      - name: Pin the compose artifact to this release
+        run: |
+          # docker-compose.ghcr.yml defaults MEDMCP_TAG to `main`. Published
+          # unchanged under a release tag, `compose:v0.2.0` would still pull
+          # `core:main` — a "pinned" install that keeps moving.
+          python3 - <<'PY'
+          import os
+          import pathlib
+
+          tag = os.environ["GITHUB_REF_NAME"]
+          path = pathlib.Path("docker-compose.ghcr.yml")
+          text = path.read_text()
+          old = "${MEDMCP_TAG:-main}"
+          if old not in text:
+              raise SystemExit(f"error: {old} not found in {path}; release would not be pinned")
+          path.write_text(text.replace(old, "${MEDMCP_TAG:-%s}" % tag))
+          print(f"pinned compose to {tag}")
+          PY
+          grep -n 'MEDMCP_TAG' docker-compose.ghcr.yml
+      - name: Publish the deploy compose as an OCI artifact
+        env:
+          PRERELEASE: ${{ needs.verify.outputs.prerelease }}
+        run: |
+          # `yes |` answers the bind-mount confirmation that -y does not cover;
+          # without it the TTY-less runner reads EOF, defaults to No, and skips
+          # the publish while exiting 0. MEDMCP_WORKSPACE only satisfies
+          # publish-time interpolation — it is not baked in (no --with-env).
+          tags="${GITHUB_REF_NAME}"
+          [ "$PRERELEASE" = "true" ] || tags="$tags latest"
+          for tag in $tags; do
+            yes | MEDMCP_WORKSPACE=/run/medmcp \
+              docker compose -f docker-compose.ghcr.yml publish \
+              "ghcr.io/medmcp/compose:$tag" -y
+          done
+      - name: Create the GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.verify.outputs.version }}
+          PRERELEASE: ${{ needs.verify.outputs.prerelease }}
+        run: |
+          python3 scripts/changelog_section.py "$VERSION" > /tmp/notes.md
+          flags=""
+          [ "$PRERELEASE" = "true" ] && flags="--prerelease"
+          # shellcheck disable=SC2086
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "${GITHUB_REF_NAME}" \
+            --notes-file /tmp/notes.md \
+            $flags

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Notable, user-visible changes to MedMCP. Format follows
 
 ## Unreleased
 
+## 0.2.0 — 2026-08-25
+
 ### Added
 
 - **External MCP servers** — connect the agent to remote MCP services (Settings →

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,82 +6,30 @@ Notable, user-visible changes to MedMCP. Format follows
 
 ## Unreleased
 
+### Added
+
+- **External MCP servers** — connect the agent to remote MCP services (Settings →
+  Advanced). Off by default, behind a consent dialog; tokens stay on this machine.
+- **TotalSegmentator stack** — whole-body CT/MR anatomy segmentation, installable
+  from the Tool stacks window.
+- `/healthz` reports the running version and the build it came from.
+
 ### Changed
 
-- **Settings is easier to read.** General and Advanced are now the same kind of
-  heading rather than a heading and a button, and everything inside Advanced is
-  visibly inside it. External MCP servers moved out of the drawer into a window
-  of their own, reached from Advanced or from the warning strip, so settings is a
-  short list of switches and the servers get room for their list, their tokens
-  and the consent text. Wording across the interface was cleaned up as well.
+- Settings drawer reorganised; external MCP servers moved into a window of their own.
+- Wording tidied across the interface.
 
 ### Fixed
 
-- **Uninstalling a tool stack now removes it properly.** A stack could disappear
-  from the stacks window while still showing in settings, and on an installation
-  that had never changed which stacks are switched on, it could come back
-  entirely — the agent kept being told to launch something you had removed.
+- Uninstalling a tool stack now removes it for good — it could previously come back.
 
 ### Security
 
-- **A tool stack can no longer get internet access without you agreeing to it.**
-  Stacks normally run with networking switched off — they see the files you point
-  them at and nothing else — but an image can ask for network access, and your
-  workspace is available to it, so it could send what it reads elsewhere. That
-  request now stops the install and asks you first, and any stack that has it is
-  marked **internet** in the stacks window for as long as it is installed.
-- **Saved workflows can only touch your workspace.** A workflow runs its recorded
-  tool calls without asking for approval each time, so a file it names is now
-  required to be inside the workspace — including by way of a shortcut that
-  points out of it. Anything else is refused before the first step runs.
-
-- **A website you visit can no longer reach the workspace.** The workspace
-  listens on your machine only, but a browser will still let any page send
-  requests to it — and a chat connection is not covered by the browser's usual
-  same-site protection at all, so a page could open one, ask the agent to read
-  your files and receive the contents, without any approval prompt appearing.
-  Requests and connections that do not come from the workspace's own page are
-  now refused, as are requests aimed at it under another name (a technique that
-  otherwise gets around the first check). If you reach MedMCP through a
-  hostname of your own — a reverse proxy, say — list it in
-  `MEDMCP_ALLOWED_HOSTS` / `MEDMCP_ALLOWED_ORIGINS`; anything unlisted is
-  refused.
-
-### Added
-
-- **TotalSegmentator stack**, installable from the Tool stacks window. Segments
-  anatomical structures on whole-body CT and MR — 117 structures in one pass with
-  the general CT model and 50 with the MR one, plus focused models for the spine,
-  lungs, liver, head and neck, and teeth — and reports per-structure volumes. A
-  GPU is strongly recommended; it also runs on CPU, considerably more slowly.
-- **External MCP servers** (Settings → Advanced, off by default). Lets you connect
-  the agent to MCP tool services hosted outside your machine — a literature
-  search, a hospital system, a vendor API — alongside your local imaging stacks.
-  Because this ends the guarantee that nothing leaves your infrastructure, the
-  switch does not simply flip: it first explains what changes and asks you to
-  accept responsibility for what those services receive. Nothing is connected
-  until you do, and turning it off both removes the servers from the agent and
-  withdraws your acceptance, so switching it back on asks again.
-  Servers are addressed by URL (`streamable-http` or `http`); if one needs a
-  token, you paste it into the form. It is kept on this machine, handed to the
-  agent when it starts, and never written into the agent's configuration or sent
-  back to the browser — you can replace it later, but nothing can read it out.
-  Tokens are sent as `Authorization: Bearer …` by default, and services that
-  expect something else (an `X-API-Key` header, say) can set the header and value
-  format themselves.
-  Individual servers can be switched off without deleting them, and every tool
-  call still asks for your approval. While anything external is enabled, a red
-  strip under the header says so from every panel, names the servers, and turns
-  them all off in one click — the settings switch is easy to forget, this is not.
-  Turning it off applies to every server at once, whatever their individual
-  switches say, and the setting states plainly that nothing is enabled any more;
-  the agent is restarted so nothing already running keeps a connection. Servers
-  and your acceptance are kept across restarts and updates. A deployment that
-  manages its own secrets can name an environment variable instead of a token: put
-  `NAME=value` lines in a `medmcp.env` file next to your compose file (or point
-  `MEDMCP_ENV_FILE` at one), which is optional and read only if present. If a
-  named variable turns out not to be set where the agent runs, the setting says
-  so — rather than leaving you with an unexplained rejection from the service.
+- Stacks that ask for network access need your consent at install, and are marked
+  **internet** while installed.
+- Saved workflows can only touch files inside your workspace.
+- Requests to the workspace from other websites are refused (`MEDMCP_ALLOWED_HOSTS`
+  / `MEDMCP_ALLOWED_ORIGINS` allow a reverse proxy).
 
 ## 0.1.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,13 @@ COPY catalog.ghcr.json ./catalog.ghcr.json
 COPY docker/entrypoint.sh /usr/local/bin/medmcp-entrypoint
 RUN chmod +x /usr/local/bin/medmcp-entrypoint
 
+# What this image was built from — a release tag for a released image, a commit
+# sha for a rolling :main one. Reported by /healthz; empty for a local build.
+ARG MEDMCP_BUILD=""
+
 ENV PATH=/app/.venv/bin:$PATH \
     UV_NO_SYNC=1 \
+    MEDMCP_BUILD=$MEDMCP_BUILD \
     MEDMCP_WORKSPACE_HOST=0.0.0.0 \
     OLLAMA_BASE_URL=http://llm:11434
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "medmcp"
-version = "0.1.0"
+version = "0.2.0"
 description = "A local medical imaging agent"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/scripts/changelog_section.py
+++ b/scripts/changelog_section.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Print one version's section of CHANGELOG.md, for use as release notes.
+
+The release workflow feeds the output to ``gh release create --notes-file``, so
+a missing section is a hard error: a release whose notes silently came out empty
+is worse than one that fails to publish.
+
+Usage:
+    python scripts/changelog_section.py 0.2.0 [--changelog CHANGELOG.md]
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+def extract(text: str, version: str) -> str:
+    """Return the body of ``version``'s section, without its own heading.
+
+    Accepts the heading spellings the file has used: ``## 0.1.0``,
+    ``## [0.2.0]``, and either with a trailing date.
+
+    Args:
+        text: Full contents of the changelog.
+        version: Version to look for, without a leading ``v``.
+
+    Returns:
+        The section body, stripped of surrounding blank lines.
+
+    Raises:
+        LookupError: If no heading for that version is present.
+    """
+    start = re.compile(rf"^## +\[?{re.escape(version)}\]?\b.*$", re.MULTILINE)
+    match = start.search(text)
+    if match is None:
+        raise LookupError(f"no '## {version}' heading in the changelog")
+
+    rest = text[match.end() :]
+    following = re.search(r"^## ", rest, re.MULTILINE)
+    body = rest[: following.start()] if following else rest
+    return body.strip("\n")
+
+
+def main() -> int:
+    """Parse arguments, print the section, and report failure as an exit code."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("version", help="version to extract, e.g. 0.2.0")
+    parser.add_argument(
+        "--changelog",
+        type=Path,
+        default=Path("CHANGELOG.md"),
+        help="path to the changelog (default: ./CHANGELOG.md)",
+    )
+    args = parser.parse_args()
+
+    try:
+        section = extract(args.changelog.read_text(encoding="utf-8"), args.version)
+    except (OSError, LookupError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    if not section:
+        print(f"error: section for {args.version} is empty", file=sys.stderr)
+        return 1
+
+    print(section)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/medmcp/__init__.py
+++ b/src/medmcp/__init__.py
@@ -1,3 +1,12 @@
 """MedMCP: an LLM agent for medical imaging workflows."""
 
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    # Single source of truth: the version declared in pyproject.toml, read back
+    # from the installed distribution so the two can never drift.
+    __version__ = version("medmcp")
+except PackageNotFoundError:  # pragma: no cover - source tree with no install
+    __version__ = "0+unknown"
+
+__all__ = ["__version__"]

--- a/src/medmcp/server.py
+++ b/src/medmcp/server.py
@@ -51,6 +51,7 @@ from pydantic import BaseModel, Field
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from medmcp import (
+    __version__,
     batchplan,
     distill,
     explain,
@@ -81,6 +82,12 @@ WORKSPACE_ROOT: Path = Path(
 ).resolve()
 FRONTEND_DIST: Path = Path(PROJECT_ROOT) / "frontend" / "dist"
 DEFAULT_PORT: int = 8100
+
+# What this instance was built from, baked in by the image build: a release
+# tag (v1.2.3) for a released image, a commit sha for a rolling :main one,
+# empty when running from a source checkout. The version alone cannot say
+# which, since main carries the released version until the next bump.
+BUILD: str = os.environ.get("MEDMCP_BUILD", "")
 
 # Tool/VCS internals hidden from the explorer tree.
 _SKIP_DIRS: frozenset[str] = frozenset(
@@ -462,8 +469,12 @@ def _apply_stack_change() -> None:
 
 @app.get("/healthz")
 async def healthz() -> JsonDict:
-    """Liveness probe for container healthchecks (touches no dependencies)."""
-    return {"status": "ok"}
+    """Liveness probe for container healthchecks (touches no dependencies).
+
+    Carries the version and build identifier so an installed instance can say
+    what it is — the first question any bug report has to answer.
+    """
+    return {"status": "ok", "version": __version__, "build": BUILD}
 
 
 @app.get("/api/gpus")

--- a/tests/test_release_meta.py
+++ b/tests/test_release_meta.py
@@ -1,0 +1,91 @@
+"""Guards on the release plumbing.
+
+A release is cut by pushing a `v*` tag, and `release.yml` refuses to publish
+unless the tag, `pyproject.toml` and the changelog agree. Those checks run at
+release time, when the fix is a retag; these run in CI, when it is an edit.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import cast
+
+import pytest
+from fastapi.testclient import TestClient
+
+import medmcp
+from medmcp import server
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _declared_version() -> str:
+    """Return the version literal in pyproject.toml."""
+    match = re.search(r'^version = "([^"]+)"', (ROOT / "pyproject.toml").read_text(), re.MULTILINE)
+    assert match is not None, "pyproject.toml has no version"
+    return match.group(1)
+
+
+def _extract() -> Callable[[str, str], str]:
+    """Load `scripts/changelog_section.py`, which is tooling and not importable."""
+    path = ROOT / "scripts" / "changelog_section.py"
+    spec = importlib.util.spec_from_file_location("changelog_section", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return cast(Callable[[str, str], str], module.extract)
+
+
+class TestVersion:
+    """One version string, reachable from the running instance."""
+
+    def test_package_version_matches_pyproject(self) -> None:
+        """`__version__` is read back from the distribution, so it cannot drift."""
+        assert medmcp.__version__ == _declared_version()
+
+    def test_healthz_reports_version_and_build(self) -> None:
+        """An installed instance can say what it is — the first question a bug report asks."""
+        client = TestClient(server.app, base_url="http://127.0.0.1:8100")
+        payload = cast(dict[str, str], client.get("/healthz").json())
+        assert payload["status"] == "ok"
+        assert payload["version"] == medmcp.__version__
+        assert "build" in payload  # empty outside a built image
+
+
+class TestChangelogSection:
+    """The release notes come from the changelog; an empty section must be loud."""
+
+    def test_extracts_body_without_the_heading(self) -> None:
+        """The section stops at the next version heading."""
+        text = "# Changelog\n\n## 0.2.0 — 2026-01-01\n\nnew things\n\n## 0.1.0\n\nold things\n"
+        assert _extract()(text, "0.2.0") == "new things"
+
+    def test_accepts_the_bracketed_spelling(self) -> None:
+        """Keep a Changelog links versions as `## [0.2.0]`; both forms are in the file."""
+        assert _extract()("## [0.2.0]\n\nbody\n", "0.2.0") == "body"
+
+    def test_missing_version_raises(self) -> None:
+        """A tag with no changelog section must stop the release, not ship empty notes."""
+        with pytest.raises(LookupError):
+            _extract()("## 0.1.0\n\nbody\n", "9.9.9")
+
+    def test_shipped_changelog_has_a_section_for_the_current_version(self) -> None:
+        """Whatever `pyproject.toml` declares must be releasable from this tree."""
+        changelog = (ROOT / "CHANGELOG.md").read_text()
+        assert _extract()(changelog, _declared_version()).strip()
+
+
+def test_compose_still_carries_the_tag_default_release_rewrites() -> None:
+    """`release.yml` pins the published compose by substituting this exact literal.
+
+    Renaming it would leave `compose:vX.Y.Z` pulling `core:main` — a pinned
+    install that keeps moving. The release job fails loudly on this, but CI is
+    the cheaper place to find out.
+    """
+    compose = (ROOT / "docker-compose.ghcr.yml").read_text()
+    assert "${MEDMCP_TAG:-main}" in compose

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -4,5 +4,9 @@ import medmcp
 
 
 def test_package_imports() -> None:
-    """The package should be importable."""
-    assert medmcp.__version__ == "0.1.0"
+    """The package should be importable and know its version.
+
+    The number is not pinned here — it lives in pyproject.toml alone, and
+    ``test_release_meta`` is what checks the two agree.
+    """
+    assert medmcp.__version__

--- a/uv.lock
+++ b/uv.lock
@@ -733,7 +733,7 @@ wheels = [
 
 [[package]]
 name = "medmcp"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

Pushing a `v*` tag now publishes a release: immutable `:vX.Y.Z` images and compose artifact, `:latest` moved to them, and a GitHub Release whose notes are that version's changelog section. `:main` keeps meaning "rolling development build". Includes the 0.2.0 release commit, ready to tag on merge.

## Test plan

- [x] `just check` green on the branch tip — 553 passed, 2 skipped
- [x] `verify`'s three checks dry-run locally for both `v0.2.0` and `v0.2.0-rc1` (tag ↔ pyproject, changelog section present, commit on main)
- [x] compose pinning substitution dry-run: `${MEDMCP_TAG:-main}` → `${MEDMCP_TAG:-v0.2.0}`
- [x] `scripts/changelog_section.py` extracts 0.1.0 and 0.2.0, exits 1 on a missing version
- [ ] First real workflow run is `v0.2.0-rc1` after merge — publishes under its own tag and does not move `:latest`, so a failure costs nothing

## Security & data handling

`release.yml` needs `contents: write` to create the GitHub Release (`packages: write` matches `images.yml`). No new tool surface, network calls, or file-write paths in the application. `/healthz` now returns the version and the build the image came from; it was already unauthenticated and reachable only from loopback.

## Notes

- **Version has one home.** `pyproject.toml`; `medmcp.__version__` reads it back through `importlib.metadata`. `tests/test_smoke.py` had `0.1.0` hardcoded and would have failed CI on every release — unpinned, with `test_release_meta.py` asserting the real invariant.
- **`release.yml` duplicates ~60 lines** of build/merge from `images.yml`. Factoring both onto a `workflow_call` is the right end state but means editing the pipeline that currently publishes `:main`, so it is left as a follow-up; the two files cross-reference each other.
- **README still installs `compose:main`** — deliberately. `:latest` does not exist until the first release publishes; switching earlier would document a tag that isn't there.
- **`catalog.ghcr.json` still points at `:main` stack images**, so a release installs rolling stacks. Stacks version independently and their repos aren't tagged yet, so `verify` warns rather than failing.
- Pre-release tags are checked against their base version, so `pyproject.toml` is not churned for release candidates.
