### PR TITLE
docs: install from :latest, label the published images, release 0.2.1

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -63,7 +63,8 @@ jobs:
         run: |
           docker build -f Dockerfile.base --build-arg CUDA_TAG="${CUDA_TAG}" -t medmcp-base:ci .
           docker build --build-arg BASE_IMAGE=medmcp-base:ci \
-            --build-arg MEDMCP_BUILD="${GITHUB_SHA}" -t medmcp-core:ci .
+            --build-arg MEDMCP_BUILD="${GITHUB_SHA}" \
+            --build-arg MEDMCP_REVISION="${GITHUB_SHA}" -t medmcp-core:ci .
       - name: Smoke test (entrypoint sanitizer + server boots)
         run: |
           # A host-like docker config carrying the leaked context + a credential

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,8 @@ jobs:
         run: |
           docker build -f Dockerfile.base --build-arg CUDA_TAG="${CUDA_TAG}" -t medmcp-base:ci .
           docker build --build-arg BASE_IMAGE=medmcp-base:ci \
-            --build-arg MEDMCP_BUILD="${GITHUB_REF_NAME}" -t medmcp-core:ci .
+            --build-arg MEDMCP_BUILD="${GITHUB_REF_NAME}" \
+            --build-arg MEDMCP_REVISION="${GITHUB_SHA}" -t medmcp-core:ci .
       - name: Smoke test (entrypoint sanitizer + server boots + reports version)
         env:
           VERSION: ${{ needs.verify.outputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Notable, user-visible changes to MedMCP. Format follows
 
 ## Unreleased
 
+### Changed
+
+- Published images link back to this repository and carry version and commit labels.
+
 ## 0.2.0 — 2026-08-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Notable, user-visible changes to MedMCP. Format follows
 
 ## Unreleased
 
+## 0.2.1 — 2026-08-25
+
 ### Changed
 
 - Published images link back to this repository and carry version and commit labels.

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,19 @@ RUN chmod +x /usr/local/bin/medmcp-entrypoint
 # What this image was built from — a release tag for a released image, a commit
 # sha for a rolling :main one. Reported by /healthz; empty for a local build.
 ARG MEDMCP_BUILD=""
+# The commit itself, which a release tag does not spell out.
+ARG MEDMCP_REVISION=""
+
+# OCI metadata. `image.source` is the one GitHub acts on: it links the published
+# package to this repository, so the images are reachable from the repo instead
+# of floating in the org with no visible relationship to the code. The rest is
+# what `docker inspect` and SBOM tooling read to identify an image.
+LABEL org.opencontainers.image.source="https://github.com/medmcp/medmcp" \
+      org.opencontainers.image.title="MedMCP" \
+      org.opencontainers.image.description="A local medical imaging agent" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.version="$MEDMCP_BUILD" \
+      org.opencontainers.image.revision="$MEDMCP_REVISION"
 
 ENV PATH=/app/.venv/bin:$PATH \
     UV_NO_SYNC=1 \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -34,5 +34,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # uv (pinned) — a single static binary, copied from the official distroless image.
 COPY --from=ghcr.io/astral-sh/uv:0.11.6 /uv /uvx /usr/local/bin/
 
+# Links the published package to this repository (see Dockerfile for why).
+LABEL org.opencontainers.image.source="https://github.com/medmcp/medmcp" \
+      org.opencontainers.image.title="MedMCP base" \
+      org.opencontainers.image.description="Shared CUDA + Python base for MedMCP images" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
 # Reasonable default workdir; downstream images override as needed.
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -28,15 +28,19 @@ The easiest way to run MedMCP is with the prebuilt Docker images.
 
 ```bash
 MEDMCP_WORKSPACE="$HOME/medmcp-data" \
-  docker compose -f oci://ghcr.io/medmcp/compose:main up -d
+  docker compose -f oci://ghcr.io/medmcp/compose:latest up -d
 ```
 Then open **http://localhost:8100**.
 
 **Requirements:** Linux OS with an NVIDIA GPU (≥ 24 GB VRAM recommended for the local Muse Glimmer 30B model), a recent driver (≥ R570 / CUDA 12.8), and Docker with GPU access via the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/) (CDI; rootless Docker works).
 
-**Stop** with `docker compose -f oci://ghcr.io/medmcp/compose:main down`.
+**Stop** with `docker compose -f oci://ghcr.io/medmcp/compose:latest down`.
 
 **Update** by re-running the start command with `--pull always`.
+
+**Versions:** `latest` is the newest release. Pin a specific one with
+`oci://ghcr.io/medmcp/compose:v0.2.0` — release tags are never moved, so a
+pinned fleet stays put. `main` is the rolling development build.
 
 > Want to build from source or run host-native? See **[CONTRIBUTING.md](CONTRIBUTING.md)**.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "medmcp"
-version = "0.2.0"
+version = "0.2.1"
 description = "A local medical imaging agent"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -733,7 +733,7 @@ wheels = [
 
 [[package]]
 name = "medmcp"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

The quickstart installed `:main`, the rolling development build. v0.2.0 is published, so it now installs `compose:latest` and documents how to pin a release. The images also carry OCI metadata for the first time — `image.source` is what links the GHCR packages to this repository instead of leaving them floating in the org.

## Test plan

- [x] `just check` green — 553 passed, 2 skipped
- [x] `compose:latest`, rendered straight from the registry, resolves to `ghcr.io/medmcp/core:v0.2.0` — so the new README command installs the release and not `main`
- [x] Both workflow files parse; each build step passes `MEDMCP_REVISION`
- [ ] After merge: `docker buildx imagetools inspect ghcr.io/medmcp/core:main` shows the labels, and the package links to this repo from its GHCR page

## Notes

- **Labels apply to the next build.** `core:v0.2.0` as published carries none; they land on `:main` when this merges and on the next release tag. Re-tagging v0.2.0 to pick them up would mean rewriting a release tag, which is not worth it.
- `image.version` comes from `MEDMCP_BUILD` — the release tag on a release build, the commit sha on a `main` build (the same value `/healthz` reports). `image.revision` is always the commit.
- Only `Dockerfile`/`Dockerfile.base` are labelled here; the stack images live in their own repos.
