### PR TITLE
Release 0.2.3: replay runs that outlive the page, one run editor, recipe-only distillation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -230,6 +230,7 @@ medmcp.env
 # Derived from .vibe/prompts/medmcp.md at sync time when external MCP is in use.
 .vibe/prompts/medmcp-external.md
 .vibe/provenance/
+.vibe/runs/
 .vibe/workflows/
 data/
 node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Notable, user-visible changes to MedMCP. Format follows
 
 ## Unreleased
 
+### Changed
+
+- Workflow runs keep going when the page is closed or reloaded; the page picks them up again.
+- The run editor checks every row's input files before anything starts and flags a missing file per row.
+- One run editor replaces the Single/Batch switch and the separate preview screen: rows, checks, and the resolved steps sit on one screen with one Run button. Stop is now an explicit action rather than closing the page.
+
 ## 0.2.2 — 2026-09-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,15 @@ Notable, user-visible changes to MedMCP. Format follows
 
 ## Unreleased
 
+## 0.2.3 — 2026-09-03
+
 ### Changed
 
 - Workflow runs keep going when the page is closed or reloaded; the page picks them up again.
 - The run editor checks every row's input files before anything starts and flags a missing file per row.
 - One run editor replaces the Single/Batch switch and the separate preview screen: rows, checks, and the resolved steps sit on one screen with one Run button. Stop is now an explicit action rather than closing the page.
 - Saving a chat as a workflow is instant and names the workflow after the chat; no model pass runs and only `recipe.yaml` is written.
-- Workflows no longer have a draft/active state: every workflow can be run, renamed, exported and deleted. Existing `draft/` and `active/` folders are folded together on first use.
+- Workflows no longer have a draft/active state: every workflow can be run, renamed, exported and deleted. Existing `draft/` and `active/` folders are folded together on first use; an earlier release will not list them afterwards.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Notable, user-visible changes to MedMCP. Format follows
 - Workflow runs keep going when the page is closed or reloaded; the page picks them up again.
 - The run editor checks every row's input files before anything starts and flags a missing file per row.
 - One run editor replaces the Single/Batch switch and the separate preview screen: rows, checks, and the resolved steps sit on one screen with one Run button. Stop is now an explicit action rather than closing the page.
+- Saving a chat as a workflow is instant and names the workflow after the chat; no model pass runs and only `recipe.yaml` is written.
+- Workflows no longer have a draft/active state: every workflow can be run, renamed, exported and deleted. Existing `draft/` and `active/` folders are folded together on first use.
+
+### Removed
+
+- The Refine action and the generated `SKILL.md` narrative; a workflow is its recorded steps.
+- `medmcp promote` (and `just promote`) and the `--no-llm` flag of `medmcp distill`.
 
 ## 0.2.2 — 2026-09-02
 

--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -159,6 +159,7 @@ services:
       # stay image-fresh.
       - "vibe-workflows:/app/.vibe/workflows"
       - "vibe-provenance:/app/.vibe/provenance"
+      - "vibe-runs:/app/.vibe/runs"
       - "vibe-logs:/app/.vibe/logs"
       # External MCP servers and the consent that armed them. Losing these on an
       # image update would silently disconnect a configured setup.
@@ -174,5 +175,6 @@ volumes:
   stacks-d:
   vibe-workflows:
   vibe-provenance:
+  vibe-runs:
   vibe-logs:
   vibe-state:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -149,6 +149,7 @@ services:
       # stay image-fresh.
       - "vibe-workflows:/app/.vibe/workflows"
       - "vibe-provenance:/app/.vibe/provenance"
+      - "vibe-runs:/app/.vibe/runs"
       - "vibe-logs:/app/.vibe/logs"
       # External MCP servers and the consent that armed them. Losing these on an
       # image update would silently disconnect a configured setup.
@@ -166,5 +167,6 @@ volumes:
   ollama-models:
   vibe-workflows:
   vibe-provenance:
+  vibe-runs:
   vibe-logs:
   vibe-state:

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -4,7 +4,8 @@ import type {
   ExternalMcpState,
   GpuInfo,
   InstalledStack,
-  ReplayPreviewStep,
+  ReplayPreviewResult,
+  RunSummary,
   RewindResult,
   SessionInfo,
   SettingsState,
@@ -45,6 +46,13 @@ async function sendJson(
 
 async function postJson(url: string, body: object): Promise<Response> {
   return sendJson('POST', url, body)
+}
+
+/** The absolute on-disk workspace root, so absolute tool outputs can be shown
+ *  and opened as workspace paths. */
+export async function fetchWorkspaceRoot(): Promise<string> {
+  const res = await check(await fetch('/api/workspace'))
+  return ((await res.json()) as { root: string }).root
 }
 
 export async function fetchTree(): Promise<TreeNode[]> {
@@ -239,14 +247,30 @@ export async function importWorkflow(content: string): Promise<WorkflowDetail> {
   return (await res.json()) as WorkflowDetail
 }
 
+/** Pre-flight every run item and resolve the first runnable one's steps. */
 export async function replayPreview(
   name: string,
-  inputs: Record<string, string>,
-): Promise<{ ok: boolean; error: string | null; steps: ReplayPreviewStep[] }> {
+  runs: Record<string, string>[],
+): Promise<ReplayPreviewResult> {
   const res = await postJson(`/api/workflows/${encodeURIComponent(name)}/replay-preview`, {
-    inputs,
+    runs,
   })
-  return (await res.json()) as { ok: boolean; error: string | null; steps: ReplayPreviewStep[] }
+  return (await res.json()) as ReplayPreviewResult
+}
+
+/** Recent replay runs (newest first), plus the ids still in flight on the server. */
+export async function fetchRuns(
+  workflow?: string,
+  limit = 10,
+): Promise<{ runs: RunSummary[]; live: string[] }> {
+  const q = new URLSearchParams({ limit: String(limit) })
+  if (workflow) q.set('workflow', workflow)
+  const res = await check(await fetch(`/api/runs?${q.toString()}`))
+  return (await res.json()) as { runs: RunSummary[]; live: string[] }
+}
+
+export async function deleteRun(id: string): Promise<void> {
+  await check(await fetch(`/api/runs/${encodeURIComponent(id)}`, { method: 'DELETE' }))
 }
 
 /** Turn a plan_batch manifest CSV into per-subject batch rows for this workflow. */

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -196,31 +196,19 @@ export async function fetchWorkflowDetail(name: string): Promise<WorkflowDetail>
   return (await res.json()) as WorkflowDetail
 }
 
-/** Distill a chat session into a draft workflow; returns the new draft's detail. */
+/** Distill a chat session into a workflow named after the chat; returns its detail. */
 export async function distillSession(sessionId: string): Promise<WorkflowDetail> {
   const res = await postJson('/api/workflows/distill', { session_id: sessionId })
   return (await res.json()) as WorkflowDetail
 }
 
-export async function promoteWorkflow(name: string): Promise<void> {
-  await postJson(`/api/workflows/${encodeURIComponent(name)}/promote`, {})
-}
-
-export async function unpromoteWorkflow(name: string): Promise<void> {
-  await postJson(`/api/workflows/${encodeURIComponent(name)}/unpromote`, {})
-}
-
-/** Rename a draft; returns the new (slugified) name. */
+/** Rename a workflow; returns the new (slugified) name. */
 export async function renameWorkflow(name: string, newName: string): Promise<string> {
   const res = await postJson(`/api/workflows/${encodeURIComponent(name)}/rename`, {
     new_name: newName,
   })
   const body = (await res.json()) as { name: string }
   return body.name
-}
-
-export async function refineWorkflow(name: string, instruction: string): Promise<void> {
-  await postJson(`/api/workflows/${encodeURIComponent(name)}/refine`, { instruction })
 }
 
 export async function deleteWorkflow(name: string): Promise<void> {
@@ -241,7 +229,7 @@ export async function exportWorkflow(name: string): Promise<void> {
   URL.revokeObjectURL(url)
 }
 
-/** Import a shared workflow file (its YAML text); returns the new draft's detail. */
+/** Import a shared workflow file (its YAML text); returns the new workflow's detail. */
 export async function importWorkflow(content: string): Promise<WorkflowDetail> {
   const res = await postJson('/api/workflows/import', { content })
   return (await res.json()) as WorkflowDetail

--- a/frontend/src/components/WorkflowPanel.tsx
+++ b/frontend/src/components/WorkflowPanel.tsx
@@ -5,8 +5,10 @@ import {
   deleteWorkflow,
   distillSession,
   exportWorkflow,
+  fetchRuns,
   fetchWorkflowDetail,
   fetchWorkflows,
+  fetchWorkspaceRoot,
   importWorkflow,
   promoteWorkflow,
   refineWorkflow,
@@ -18,8 +20,9 @@ import { getDraggedFilePath } from '../dragState'
 import type {
   BatchPlanSkip,
   ReplayFrame,
-  ReplayPreviewStep,
-  StackRequirement,
+  ReplayPreviewResult,
+  RunStatus,
+    StackRequirement,
   WorkflowDetail,
   WorkflowListEntry,
 } from '../types'
@@ -28,81 +31,82 @@ import {
   BookmarkPlusIcon,
   ChevronRightIcon,
   DownloadIcon,
+  FileIcon,
   PlayIcon,
   RefreshIcon,
   StopSquareIcon,
-  UploadIcon,
+  TableIcon,
   XIcon,
 } from './icons'
 
 type ReplayStepFrame = Extract<ReplayFrame, { type: 'step' }>
 
+/** localStorage key holding the run the page is following (reattached on reload). */
+const ACTIVE_RUN_KEY = 'medmcp.activeRun'
+
 /** Outcome of one batch item; `steps` counts its logged step frames. */
 type ItemResult = { ok: boolean; error?: string | null; outputs: string[]; steps: number }
+
+/** One row of the run editor: one value per required input. */
+type Row = { values: Record<string, string> }
 
 /** What the expanded workflow's detail area is currently showing. */
 type Mode =
   | { kind: 'view' }
   | { kind: 'rename'; value: string }
   | { kind: 'refine'; value: string }
-  | { kind: 'inputs'; batch: boolean; values: Record<string, string>; rows: Record<string, string>[] }
-  | {
-      kind: 'preview'
-      batch: boolean
-      values: Record<string, string>
-      rows: Record<string, string>[]
-      runs: Record<string, string>[]
-      steps: ReplayPreviewStep[]
-    }
-  | {
-      kind: 'running'
-      name: string
-      runs: Record<string, string>[]
-      total: number
-      stepsPerItem: number
-      startedAt: number
-      lastStepAt: number
-      items: ItemResult[]
-      log: ReplayStepFrame[]
-    }
-  | {
-      kind: 'done'
-      name: string
-      runs: Record<string, string>[]
-      total: number
-      stepsPerItem: number
-      startedAt: number
-      finishedAt: number
-      items: ItemResult[]
-      log: ReplayStepFrame[]
-      ok: boolean
-      error?: string | null
-    }
+  | { kind: 'run'; source: RunSource; rows: Row[]; resultsDir: string }
 
-/** Fraction complete: finished items plus the current item's step fraction. */
-function runProgress(m: Extract<Mode, { kind: 'running' }>): number {
-  if (m.total === 0) return 0
-  const prevSteps = m.items.reduce((acc, it) => acc + it.steps, 0)
-  const currentFrac =
-    m.stepsPerItem > 0 ? Math.min((m.log.length - prevSteps) / m.stepsPerItem, 1) : 0
-  return (m.items.length + currentFrac) / m.total
+/** Where a run's inputs come from: files picked by hand (the default, prefilled
+ *  from the explorer selection), or a cohort plan. The two are different jobs
+ *  (a few scans vs. a reviewed roll-out), so only the chosen editor is shown. */
+type RunSource = 'files' | 'plan'
+
+const SOURCES: { value: RunSource; icon: ReactNode; title: string; hint: string }[] = [
+  { value: 'files', icon: <FileIcon size={14} />, title: 'Files', hint: 'Pick scans by hand' },
+  {
+    value: 'plan',
+    icon: <TableIcon size={14} />,
+    title: 'Cohort plan',
+    hint: 'One row per subject',
+  },
+]
+
+/** The run the panel is following: live, or finished and still on screen. */
+type RunState = {
+  runId: string
+  workflow: string
+  runs: Record<string, string>[]
+  total: number
+  stepsPerItem: number
+  startedAt: number
+  lastStepAt: number
+  items: ItemResult[]
+  log: ReplayStepFrame[]
+  /** The tool in flight right now, with when it started. */
+  current: { item: number; index: number; server: string; tool: string; since: number } | null
+  status: RunStatus
+  error?: string | null
+  finishedAt?: number
+  /** False while the socket is down and the panel is trying to get back on. */
+  attached: boolean
 }
 
-/** The runs to execute: a single binding, or every fully-filled table row. Each
- *  run is an independent full input binding ({in_1, in_2, …}). */
-function buildRuns(
-  st: { batch: boolean; values: Record<string, string>; rows: Record<string, string>[] },
-  inputNames: string[],
-): Record<string, string>[] {
-  if (!st.batch) return [st.values]
-  return st.rows.filter((r) => inputNames.every((n) => (r[n] ?? '').trim() !== ''))
+/** Fraction complete: finished items plus the current item's step fraction. */
+function runProgress(r: RunState): number {
+  if (r.total === 0) return 0
+  const prevSteps = r.items.reduce((acc, it) => acc + it.steps, 0)
+  const currentFrac =
+    r.stepsPerItem > 0 ? Math.min((r.log.length - prevSteps) / r.stepsPerItem, 1) : 0
+  return (r.items.length + currentFrac) / r.total
 }
 
 /** "1m 23s" / "45s" from a millisecond duration. */
 function formatDuration(ms: number): string {
   const s = Math.max(0, Math.round(ms / 1000))
   if (s < 60) return `${s}s`
-  return `${Math.floor(s / 60)}m ${String(s % 60).padStart(2, '0')}s`
+  if (s < 3600) return `${Math.floor(s / 60)}m ${String(s % 60).padStart(2, '0')}s`
+  return `${Math.floor(s / 3600)}h ${String(Math.floor((s % 3600) / 60)).padStart(2, '0')}m`
 }
 
 function basename(p: string): string {
@@ -110,265 +114,169 @@ function basename(p: string): string {
   return i >= 0 ? p.slice(i + 1) : p
 }
 
-type Input = { name: string; example: string; description: string }
-
-/** Dropdown label for an input: its name plus whatever hints what it is —
- *  the human description and/or the example filename (e.g. "...T1w.nii.gz"). */
-function inputOptionLabel(i: Input): string {
-  const bits: string[] = []
-  if (i.description) bits.push(i.description)
-  if (i.example) bits.push(`e.g. ${basename(i.example)}`)
-  return bits.length > 0 ? `${i.name}: ${bits.join(' · ')}` : i.name
+/** A tool's absolute output path as a workspace path (what the viewer opens),
+ *  or null when it lies outside the workspace. */
+function workspacePath(p: string, root: string): string | null {
+  if (!root) return null
+  const prefix = root.endsWith('/') ? root : `${root}/`
+  return p.startsWith(prefix) ? p.slice(prefix.length) : null
 }
 
-/** The file basenames of a run's input values, joined (e.g. "subjA.nii + atlas.nii"). */
-function runFiles(run: Record<string, string>): string {
-  return Object.values(run)
-    .filter((v) => v.trim() !== '')
-    .map(basename)
-    .join(' + ')
+/** Shorten a value for display: absolute workspace paths become relative. */
+function display(v: unknown, root: string): string {
+  if (typeof v === 'string') return workspacePath(v, root) ?? v
+  return JSON.stringify(v)
 }
 
-/** Short label for batch item *i* — its input filenames, else "Item N". */
-function itemLabel(runs: Record<string, string>[], i: number): string {
-  return runFiles(runs[i] ?? {}) || `Item ${i + 1}`
+/** The first line of a tool error — the rest is stack/validation detail. */
+function firstLine(err: string): string {
+  const line = err.split('\n').find((l) => l.trim() !== '') ?? err
+  return line.length > 160 ? `${line.slice(0, 157)}…` : line
 }
 
-/** 1-based step number currently in progress for the active item. */
-function currentStep(m: Extract<Mode, { kind: 'running' }>): number {
-  const prevSteps = m.items.reduce((acc, it) => acc + it.steps, 0)
-  return Math.min(m.log.length - prevSteps + 1, m.stepsPerItem)
+/** How long a finished step took, from the timestamps on its frame. */
+function stepDuration(s: ReplayStepFrame): number | null {
+  if (!s.started_at || !s.finished_at) return null
+  const a = Date.parse(s.started_at)
+  const b = Date.parse(s.finished_at)
+  return Number.isNaN(a) || Number.isNaN(b) ? null : Math.max(0, b - a)
+}
+
+type Input = { name: string; example: string; description: string; default?: string }
+
+/** A readable column title for an input: the argument it feeds (from the
+ *  distilled "the X for server:tool" description), a short description the user
+ *  wrote, else the bare placeholder name. */
+function inputTitle(i: Input): string {
+  const m = /^the (\S+) for /.exec(i.description)
+  if (m) return m[1]
+  const d = i.description.trim()
+  return d && d.length <= 32 ? d : i.name
+}
+
+/** The directory prefix every path in *paths* shares (with trailing slash), or ''. */
+function commonDir(paths: string[]): string {
+  if (paths.length === 0) return ''
+  let prefix = paths[0].slice(0, paths[0].lastIndexOf('/') + 1)
+  for (const p of paths) {
+    while (prefix && !p.startsWith(prefix)) {
+      prefix = prefix.slice(0, prefix.lastIndexOf('/', prefix.length - 2) + 1)
+    }
+  }
+  return prefix
+}
+
+/** Labels that tell the items of a batch apart: each item's input paths,
+ *  workspace-relative, minus whatever directory every item shares. A cohort of
+ *  `patient_NN/visit_01/t1n_3d.nii.gz` reads as `patient_01/visit_01/t1n_3d.nii.gz`,
+ *  and files that all sit in one folder read as bare names. */
+function itemLabels(runs: Record<string, string>[], root: string): string[] {
+  const rel = runs.map((run) =>
+    Object.values(run)
+      .filter((v) => v.trim() !== '')
+      .map((v) => workspacePath(v, root) ?? v),
+  )
+  const shared = commonDir(rel.flat())
+  return rel.map((paths, i) =>
+    paths.length > 0
+      ? paths.map((p) => (p.startsWith(shared) ? p.slice(shared.length) : p)).join(' + ')
+      : `Item ${i + 1}`,
+  )
 }
 
 /** Elapsed time, plus a counting-down ETA extrapolated from finished steps. */
-function runTiming(m: Extract<Mode, { kind: 'running' }>, now: number): string {
-  const elapsed = now - m.startedAt
+function runTiming(r: RunState, now: number): string {
+  const elapsed = now - r.startedAt
   let label = `elapsed ${formatDuration(elapsed)}`
-  const totalSteps = m.total * m.stepsPerItem
-  const doneSteps = m.log.length
+  const totalSteps = r.total * r.stepsPerItem
+  const doneSteps = r.log.length
   // Average over *finished* step time only (lastStepAt), not total elapsed —
   // otherwise a long in-flight step inflates the average and the ETA climbs.
-  // Then count down: remaining = estimated total − elapsed. Rough, hence "~".
   if (doneSteps > 0 && doneSteps < totalSteps) {
-    const avgPerStep = (m.lastStepAt - m.startedAt) / doneSteps
+    const avgPerStep = (r.lastStepAt - r.startedAt) / doneSteps
     const remaining = avgPerStep * totalSteps - elapsed
     if (remaining > 0) label += ` · ~${formatDuration(remaining)} left`
   }
   return label
 }
 
-/** Produced file paths, clickable to open in the viewer when a handler is given. */
-function OutputLinks({
+/** Produced files as small chips: the file name, full path on hover, and a
+ *  click opens it in the viewer when it lives inside the workspace. */
+function FileChips({
   paths,
+  root,
   onOpenFile,
 }: {
   paths: string[]
+  root: string
   onOpenFile?: (path: string) => void
 }) {
+  if (paths.length === 0) return null
   return (
-    <span className="wf-output-list">
-      {paths.map((p) =>
-        onOpenFile ? (
+    <span className="wf-chips">
+      {paths.map((p) => {
+        const rel = workspacePath(p, root)
+        const openable = rel !== null && !!onOpenFile
+        return (
           <button
             key={p}
             type="button"
-            className="wf-output-link"
-            title="Open in viewer"
-            onClick={() => onOpenFile(p)}
+            className={openable ? 'wf-file-chip' : 'wf-file-chip static'}
+            title={openable ? `${rel} — open in viewer` : p}
+            disabled={!openable}
+            onClick={() => rel !== null && onOpenFile?.(rel)}
           >
-            {p}
+            {basename(p)}
           </button>
-        ) : (
-          <code key={p}>{p}</code>
-        ),
+        )
+      })}
+    </span>
+  )
+}
+
+/** A tool error: its first line, with the rest behind a toggle. */
+function ErrorText({ text }: { text: string }) {
+  const [open, setOpen] = useState(false)
+  const head = firstLine(text)
+  const more = text.trim() !== head.replace(/…$/, '') && text.includes('\n')
+  return (
+    <span className="wf-step-error">
+      {head}
+      {(more || head.endsWith('…')) && (
+        <>
+          {' '}
+          <button type="button" className="btn-text wf-more" onClick={() => setOpen((v) => !v)}>
+            {open ? 'less' : 'more'}
+          </button>
+          {open && <pre className="wf-error-full">{text}</pre>}
+        </>
       )}
     </span>
   )
 }
 
-/** One replay input field; accepts a file drag from the explorer (and is
- *  auto-filled from the explorer selection by the parent form). */
-function InputField({
-  name,
-  example,
-  description,
+/** A path input that also accepts a file drag from the explorer. */
+function PathCell({
   value,
+  placeholder,
   onChange,
-  defaultHint = '',
-}: {
-  name: string
-  example: string
-  description: string
-  value: string
-  onChange: (v: string) => void
-  /** Set when the input fills itself if left blank; shown instead of an example. */
-  defaultHint?: string
-}) {
-  const [dropReady, setDropReady] = useState(false)
-  return (
-    <label className="wf-input-row">
-      <span className="wf-input-label">
-        <code>{name}</code>
-        {description && <span className="wf-input-desc">{description}</span>}
-        {defaultHint && <span className="wf-input-desc">{defaultHint}</span>}
-      </span>
-      <input
-        className={dropReady ? 'wf-input drop-ready' : 'wf-input'}
-        value={value}
-        placeholder={defaultHint ? 'leave blank to derive it' : example ? `e.g. ${example}` : 'value'}
-        onChange={(e) => onChange(e.target.value)}
-        onDragOver={(e) => {
-          if (e.dataTransfer.types.includes(DRAG_PATH_MIME) || getDraggedFilePath() !== null) {
-            e.preventDefault()
-            setDropReady(true)
-          }
-        }}
-        onDragLeave={() => setDropReady(false)}
-        onDrop={(e) => {
-          const path = e.dataTransfer.getData(DRAG_PATH_MIME) || getDraggedFilePath()
-          if (path) {
-            e.preventDefault()
-            onChange(path)
-          }
-          setDropReady(false)
-        }}
-      />
-    </label>
-  )
-}
-
-/** The stacks a workflow needs, pinned by image(+digest) or version. */
-const REQ_STATUS: Record<
-  NonNullable<StackRequirement['status']>,
-  { icon: string; cls: string; title: string }
-> = {
-  ok: { icon: '✓', cls: 'ok', title: 'installed' },
-  missing: { icon: '✗', cls: 'missing', title: 'not installed' },
-  mismatch: { icon: '⚠', cls: 'mismatch', title: 'installed, but a different version' },
-}
-
-function Requirements({ requires }: { requires: StackRequirement[] }) {
-  if (requires.length === 0) return null
-  const mismatched = requires.filter((r) => r.status === 'mismatch')
-  return (
-    <div className="wf-requires">
-      <div className="wf-requires-title">Requires</div>
-      <ul className="wf-requires-list">
-        {requires.map((r) => {
-          const pin = r.image
-            ? `${r.image}${r.digest ? ` @ ${r.digest.slice(0, 19)}…` : ''}`
-            : r.version
-              ? `v${r.version}`
-              : ''
-          const s = r.status ? REQ_STATUS[r.status] : null
-          return (
-            <li key={r.stack}>
-              {s && (
-                <span className={`wf-req-status ${s.cls}`} title={s.title}>
-                  {s.icon}
-                </span>
-              )}
-              <code>{r.stack}</code>
-              {pin && <span className="wf-req-pin">{pin}</span>}
-            </li>
-          )
-        })}
-      </ul>
-      {mismatched.length > 0 && (
-        <div className="wf-req-warn">
-          A different version of {mismatched.map((r) => r.stack).join(', ')} is installed than this
-          workflow was built with. Results may not reproduce exactly.
-        </div>
-      )}
-    </div>
-  )
-}
-
-function StepList({ steps }: { steps: { server: string; tool: string }[] }) {
-  return (
-    <ol className="wf-steps">
-      {steps.map((s, i) => (
-        <li key={i}>
-          <code>
-            {s.server}:{s.tool}
-          </code>
-        </li>
-      ))}
-    </ol>
-  )
-}
-
-function RunLog({
-  log,
-  total = 1,
-  runs,
-}: {
-  log: ReplayStepFrame[]
-  total?: number
-  runs?: Record<string, string>[]
-}) {
-  const rows: ReactNode[] = []
-  let lastItem = -1
-  for (const s of log) {
-    const item = s.item ?? 0
-    if (total > 1 && item !== lastItem) {
-      const file = runs ? runFiles(runs[item] ?? {}) : ''
-      rows.push(
-        <div key={`item-${item}`} className="wf-runitem">
-          Item {item + 1} of {total}
-          {file && ` · ${file}`}
-        </div>,
-      )
-      lastItem = item
-    }
-    rows.push(
-      <div key={`${item}-${s.index}`} className={s.ok ? 'wf-runstep ok' : 'wf-runstep fail'}>
-        <span className={`status-dot ${s.ok ? 'ok' : 'fail'}`} />
-        <span>
-          {s.index}.{' '}
-          <code>
-            {s.server}:{s.tool}
-          </code>
-          {Object.values(s.produced).length > 0 && (
-            <span className="wf-produced"> → {Object.values(s.produced).join(', ')}</span>
-          )}
-          {!s.ok && s.error && <span className="wf-step-error"> {s.error}</span>}
-        </span>
-      </div>,
-    )
-  }
-  return <div className="wf-runlog">{rows}</div>
-}
-
-function ProgressBar({ frac, label, active }: { frac: number; label: string; active?: boolean }) {
-  const pct = Math.round(Math.min(Math.max(frac, 0), 1) * 100)
-  return (
-    <div className="wf-progress" title={`${pct}%`}>
-      <span className={active ? 'wf-progress-bar active' : 'wf-progress-bar'}>
-        <span className="wf-progress-fill" style={{ width: `${pct}%` }} />
-      </span>
-      <span className="wf-progress-label">{label}</span>
-    </div>
-  )
-}
-
-/** One batch-table cell: a compact path input that also accepts a file drag. */
-function BatchCell({
-  value,
-  example,
-  onChange,
+  onFocus,
+  className = 'wf-batch-cell',
 }: {
   value: string
-  example: string
+  placeholder: string
   onChange: (v: string) => void
+  onFocus?: () => void
+  className?: string
 }) {
   const [dropReady, setDropReady] = useState(false)
   return (
     <input
-      className={dropReady ? 'wf-batch-cell drop-ready' : 'wf-batch-cell'}
+      className={dropReady ? `${className} drop-ready` : className}
       value={value}
-      placeholder={example ? `e.g. ${basename(example)}` : 'path'}
+      placeholder={placeholder}
       title={value || undefined}
+      onFocus={onFocus}
       onChange={(e) => onChange(e.target.value)}
       onDragOver={(e) => {
         if (e.dataTransfer.types.includes(DRAG_PATH_MIME) || getDraggedFilePath() !== null) {
@@ -389,10 +297,243 @@ function BatchCell({
   )
 }
 
+/** The stacks a workflow needs, pinned by image(+digest) or version. */
+const REQ_STATUS: Record<
+  NonNullable<StackRequirement['status']>,
+  { icon: string; cls: string; title: string }
+> = {
+  ok: { icon: '✓', cls: 'ok', title: 'installed' },
+  missing: { icon: '✗', cls: 'missing', title: 'not installed' },
+  mismatch: { icon: '⚠', cls: 'mismatch', title: 'installed, but a different version' },
+}
+
+function Requirements({ requires }: { requires: StackRequirement[] }) {
+  if (requires.length === 0) return null
+  const mismatched = requires.filter((r) => r.status === 'mismatch')
+  return (
+    <div className="wf-requires">
+      <span className="wf-requires-title">Requires</span>
+      <ul className="wf-requires-list">
+        {requires.map((r) => {
+          const pin = r.image
+            ? `${r.image}${r.digest ? ` @ ${r.digest.slice(0, 19)}…` : ''}`
+            : r.version
+              ? `v${r.version}`
+              : ''
+          const s = r.status ? REQ_STATUS[r.status] : null
+          return (
+            <li key={r.stack} title={pin ? `${s?.title ?? ''} · ${pin}`.replace(/^ · /, '') : s?.title}>
+              {s && <span className={`wf-req-status ${s.cls}`}>{s.icon}</span>}
+              <code>{r.stack}</code>
+            </li>
+          )
+        })}
+      </ul>
+      {mismatched.length > 0 && (
+        <div className="wf-req-warn">
+          A different version of {mismatched.map((r) => r.stack).join(', ')} is installed than this
+          workflow was built with. Results may not reproduce exactly.
+        </div>
+      )}
+    </div>
+  )
+}
+
+function StepList({ steps }: { steps: { server: string; tool: string }[] }) {
+  return (
+    <ol className="wf-steps">
+      {steps.map((s, i) => (
+        <li key={i} title={`${s.server}:${s.tool}`}>
+          <code>{s.tool}</code>
+        </li>
+      ))}
+    </ol>
+  )
+}
+
+/** The steps of one item, one line each: tick, tool, how long. */
+function StepRows({
+  steps,
+  current,
+  now,
+  stepsPerItem,
+}: {
+  steps: ReplayStepFrame[]
+  current?: RunState['current']
+  now?: number
+  stepsPerItem?: number
+}) {
+  const rows = steps.map((s) => {
+    const dur = stepDuration(s)
+    return (
+      <div key={s.index} className={s.ok ? 'wf-steprow' : 'wf-steprow fail'}>
+        <span className={`status-dot ${s.ok ? 'ok' : 'fail'}`} />
+        <code>{s.tool}</code>
+        <span className="wf-recent-muted">
+          {dur !== null ? formatDuration(dur) : ''}
+        </span>
+        {!s.ok && s.error && <ErrorText text={s.error} />}
+      </div>
+    )
+  })
+  if (current) {
+    rows.push(
+      <div key={`live-${current.index}`} className="wf-steprow live">
+        <span className="status-dot busy" />
+        <code>{current.tool}</code>
+        <span className="wf-recent-muted">
+          {now !== undefined ? formatDuration(now - current.since) : 'running'}
+        </span>
+      </div>,
+    )
+  }
+  const remaining = (stepsPerItem ?? 0) - steps.length - (current ? 1 : 0)
+  if (remaining > 0 && current) {
+    rows.push(
+      <div key="queued" className="wf-steprow queued">
+        <span className="status-dot" />
+        <span className="wf-recent-muted">
+          {remaining} more step{remaining === 1 ? '' : 's'}
+        </span>
+      </div>,
+    )
+  }
+  return <div className="wf-steprows">{rows}</div>
+}
+
+/** One line per batch item — finished ones with outputs, the current one with
+ *  its step, the rest folded into a count. Click a line for its steps. */
+function ItemRows({
+  r,
+  now,
+  root,
+  onOpenFile,
+}: {
+  r: RunState
+  now: number
+  root: string
+  onOpenFile?: (path: string) => void
+}) {
+  const [open, setOpen] = useState<number | null>(null)
+  const labels = itemLabels(r.runs, root)
+  const rows: ReactNode[] = []
+  let queued = 0
+  for (let i = 0; i < r.total; i++) {
+    const it = r.items[i]
+    const steps = r.log.filter((s) => (s.item ?? 0) === i)
+    const isCurrent = !it && (r.current?.item === i || (steps.length > 0 && r.status === 'running'))
+    if (!it && !isCurrent) {
+      queued += 1
+      continue
+    }
+    const dot = it ? (it.ok ? 'ok' : 'fail') : 'busy'
+    const expanded = open === i
+    rows.push(
+      <div key={i} className="wf-itemrow-wrap">
+        <button
+          type="button"
+          className={`wf-itemrow ${dot}`}
+          onClick={() => setOpen(expanded ? null : i)}
+          title={expanded ? 'Hide steps' : 'Show steps'}
+        >
+          <span className={`status-dot ${dot}`} />
+          <span className="wf-itemrow-label">{labels[i]}</span>
+          <span className="wf-recent-muted wf-itemrow-note">
+            {it
+              ? it.ok
+                ? it.outputs.length > 0
+                  ? `${it.outputs.length} file${it.outputs.length === 1 ? '' : 's'}`
+                  : ''
+                : expanded
+                  ? ''
+                  : firstLine(it.error ?? 'failed')
+              : r.current && r.current.item === i
+                ? `step ${r.current.index} of ${r.stepsPerItem} · ${r.current.tool}`
+                : 'starting'}
+          </span>
+        </button>
+        {expanded && it?.ok && (
+          <FileChips paths={it.outputs} root={root} onOpenFile={onOpenFile} />
+        )}
+        {expanded && (
+          <StepRows
+            steps={steps}
+            current={!it && r.current?.item === i ? r.current : null}
+            now={now}
+            stepsPerItem={r.stepsPerItem}
+          />
+        )}
+      </div>,
+    )
+  }
+  if (queued > 0) {
+    rows.push(
+      <div key="queued" className="wf-itemrow queued">
+        <span className="status-dot" />
+        <span className="wf-recent-muted">
+          {queued} more item{queued === 1 ? '' : 's'} {r.status === 'running' ? 'queued' : 'not run'}
+        </span>
+      </div>,
+    )
+  }
+  return <div className="wf-itemrows">{rows}</div>
+}
+
+function ProgressBar({ frac, label, active }: { frac: number; label: string; active?: boolean }) {
+  const pct = Math.round(Math.min(Math.max(frac, 0), 1) * 100)
+  return (
+    <div className="wf-progress" title={`${pct}%`}>
+      <span className={active ? 'wf-progress-bar active' : 'wf-progress-bar'}>
+        <span className="wf-progress-fill" style={{ width: `${pct}%` }} />
+      </span>
+      <span className="wf-progress-label">{label}</span>
+    </div>
+  )
+}
+
+function emptyRow(names: string[]): Row {
+  return { values: Object.fromEntries(names.map((n) => [n, ''])) }
+}
+
+/** Put newly selected files into the editor: the first one into the cell the
+ *  user last focused (if it is still there), the rest into the empty cells in
+ *  row order, appending rows when none are left. Rows are never removed or
+ *  reordered by a selection — "add a row, then click the file" must land the
+ *  file in that row. */
+function placeFiles(
+  rows: Row[],
+  names: string[],
+  files: string[],
+  focused: { row: number; name: string } | null,
+): Row[] {
+  if (names.length === 0 || files.length === 0) return rows
+  const next = rows.map((r) => ({ values: { ...r.values } }))
+  const queue = [...files]
+  if (focused && next[focused.row] && names.includes(focused.name)) {
+    next[focused.row].values[focused.name] = queue.shift() ?? ''
+  }
+  for (const row of next) {
+    for (const n of names) {
+      if (queue.length === 0) return next
+      if (!(row.values[n] ?? '').trim()) row.values[n] = queue.shift() ?? ''
+    }
+  }
+  while (queue.length > 0) {
+    const row = emptyRow(names)
+    for (const n of names) {
+      if (queue.length === 0) break
+      row.values[n] = queue.shift() ?? ''
+    }
+    next.push(row)
+  }
+  return next
+}
+
 /**
  * Personal-workflows panel: save the current chat as a reusable workflow,
- * review/promote/refine drafts, and replay a recipe deterministically (no
- * LLM) on new inputs with a preview + explicit confirmation.
+ * review/promote/refine drafts, and run a recipe deterministically (no LLM)
+ * on new inputs. A run is a server-side job: it keeps going if this page goes
+ * away, and the page reattaches to it on reload.
  */
 // Memoized: App bumps `fsVersion` on every completed tool call / turn end to
 // refresh the explorer and viewer, but this panel doesn't read it — memo keeps
@@ -410,21 +551,33 @@ export const WorkflowPanel = memo(function WorkflowPanel({
   onWorkspaceChanged?: () => void
   /** Open a produced file in the viewer. */
   onOpenFile?: (path: string) => void
-  /** Files multi-selected in the explorer — offered to the batch editor. */
+  /** Files multi-selected in the explorer — offered to the run editor. */
   selectedPaths?: string[]
 }) {
   const [workflows, setWorkflows] = useState<WorkflowListEntry[] | null>(null)
   const [expanded, setExpanded] = useState<string | null>(null)
   const [detail, setDetail] = useState<WorkflowDetail | null>(null)
   const [mode, setMode] = useState<Mode>({ kind: 'view' })
+  const [run, setRun] = useState<RunState | null>(null)
+  const [preview, setPreview] = useState<{ key: string; result: ReplayPreviewResult } | null>(null)
   const [busy, setBusy] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
-  const [now, setNow] = useState(0)
+  const [now, setNow] = useState(() => Date.now())
   const [planCsv, setPlanCsv] = useState('')
   const [planSkipped, setPlanSkipped] = useState<BatchPlanSkip[] | null>(null)
-  // Derived inputs stay collapsed until the user wants to redirect the output.
-  const [showDerived, setShowDerived] = useState(false)
+  const [showSteps, setShowSteps] = useState(false)
+  const [showResultsDir, setShowResultsDir] = useState(false)
+  // Absolute workspace root: tool outputs come back absolute, the viewer wants
+  // workspace-relative, and nobody wants to read the host prefix on every chip.
+  const [root, setRoot] = useState('')
+  // The editor cell the user focused last: a file clicked in the explorer goes
+  // there first. State rather than a ref because it is read while adjusting
+  // state during render (below), where refs are off limits.
+  const [focusedCell, setFocusedCell] = useState<{ row: number; name: string } | null>(null)
   const runWs = useRef<WebSocket | null>(null)
+  // A dropped socket on a live run: the id to get back on, and a counter so a
+  // second drop re-arms the timer even for the same id.
+  const [reattach, setReattach] = useState<{ id: string; attempt: number } | null>(null)
   const fileInputRef = useRef<HTMLInputElement | null>(null)
 
   const reload = useCallback(
@@ -438,61 +591,216 @@ export const WorkflowPanel = memo(function WorkflowPanel({
     [],
   )
 
+  // ── The run socket ──
+  //
+  // One socket per followed run. `first` is either a start request or an attach;
+  // the server answers both with the same frame stream. Closing the socket never
+  // stops the run — Stop is an explicit cancel message — so a drop while the run
+  // is live is followed by a reattach.
+  const followRun = useCallback(
+    (first: Record<string, unknown>) => {
+      runWs.current?.close()
+      const proto = location.protocol === 'https:' ? 'wss' : 'ws'
+      const ws = new WebSocket(`${proto}://${location.host}/ws/replay`)
+      runWs.current = ws
+      let finished = false
+      let runId = typeof first.attach === 'string' ? first.attach : ''
+      ws.onopen = () => ws.send(JSON.stringify(first))
+      ws.onmessage = (ev: MessageEvent<string>) => {
+        let frame: ReplayFrame
+        try {
+          frame = JSON.parse(ev.data) as ReplayFrame
+        } catch {
+          return
+        }
+        if (frame.type === 'started') {
+          runId = frame.run_id
+          localStorage.setItem(ACTIVE_RUN_KEY, frame.run_id)
+          const startedAt = Date.parse(frame.started_at) || Date.now()
+          setNow(Date.now())
+          setReattach(null)
+          setRun({
+            runId: frame.run_id,
+            workflow: frame.workflow,
+            runs: frame.runs,
+            total: frame.total,
+            stepsPerItem: frame.steps_per_item,
+            startedAt,
+            lastStepAt: startedAt,
+            items: [],
+            log: [],
+            current: null,
+            status: 'running',
+            attached: true,
+          })
+          return
+        }
+        if (frame.type === 'step_started') {
+          const f = frame
+          const since = (f.started_at && Date.parse(f.started_at)) || Date.now()
+          setRun((r) => (r ? { ...r, current: { ...f, since }, attached: true } : r))
+          return
+        }
+        onWorkspaceChanged?.()
+        if (frame.type === 'step') {
+          const step = frame
+          setRun((r) =>
+            r
+              ? { ...r, log: [...r.log, step], current: null, lastStepAt: Date.now(), attached: true }
+              : r,
+          )
+        } else if (frame.type === 'item_result') {
+          const res = frame
+          setRun((r) => {
+            if (!r) return r
+            const prevSteps = r.items.reduce((acc, it) => acc + it.steps, 0)
+            const item: ItemResult = {
+              ok: res.ok,
+              error: res.error,
+              outputs: res.outputs,
+              steps: r.log.length - prevSteps,
+            }
+            return { ...r, items: [...r.items, item] }
+          })
+        } else {
+          finished = true
+          const result = frame
+          localStorage.removeItem(ACTIVE_RUN_KEY)
+          setRun((r) => {
+            if (!r) {
+              // An attach that failed outright (unknown run): nothing to show.
+              if (!result.ok && result.error) setError(result.error)
+              return r
+            }
+            return {
+              ...r,
+              current: null,
+              status: result.status ?? (result.ok ? 'done' : 'failed'),
+              error: result.error,
+              finishedAt: (result.finished_at && Date.parse(result.finished_at)) || Date.now(),
+              attached: true,
+            }
+          })
+        }
+      }
+      ws.onclose = () => {
+        if (finished || runWs.current !== ws) return
+        // The run is still going on the server; get back on it (see the
+        // reattach effect below).
+        setRun((r) => (r && r.status === 'running' ? { ...r, attached: false } : r))
+        if (runId) setReattach((prev) => ({ id: runId, attempt: (prev?.attempt ?? 0) + 1 }))
+      }
+    },
+    [onWorkspaceChanged],
+  )
+
+  useEffect(() => {
+    if (!reattach) return
+    const id = window.setTimeout(() => followRun({ attach: reattach.id }), 2000)
+    return () => clearTimeout(id)
+  }, [reattach, followRun])
+
   useEffect(() => {
     void reload()
+    fetchWorkspaceRoot()
+      .then(setRoot)
+      .catch(() => undefined)
+    // Pick the run up again after a reload: the one this page was following,
+    // else whatever is live on the server (started from another tab).
+    const remembered = localStorage.getItem(ACTIVE_RUN_KEY)
+    if (remembered) {
+      followRun({ attach: remembered })
+    } else {
+      fetchRuns(undefined, 1)
+        .then((r) => {
+          if (r.live[0]) followRun({ attach: r.live[0] })
+        })
+        .catch(() => undefined)
+    }
     return () => runWs.current?.close()
-  }, [reload])
+    // Mount only: reattaching is a one-time decision, not something to redo
+    // whenever a callback identity changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
-  // Tick once a second while a run is live so the elapsed/ETA readout updates.
+  // Tick once a second while a run is live so the elapsed/ETA readout updates;
+  // slower otherwise so "5 min ago" labels stay honest.
   useEffect(() => {
-    if (mode.kind !== 'running') return
-    const id = setInterval(() => setNow(Date.now()), 1000)
+    const live = run?.status === 'running'
+    const id = setInterval(() => setNow(Date.now()), live ? 1000 : 30000)
     return () => clearInterval(id)
-  }, [mode.kind])
+  }, [run?.status])
 
-  // Auto-fill the single-run inputs form from the explorer selection — no extra
-  // click, mirroring how the batch flow binds the selection. Done by adjusting
-  // state during render on a selection change (tracked via prevSel) rather than
-  // in an effect — the React-recommended pattern for "adjust state when a prop
-  // changes" (https://react.dev/learn/you-might-not-need-an-effect). One input:
-  // take the latest selected file (re-selecting updates it). Several inputs:
-  // fill the still-empty ones in order. Skipped while batching (the selection is
-  // reserved for the batch input then) and when nothing is selected; the no-op
-  // guard avoids a render loop. Typing/dragging still overrides.
+  // ── Explorer selection feeds the run editor ──
+  // Adjusting state during render on a prop change (tracked via prevSel), the
+  // React-recommended pattern for "derive state from a changed prop". Only the
+  // files that were *added* to the selection are placed (see placeFiles), so a
+  // deselect or a re-click changes nothing and no row is ever taken away.
   const [prevSel, setPrevSel] = useState<string[]>(selectedPaths)
   if (selectedPaths !== prevSel) {
     setPrevSel(selectedPaths)
-    if (mode.kind === 'inputs' && !mode.batch && selectedPaths.length > 0) {
-      setMode((m) => {
-        if (m.kind !== 'inputs' || m.batch) return m
-        const fields = Object.keys(m.values)
-        const values = { ...m.values }
-        if (fields.length === 1) {
-          values[fields[0]] = selectedPaths[selectedPaths.length - 1]
-        } else {
-          const empty = fields.filter((n) => !(values[n] ?? '').trim())
-          empty.forEach((n, idx) => {
-            if (selectedPaths[idx]) values[n] = selectedPaths[idx]
-          })
-        }
-        return fields.some((n) => values[n] !== m.values[n]) ? { ...m, values } : m
-      })
+    const added = selectedPaths.filter((p) => !prevSel.includes(p))
+    if (mode.kind === 'run' && detail && added.length > 0) {
+      if (mode.source === 'files') {
+        const names = detail.inputs.filter((i) => !i.default).map((i) => i.name)
+        setMode({ ...mode, rows: placeFiles(mode.rows, names, added, focusedCell) })
+        setFocusedCell(null)
+      } else if (mode.source === 'plan' && mode.rows.length === 0) {
+        setPlanCsv(added[0])
+      }
     }
   }
 
+  // ── Pre-flight preview, debounced on every edit ──
+  // The run button is only enabled once the preview for exactly these rows has
+  // come back: the resolved steps and per-row checks are the confirmation the
+  // engine's no-permission-prompt design requires.
+  const requiredNames = detail ? detail.inputs.filter((i) => !i.default).map((i) => i.name) : []
+  const derivedNames = detail ? detail.inputs.filter((i) => i.default).map((i) => i.name) : []
+  const runBindings: Record<string, string>[] =
+    mode.kind === 'run'
+      ? mode.rows
+          .filter((r) => requiredNames.every((n) => (r.values[n] ?? '').trim() !== ''))
+          .map((r) => {
+            const values: Record<string, string> = {}
+            requiredNames.forEach((n) => {
+              values[n] = r.values[n].trim()
+            })
+            if (mode.resultsDir.trim()) {
+              derivedNames.forEach((n) => {
+                values[n] = mode.resultsDir.trim()
+              })
+            }
+            return values
+          })
+      : []
+  const previewKey =
+    mode.kind === 'run' && detail
+      ? JSON.stringify([detail.name, runBindings])
+      : ''
+  useEffect(() => {
+    if (!previewKey || !detail) return
+    if (runBindings.length === 0) return
+    const name = detail.name
+    const bindings = runBindings
+    const id = window.setTimeout(() => {
+      replayPreview(name, bindings)
+        .then((result) => setPreview({ key: previewKey, result }))
+        .catch((e: unknown) => setError(e instanceof Error ? e.message : String(e)))
+    }, 350)
+    return () => clearTimeout(id)
+    // previewKey encodes everything the request depends on.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [previewKey])
+
   // The workflow whose detail the panel currently wants. Guards against a
   // slow response for a previously clicked row overwriting the current one —
-  // the detail's action buttons (Run/Promote/Delete) act on detail.name, so a
-  // stale detail under another row's header would target the wrong workflow.
+  // the detail's action buttons act on detail.name, so a stale detail under
+  // another row's header would target the wrong workflow.
   const detailForRef = useRef<string | null>(null)
 
   const openDetail = async (name: string) => {
-    // Leave an in-flight or finished run alone when toggling rows — its card is
-    // pinned at the panel top, so collapsing/switching no longer aborts or hides it.
-    if (mode.kind !== 'running' && mode.kind !== 'done') {
-      runWs.current?.close()
-      setMode({ kind: 'view' })
-    }
+    setMode({ kind: 'view' })
     if (expanded === name) {
       detailForRef.current = null
       setExpanded(null)
@@ -525,15 +833,19 @@ export const WorkflowPanel = memo(function WorkflowPanel({
     }
   }
 
+  const showDraft = (draft: WorkflowDetail) => {
+    detailForRef.current = draft.name
+    setExpanded(draft.name)
+    setDetail(draft)
+    setMode({ kind: 'view' })
+  }
+
   const saveChat = () =>
     withBusy('Distilling the chat into a workflow (local model)…', async () => {
       if (!distillSessionId) return
       const draft = await distillSession(distillSessionId)
       await reload()
-      detailForRef.current = draft.name
-      setExpanded(draft.name)
-      setDetail(draft)
-      setMode({ kind: 'view' })
+      showDraft(draft)
     })
 
   const promote = (name: string) =>
@@ -549,10 +861,7 @@ export const WorkflowPanel = memo(function WorkflowPanel({
     withBusy('Importing workflow…', async () => {
       const draft = await importWorkflow(await file.text())
       await reload()
-      detailForRef.current = draft.name
-      setExpanded(draft.name)
-      setDetail(draft)
-      setMode({ kind: 'view' })
+      showDraft(draft)
     })
 
   const unpromote = (name: string) =>
@@ -591,10 +900,9 @@ export const WorkflowPanel = memo(function WorkflowPanel({
       setMode({ kind: 'view' })
     })
 
-  // Fill the batch table from a plan_batch manifest — the "binding name list"
-  // built once from a single-subject prototype, so the roll-out over the whole
-  // cohort is a review-and-run, not a row-by-row drag. Flagged (missing/ambiguous)
-  // items are surfaced, never silently run.
+  // Fill the editor from a plan_batch manifest — the binding list built once
+  // from a single-subject prototype, so the cohort roll-out is a review-and-run.
+  // Flagged (missing/ambiguous) items are surfaced, never silently run.
   const fillFromPlan = (name: string) =>
     withBusy('Building the binding list from the cohort plan…', async () => {
       const res = await batchFromPlan(name, planCsv.trim())
@@ -609,246 +917,443 @@ export const WorkflowPanel = memo(function WorkflowPanel({
         return
       }
       setMode((m) =>
-        m.kind === 'inputs' ? { ...m, batch: true, rows: res.runs } : m,
+        m.kind === 'run'
+          ? { ...m, source: 'plan', rows: res.runs.map((values) => ({ values })) }
+          : m,
       )
     })
 
-  const toPreview = (
-    name: string,
-    st: { batch: boolean; values: Record<string, string>; rows: Record<string, string>[] },
-    inputNames: string[],
-  ) =>
-    withBusy('Resolving steps…', async () => {
-      const runs = buildRuns(st, inputNames)
-      if (runs.length === 0) {
-        setError('add at least one run with every input filled')
-        return
-      }
-      // Preview resolves the first run; a batch's other runs differ only in their
-      // input values, which the preview screen lists alongside.
-      const res = await replayPreview(name, runs[0])
-      if (!res.ok) {
-        setError(res.error ?? 'this workflow cannot be replayed')
-        return
-      }
-      setMode({ kind: 'preview', batch: st.batch, values: st.values, rows: st.rows, runs, steps: res.steps })
-    })
-
-  const startRun = (
-    name: string,
-    runs: Record<string, string>[],
-    stepsPerItem: number,
-    startedAt: number,
-  ) => {
-    const proto = location.protocol === 'https:' ? 'wss' : 'ws'
-    const ws = new WebSocket(`${proto}://${location.host}/ws/replay`)
-    runWs.current = ws
-    setNow(startedAt)
-    setMode({
-      kind: 'running',
-      name,
-      runs,
-      total: runs.length,
-      stepsPerItem,
-      startedAt,
-      lastStepAt: startedAt,
-      items: [],
-      log: [],
-    })
-    let finished = false
-    ws.onopen = () => ws.send(JSON.stringify({ name, runs }))
-    ws.onmessage = (ev: MessageEvent<string>) => {
-      let frame: ReplayFrame
-      try {
-        frame = JSON.parse(ev.data) as ReplayFrame
-      } catch {
-        return
-      }
-      onWorkspaceChanged?.()
-      if (frame.type === 'step') {
-        const step = frame
-        setMode((m) =>
-          m.kind === 'running' ? { ...m, log: [...m.log, step], lastStepAt: Date.now() } : m,
-        )
-      } else if (frame.type === 'item_result') {
-        const res = frame
-        setMode((m) => {
-          if (m.kind !== 'running') return m
-          const prevSteps = m.items.reduce((acc, it) => acc + it.steps, 0)
-          const item: ItemResult = {
-            ok: res.ok,
-            error: res.error,
-            outputs: res.outputs,
-            steps: m.log.length - prevSteps,
-          }
-          return { ...m, items: [...m.items, item] }
-        })
-      } else {
-        finished = true
-        const result = frame
-        setMode((m) =>
-          m.kind === 'running'
-            ? {
-                kind: 'done',
-                name: m.name,
-                runs: m.runs,
-                total: m.total,
-                stepsPerItem: m.stepsPerItem,
-                startedAt: m.startedAt,
-                finishedAt: Date.now(),
-                items: m.items,
-                log: m.log,
-                ok: result.ok,
-                error: result.error,
-              }
-            : m,
-        )
-      }
-    }
-    ws.onclose = () => {
-      if (!finished) {
-        setMode((m) =>
-          m.kind === 'running'
-            ? {
-                kind: 'done',
-                name: m.name,
-                runs: m.runs,
-                total: m.total,
-                stepsPerItem: m.stepsPerItem,
-                startedAt: m.startedAt,
-                finishedAt: Date.now(),
-                items: m.items,
-                log: m.log,
-                ok: false,
-                error: 'run aborted',
-              }
-            : m,
-        )
-      }
-    }
-  }
-
   const beginRun = (d: WorkflowDetail) => {
-    if (d.inputs.length === 0) {
-      void toPreview(d.name, { batch: false, values: {}, rows: [] }, [])
-      return
-    }
-    const empty = Object.fromEntries(d.inputs.map((i) => [i.name, '']))
-    setMode({ kind: 'inputs', batch: false, values: empty, rows: [{ ...empty }] })
+    setPreview(null)
+    setPlanSkipped(null)
+    setPlanCsv('')
+    setShowSteps(false)
+    setShowResultsDir(false)
+    setFocusedCell(null)
+    // Files is the default, prefilled from whatever is selected in the explorer.
+    const names = d.inputs.filter((i) => !i.default).map((i) => i.name)
+    setMode({
+      kind: 'run',
+      source: 'files',
+      rows: placeFiles([emptyRow(names)], names, selectedPaths, null),
+      resultsDir: '',
+    })
   }
 
-  const renderRunning = (m: Extract<Mode, { kind: 'running' }>) => (
-    <div className="wf-form">
-      <div className="wf-hint">Replaying… step results appear as they finish.</div>
-      <ProgressBar
-        frac={runProgress(m)}
-        active
-        label={
-          m.total > 1
-            ? `item ${Math.min(m.items.length + 1, m.total)} of ${m.total}`
-            : `step ${Math.min(m.log.length + 1, m.stepsPerItem)} of ${m.stepsPerItem}`
-        }
-      />
-      <div className="wf-active">
-        {m.items.length < m.total ? (
-          m.total > 1 ? (
-            <span>
-              Processing <strong>{itemLabel(m.runs, m.items.length)}</strong>, item{' '}
-              {m.items.length + 1} of {m.total} · step {currentStep(m)} of {m.stepsPerItem}
-            </span>
-          ) : (
-            <span>
-              Running step {currentStep(m)} of {m.stepsPerItem}
-            </span>
-          )
-        ) : (
-          <span>Finishing…</span>
-        )}
-      </div>
-      <div className="wf-timing">{runTiming(m, now)}</div>
-      <RunLog log={m.log} total={m.total} runs={m.runs} />
-      <div className="wf-actions">
-        <button className="btn-danger" onClick={() => runWs.current?.close()}>
-          <StopSquareIcon size={12} /> Stop
-        </button>
-      </div>
-    </div>
-  )
+  /** Pick (or switch) where the inputs come from; switching starts over. */
+  const chooseSource = (
+    d: WorkflowDetail,
+    m: Extract<Mode, { kind: 'run' }>,
+    source: RunSource,
+  ) => {
+    if (source === m.source) return
+    const names = d.inputs.filter((i) => !i.default).map((i) => i.name)
+    setPreview(null)
+    setPlanSkipped(null)
+    setPlanCsv('')
+    setFocusedCell(null)
+    setMode({
+      ...m,
+      source,
+      rows: source === 'files' ? placeFiles([emptyRow(names)], names, selectedPaths, null) : [],
+    })
+  }
 
-  const renderDone = (m: Extract<Mode, { kind: 'done' }>) => {
-    const succeeded = m.items.filter((it) => it.ok).length
-    const failedRan = m.items.filter((it) => !it.ok).length
-    const notRun = m.total - m.items.length
-    const retryRuns = m.runs.filter((_, i) => !m.items[i]?.ok)
-    const duration = m.finishedAt - m.startedAt
+  const startRun = (name: string, runs: Record<string, string>[]) => {
+    setError(null)
+    followRun({ name, runs })
+    setMode({ kind: 'view' })
+  }
+
+  const stopRun = () => {
+    runWs.current?.send(JSON.stringify({ type: 'cancel' }))
+  }
+
+  const closeRun = () => {
+    runWs.current?.close()
+    runWs.current = null
+    localStorage.removeItem(ACTIVE_RUN_KEY)
+    setRun(null)
+  }
+
+  const renderRun = (r: RunState) => {
+    const live = r.status === 'running'
+    const succeeded = r.items.filter((it) => it.ok).length
+    const failedRan = r.items.filter((it) => !it.ok).length
+    const notRun = r.total - r.items.length
+    const retryRuns = r.runs.filter((_, i) => !r.items[i]?.ok)
+    const duration = (r.finishedAt ?? now) - r.startedAt
+    const single = r.total === 1
+    const failedStep = single ? r.log.find((s) => !s.ok) : undefined
     return (
       <div className="wf-form">
-        {m.total > 1 && (
+        {live ? (
+          <>
+            <ProgressBar
+              frac={runProgress(r)}
+              active
+              label={
+                single
+                  ? `step ${Math.min(r.log.length + 1, r.stepsPerItem)} of ${r.stepsPerItem}`
+                  : `${r.items.length} of ${r.total}`
+              }
+            />
+            <div className="wf-timing">
+              {!r.attached
+                ? 'Connection lost — reconnecting. The run continues on the server.'
+                : runTiming(r, now)}
+            </div>
+          </>
+        ) : (
           <div className="wf-run-summary">
-            <span className="tally-ok">{succeeded} done</span>
-            {failedRan > 0 && <span className="tally-fail">{failedRan} failed</span>}
-            {notRun > 0 && <span className="tally-muted">{notRun} not run</span>}
-            <span className="tally-muted">in {formatDuration(duration)}</span>
+            {single ? (
+              <span className={r.status === 'done' ? 'tally-ok' : 'tally-fail'}>
+                {r.status === 'done'
+                  ? 'Done'
+                  : r.status === 'cancelled'
+                    ? 'Stopped'
+                    : failedStep
+                      ? `Failed at step ${failedStep.index}`
+                      : 'Failed'}
+              </span>
+            ) : (
+              <>
+                <span className="tally-ok">{succeeded} done</span>
+                {failedRan > 0 && <span className="tally-fail">{failedRan} failed</span>}
+                {notRun > 0 && <span className="tally-muted">{notRun} not run</span>}
+              </>
+            )}
+            <span className="tally-muted">{formatDuration(duration)}</span>
           </div>
         )}
-        <RunLog log={m.log} total={m.total} runs={m.runs} />
-        {m.total > 1 && (
-          <div className="wf-batch-summary">
-            {m.items.map((it, i) => (
-              <div key={i} className={it.ok ? 'wf-runstep ok' : 'wf-runstep fail'}>
-                <span className={`status-dot ${it.ok ? 'ok' : 'fail'}`} />
-                <span>
-                  {itemLabel(m.runs, i)}:{' '}
-                  {it.ok ? (
-                    it.outputs.length > 0 ? (
-                      <>
-                        done → <OutputLinks paths={it.outputs} onOpenFile={onOpenFile} />
-                      </>
-                    ) : (
-                      'done'
-                    )
-                  ) : (
-                    (it.error ?? 'failed')
-                  )}
+        {single ? (
+          <>
+            <StepRows
+              steps={r.log}
+              current={live ? r.current : null}
+              now={now}
+              stepsPerItem={r.stepsPerItem}
+            />
+            {!live && r.items[0]?.outputs.length ? (
+              <FileChips paths={r.items[0].outputs} root={root} onOpenFile={onOpenFile} />
+            ) : null}
+          </>
+        ) : (
+          <ItemRows r={r} now={now} root={root} onOpenFile={onOpenFile} />
+        )}
+        {!live && !single && r.error && r.status === 'failed' && failedRan === 0 && (
+          <div className="wf-step-error">{firstLine(r.error)}</div>
+        )}
+        <div className="wf-actions">
+          {live ? (
+            <button className="btn-danger" onClick={stopRun} disabled={!r.attached}>
+              <StopSquareIcon size={12} /> Stop
+            </button>
+          ) : (
+            <>
+              {retryRuns.length > 0 && (
+                <button
+                  className="btn-primary"
+                  title={
+                    r.status === 'cancelled'
+                      ? 'Continue with the items that did not finish.'
+                      : 'Run only what failed.'
+                  }
+                  onClick={() => startRun(r.workflow, retryRuns)}
+                >
+                  {r.status === 'cancelled' ? <PlayIcon size={12} /> : <RefreshIcon size={12} />}{' '}
+                  {r.status === 'cancelled' ? 'Resume' : 'Retry'}
+                  {single ? '' : ` ${retryRuns.length}`}
+                </button>
+              )}
+              <button className="btn-plain" onClick={closeRun}>
+                Close
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    )
+  }
+
+  const renderEditor = (d: WorkflowDetail, m: Extract<Mode, { kind: 'run' }>) => {
+    const required = d.inputs.filter((i) => !i.default)
+    const derived = d.inputs.filter((i) => i.default)
+    const ready = preview && preview.key === previewKey ? preview.result : null
+    const readyItems = ready ? ready.items.filter((it) => it.ok) : []
+    const complete = runBindings.length
+    // Row i of the editor maps to binding j only when it is complete; keep the
+    // preview verdicts aligned with the rows they were computed for.
+    let bindingIdx = -1
+    const rowVerdict = m.rows.map((r) => {
+      const isComplete = requiredNames.every((n) => (r.values[n] ?? '').trim() !== '')
+      if (!isComplete) return null
+      bindingIdx += 1
+      return ready?.items[bindingIdx] ?? null
+    })
+    const canRun = !!ready && ready.ok && readyItems.length > 0 && run?.status !== 'running'
+    // The run controls appear once there is something to run: right away for
+    // hand-picked files, after the plan has been loaded for a cohort.
+    const showControls = m.source === 'files' || (m.source === 'plan' && m.rows.length > 0)
+    const runnable = ready
+      ? runBindings.filter((_, i) => ready.items[i]?.ok)
+      : []
+    return (
+      <form
+        className="wf-form"
+        onSubmit={(e) => {
+          e.preventDefault()
+          if (canRun) startRun(d.name, runnable)
+        }}
+      >
+        {required.length > 0 && (
+          <div className="wf-source-cards" role="radiogroup" aria-label="Where the inputs come from">
+            {SOURCES.map((o) => (
+              <button
+                key={o.value}
+                type="button"
+                role="radio"
+                aria-checked={m.source === o.value}
+                className={m.source === o.value ? 'wf-source-card active' : 'wf-source-card'}
+                onClick={() => chooseSource(d, m, o.value)}
+              >
+                <span className="wf-source-icon">{o.icon}</span>
+                <span className="wf-source-text">
+                  <span className="wf-source-title">{o.title}</span>
+                  <span className="wf-source-hint">{o.hint}</span>
                 </span>
-              </div>
+              </button>
             ))}
           </div>
         )}
-        {m.ok ? (
-          <div className="wf-result ok">
-            {m.total > 1
-              ? `Batch complete. All ${m.items.length} item(s) succeeded in ${formatDuration(duration)}.`
-              : `Replay complete in ${formatDuration(duration)}. ${m.log.length} step(s) ran.`}
-            {m.total === 1 && m.items.some((it) => it.outputs.length > 0) && (
-              <div className="wf-outputs">
-                Outputs:
-                <OutputLinks paths={m.items.flatMap((it) => it.outputs)} onOpenFile={onOpenFile} />
+        <div className="wf-hint">
+          {required.length === 0
+            ? 'This workflow takes no inputs.'
+            : m.source === 'files'
+              ? 'One row per run. Click a cell, then a file in the explorer, or drag a file into it.'
+              : m.rows.length === 0
+                ? 'Point at the batch_plan.csv written by the cohort plan_batch step: click the field, then the file in the explorer, or drag it in.'
+                : 'One row per cohort item, as resolved by the plan. Fix a path here if one is wrong.'}
+        </div>
+        {m.source === 'plan' && m.rows.length === 0 && (
+          <div className="wf-batch-tools">
+            <PathCell value={planCsv} placeholder="…/batch_plan.csv" onChange={setPlanCsv} />
+            <button
+              type="button"
+              className="btn-primary"
+              disabled={!planCsv.trim()}
+              onClick={() => void fillFromPlan(d.name)}
+            >
+              Load plan
+            </button>
+          </div>
+        )}
+        {required.length > 0 && m.rows.length > 0 && (
+          <div className="wf-batch-table">
+            <div className="wf-batch-row wf-batch-head">
+              <span className="wf-batch-idx">#</span>
+              {required.map((i) => (
+                <span key={i.name} className="wf-batch-col" title={`${i.name}${i.description ? ` — ${i.description}` : ''}`}>
+                  {inputTitle(i)}
+                </span>
+              ))}
+              <span className="wf-batch-status" />
+              <span className="wf-batch-rm" />
+            </div>
+            {m.rows.map((row, ri) => {
+              const verdict = rowVerdict[ri]
+              const warn = verdict?.findings.find((f) => f.severity === 'warning')
+              return (
+                <div key={ri} className="wf-batch-row">
+                  <span className="wf-batch-idx">{ri + 1}</span>
+                  {required.map((i) => (
+                    <PathCell
+                      key={i.name}
+                      value={row.values[i.name] ?? ''}
+                      placeholder={i.example ? `e.g. ${basename(i.example)}` : 'path'}
+                      onFocus={() => setFocusedCell({ row: ri, name: i.name })}
+                      onChange={(v) =>
+                        setMode({
+                          ...m,
+                          rows: m.rows.map((r, j) =>
+                            j === ri ? { values: { ...r.values, [i.name]: v } } : r,
+                          ),
+                        })
+                      }
+                    />
+                  ))}
+                  <span
+                    className={`wf-batch-status ${verdict ? (verdict.ok ? (warn ? 'warn' : 'ok') : 'fail') : ''}`}
+                    title={
+                      verdict
+                        ? verdict.ok
+                          ? warn
+                            ? warn.note
+                              : 'ready'
+                          : (verdict.error ?? 'cannot run')
+                        : ''
+                    }
+                  >
+                    {verdict ? (verdict.ok ? (warn ? '⚠' : '✓') : '✗') : ''}
+                  </span>
+                  <button
+                    type="button"
+                    className="btn-icon wf-batch-rm"
+                    title="Remove row"
+                    onClick={() => setMode({ ...m, rows: m.rows.filter((_, j) => j !== ri) })}
+                  >
+                    <XIcon size={12} />
+                  </button>
+                </div>
+              )
+            })}
+            {m.rows.some((_, ri) => rowVerdict[ri] && !rowVerdict[ri].ok) && (
+              <div className="wf-row-problems">
+                {m.rows.map((_, ri) => {
+                  const v = rowVerdict[ri]
+                  if (!v || v.ok) return null
+                  const f = v.findings.find((x) => x.severity === 'error')
+                  return (
+                    <div key={ri} className="wf-step-error">
+                      Row {ri + 1}: {v.error ?? 'cannot run'}
+                      {f && f.entries.length > 0 && (
+                        <span className="wf-nearest">
+                          {' '}
+                          — in <code>{f.nearest}</code>: {f.entries.slice(0, 4).join(', ')}
+                          {f.entry_total > 4 ? ', …' : ''}
+                        </span>
+                      )}
+                    </div>
+                  )
+                })}
               </div>
             )}
+            <div className="wf-batch-tools">
+              {m.source === 'files' ? (
+                <button
+                  type="button"
+                  className="btn-plain"
+                  onClick={() => setMode({ ...m, rows: [...m.rows, emptyRow(requiredNames)] })}
+                >
+                  + Add row
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  className="btn-text"
+                  onClick={() => {
+                    setPlanSkipped(null)
+                    setPreview(null)
+                    setMode({ ...m, rows: [] })
+                  }}
+                >
+                  Load a different plan
+                </button>
+              )}
+            </div>
           </div>
-        ) : (
-          <div className="wf-result fail">
-            {m.total > 1 && succeeded > 0
-              ? `${succeeded} of ${m.total} item(s) succeeded. ${retryRuns.length} need a retry.`
-              : `Replay failed. ${m.error ?? ''}`}
+        )}
+        {planSkipped && planSkipped.length > 0 && (
+          <div className="wf-hint wf-plan-skipped">
+            {planSkipped.length} item(s) flagged and left out. Resolve them in the plan, then
+            re-fill:
+            <ul className="wf-manual-list">
+              {planSkipped.map((s, i) => (
+                <li key={i}>
+                  <code>
+                    {s.subject}
+                    {s.session ? `/${s.session}` : ''}
+                  </code>{' '}
+                  · {s.status}: {s.reason}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+        {derived.length > 0 && (
+          <>
+            <button
+              type="button"
+              className="btn-text wf-derived-toggle"
+              onClick={() => setShowResultsDir((v) => !v)}
+            >
+              {showResultsDir ? 'Hide' : 'Change'} where results are written
+            </button>
+            {showResultsDir && (
+              <label className="wf-input-row">
+                <span className="wf-input-label">
+                  <span className="wf-input-desc">
+                    Leave blank to write beside each input file. Applies to every row.
+                  </span>
+                </span>
+                <PathCell
+                  className="wf-input"
+                  value={m.resultsDir}
+                  placeholder="results folder"
+                  onChange={(v) => setMode({ ...m, resultsDir: v })}
+                />
+              </label>
+            )}
+          </>
+        )}
+        {complete > 0 && ready && ready.steps.length > 0 && (
+          <div className="wf-preview">
+            <button
+              type="button"
+              className="btn-text wf-derived-toggle"
+              onClick={() => setShowSteps((v) => !v)}
+            >
+              {showSteps ? 'Hide' : 'Show'} what will run
+              {complete > 1 ? ' (first row)' : ''}
+            </button>
+            {showSteps && (
+              <ol className="wf-steps">
+                {ready.steps.map((s) => (
+                  <li key={s.index}>
+                    <code>{s.tool}</code>
+                    <span className="wf-args-inline">
+                      {Object.entries(s.arguments).map(([k, v]) => (
+                        <span key={k} title={typeof v === 'string' ? v : undefined}>
+                          {k}: {display(v, root)}
+                        </span>
+                      ))}
+                    </span>
+                  </li>
+                ))}
+              </ol>
+            )}
           </div>
         )}
         <div className="wf-actions">
-          {retryRuns.length > 0 && (
+          {showControls && (
             <button
               className="btn-primary"
-              title="Re-run only the items that failed or didn't finish"
-              onClick={() => startRun(m.name, retryRuns, m.stepsPerItem, Date.now())}
-            >
-              <RefreshIcon size={12} /> Retry {retryRuns.length}
+              type="submit"
+              disabled={!canRun}
+            title={
+              canRun
+                ? 'Run these exact steps. No LLM, no permission prompts.'
+                : complete === 0
+                  ? 'Fill in at least one row'
+                  : ready
+                    ? (ready.error ?? 'nothing to run')
+                    : 'Checking…'
+            }
+          >
+            <PlayIcon size={12} />{' '}
+            {ready && complete > readyItems.length && readyItems.length > 0
+              ? `Run ${readyItems.length} of ${complete} rows`
+              : readyItems.length > 1
+                  ? `Run ${readyItems.length} rows`
+                  : 'Run'}
             </button>
           )}
-          <button className="btn-plain" onClick={() => setMode({ kind: 'view' })}>
-            Close
+          <button className="btn-plain" type="button" onClick={() => setMode({ kind: 'view' })}>
+            Cancel
           </button>
+          {complete > 0 && !ready && <span className="wf-recent-muted">Checking inputs…</span>}
         </div>
-      </div>
+      </form>
     )
   }
 
@@ -865,12 +1370,12 @@ export const WorkflowPanel = memo(function WorkflowPanel({
             </div>
           )}
           {!d.replayable && d.replay_error && d.steps.length > 0 && (
-            <div className="wf-notice">Can't replay: {d.replay_error}</div>
+            <div className="wf-notice">Can't run: {d.replay_error}</div>
           )}
           <Requirements requires={d.requires} />
           {d.manual_steps.length > 0 && (
             <div className="wf-notice">
-              Includes manual step(s) replay can't run. Do these by hand:
+              Includes manual step(s) a run can't do. Do these by hand:
               <ul className="wf-manual-list">
                 {d.manual_steps.map((m, i) => (
                   <li key={i}>
@@ -886,55 +1391,59 @@ export const WorkflowPanel = memo(function WorkflowPanel({
               disabled={!d.replayable}
               title={
                 d.replayable
-                  ? 'Replay these exact steps on new inputs. No LLM involved.'
+                  ? 'Run these exact steps on new inputs. No LLM involved.'
                   : (d.replay_error ?? '')
               }
               onClick={() => beginRun(d)}
             >
               <PlayIcon size={12} /> Run
             </button>
-            {d.kind === 'draft' ? (
-              <>
-                <button
-                  className="btn-plain"
-                  title="Mark as reviewed and keep permanently"
-                  onClick={() => void promote(d.name)}
-                >
-                  Promote
-                </button>
-                <button
-                  className="btn-plain"
-                  onClick={() => setMode({ kind: 'rename', value: d.name })}
-                >
-                  Rename
-                </button>
-                <button
-                  className="btn-plain"
-                  title="Rewrite the description with a plain-language instruction"
-                  onClick={() => setMode({ kind: 'refine', value: '' })}
-                >
-                  Refine
-                </button>
-              </>
-            ) : (
+            {d.kind === 'draft' && (
               <button
                 className="btn-plain"
-                title="Move back to draft for renaming/refining"
-                onClick={() => void unpromote(d.name)}
+                title="Mark as reviewed and keep permanently"
+                onClick={() => void promote(d.name)}
               >
-                Edit
+                Promote
               </button>
             )}
-            <button
-              className="btn-plain"
-              title="Export as a shareable .workflow.yaml file"
-              onClick={() => void exportFile(d.name)}
-            >
-              <UploadIcon size={12} /> Export
-            </button>
-            <button className="btn-plain wf-delete" onClick={() => remove(d.name)}>
-              Delete
-            </button>
+            <span className="wf-actions-secondary">
+              {d.kind === 'draft' ? (
+                <>
+                  <button
+                    className="btn-text"
+                    onClick={() => setMode({ kind: 'rename', value: d.name })}
+                  >
+                    Rename
+                  </button>
+                  <button
+                    className="btn-text"
+                    title="Rewrite the description with a plain-language instruction"
+                    onClick={() => setMode({ kind: 'refine', value: '' })}
+                  >
+                    Refine
+                  </button>
+                </>
+              ) : (
+                <button
+                  className="btn-text"
+                  title="Move back to draft for renaming/refining"
+                  onClick={() => void unpromote(d.name)}
+                >
+                  Edit
+                </button>
+              )}
+              <button
+                className="btn-text"
+                title="Export as a shareable .workflow.yaml file"
+                onClick={() => void exportFile(d.name)}
+              >
+                Export
+              </button>
+              <button className="btn-text wf-delete" onClick={() => remove(d.name)}>
+                Delete
+              </button>
+            </span>
           </div>
         </>
       )}
@@ -991,324 +1500,7 @@ export const WorkflowPanel = memo(function WorkflowPanel({
         </form>
       )}
 
-      {mode.kind === 'inputs' &&
-        ((m: Extract<Mode, { kind: 'inputs' }>) => {
-          const inputNames = d.inputs.map((i) => i.name)
-          // An input carrying a default fills itself server-side when left
-          // blank, so requiring it here would put the typing straight back.
-          const requiredInputs = d.inputs.filter((i) => !i.default)
-          const derivedInputs = d.inputs.filter((i) => i.default)
-          const requiredNames = requiredInputs.map((i) => i.name)
-          const emptyRow = (): Record<string, string> =>
-            Object.fromEntries(inputNames.map((n) => [n, '']))
-          // Distribute the selected files across rows: every N files (N = number
-          // of inputs the user fills) fill one row's inputs in order. So a 2-input
-          // workflow turns 2 selected files into one run (in_1, in_2), 4 files into
-          // two runs, etc. A single-input workflow gets one row per file. Derived
-          // inputs are excluded: they resolve per row from the files chosen here,
-          // and counting them would consume a selected file per row for a value
-          // nobody picked. Drops blank rows.
-          const addFromSelection = () => {
-            const k = requiredNames.length
-            if (k === 0 || selectedPaths.length === 0) return
-            const added: Record<string, string>[] = []
-            for (let i = 0; i < selectedPaths.length; i += k) {
-              const row = emptyRow()
-              requiredNames.forEach((n, j) => {
-                const file = selectedPaths[i + j]
-                if (file) row[n] = file
-              })
-              added.push(row)
-            }
-            const filled = m.rows.filter((r) => Object.values(r).some((v) => v.trim()))
-            setMode({ ...m, rows: [...filled, ...added] })
-          }
-          const singleIncomplete = requiredNames.some((n) => !(m.values[n] ?? '').trim())
-          const completeRows = m.rows.filter((r) =>
-            requiredNames.every((n) => (r[n] ?? '').trim()),
-          )
-          const previewDisabled = m.batch ? completeRows.length === 0 : singleIncomplete
-          return (
-            <form
-              className="wf-form"
-              onSubmit={(e) => {
-                e.preventDefault()
-                void toPreview(d.name, { batch: m.batch, values: m.values, rows: m.rows }, requiredNames)
-              }}
-            >
-              <div className="wf-mode-toggle">
-                <button
-                  type="button"
-                  className={!m.batch ? 'active' : ''}
-                  onClick={() => setMode({ ...m, batch: false })}
-                >
-                  Single run
-                </button>
-                <button
-                  type="button"
-                  className={m.batch ? 'active' : ''}
-                  onClick={() =>
-                    setMode({
-                      ...m,
-                      batch: true,
-                      rows: m.rows.some((r) => Object.values(r).some((v) => v.trim()))
-                        ? m.rows
-                        : [{ ...m.values }],
-                    })
-                  }
-                >
-                  Batch
-                </button>
-              </div>
-
-              {!m.batch ? (
-                <>
-                  <div className="wf-hint">
-                    Provide a value for each input. Select a file in the explorer to fill it, or
-                    type / drag a path.
-                  </div>
-                  {requiredInputs.map((i) => (
-                    <InputField
-                      key={i.name}
-                      name={i.name}
-                      example={i.example}
-                      description={i.description}
-                      value={m.values[i.name] ?? ''}
-                      onChange={(v) => setMode({ ...m, values: { ...m.values, [i.name]: v } })}
-                    />
-                  ))}
-                  {/* Derived inputs are worked out from the ones above, so they are
-                      not questions to put to the user. They stay reachable — the
-                      recipe still declares them and a caller may want the results
-                      somewhere else — but behind a disclosure rather than as empty
-                      boxes that look like something is missing. */}
-                  {derivedInputs.length > 0 && (
-                    <>
-                      <button
-                        type="button"
-                        className="btn-text wf-derived-toggle"
-                        onClick={() => setShowDerived((v) => !v)}
-                      >
-                        {showDerived ? 'Hide' : 'Change'} where results are written
-                      </button>
-                      {showDerived &&
-                        derivedInputs.map((i) => (
-                          <InputField
-                            key={i.name}
-                            name={i.name}
-                            example={i.example}
-                            description={i.description}
-                            defaultHint="leave blank to write beside the input file"
-                            value={m.values[i.name] ?? ''}
-                            onChange={(v) =>
-                              setMode({ ...m, values: { ...m.values, [i.name]: v } })
-                            }
-                          />
-                        ))}
-                    </>
-                  )}
-                </>
-              ) : (
-                <>
-                  <div className="wf-hint">
-                    One row per run. Each runs the whole workflow on its own inputs. Drag a file
-                    into any cell, or select files in the explorer and “Add from selection” (every{' '}
-                    {requiredInputs.length} selected file{requiredInputs.length === 1 ? '' : 's'}{' '}
-                    fill one row).
-                  </div>
-                  <div className="wf-batch-table">
-                    <div className="wf-batch-row wf-batch-head">
-                      <span className="wf-batch-idx">#</span>
-                      {requiredInputs.map((i) => (
-                        <span key={i.name} className="wf-batch-col" title={inputOptionLabel(i)}>
-                          {i.name}
-                        </span>
-                      ))}
-                      <span className="wf-batch-rm" />
-                    </div>
-                    {m.rows.map((row, ri) => (
-                      <div key={ri} className="wf-batch-row">
-                        <span className="wf-batch-idx">{ri + 1}</span>
-                        {requiredInputs.map((i) => (
-                          <BatchCell
-                            key={i.name}
-                            value={row[i.name] ?? ''}
-                            example={i.example}
-                            onChange={(v) =>
-                              setMode({
-                                ...m,
-                                rows: m.rows.map((r, j) =>
-                                  j === ri ? { ...r, [i.name]: v } : r,
-                                ),
-                              })
-                            }
-                          />
-                        ))}
-                        <button
-                          type="button"
-                          className="btn-icon wf-batch-rm"
-                          title="Remove row"
-                          onClick={() =>
-                            setMode({ ...m, rows: m.rows.filter((_, j) => j !== ri) })
-                          }
-                        >
-                          <XIcon size={12} />
-                        </button>
-                      </div>
-                    ))}
-                    <div className="wf-batch-tools">
-                      <button
-                        type="button"
-                        className="btn-plain"
-                        onClick={() => setMode({ ...m, rows: [...m.rows, emptyRow()] })}
-                      >
-                        + Add row
-                      </button>
-                      <button
-                        type="button"
-                        className="btn-plain"
-                        disabled={selectedPaths.length === 0}
-                        title={
-                          selectedPaths.length === 0
-                            ? 'Select files in the explorer first'
-                            : `Group the ${selectedPaths.length} selected file(s) into rows of ${d.inputs.length} (one per input)`
-                        }
-                        onClick={addFromSelection}
-                      >
-                        Add from selection ({selectedPaths.length})
-                      </button>
-                    </div>
-                    <div className="wf-batch-tools wf-batch-plan">
-                      <input
-                        className="wf-batch-cell"
-                        value={planCsv}
-                        placeholder="…/batch_plan.csv (from the cohort plan_batch step)"
-                        title={planCsv || undefined}
-                        onChange={(e) => setPlanCsv(e.target.value)}
-                        onDragOver={(e) => {
-                          if (
-                            e.dataTransfer.types.includes(DRAG_PATH_MIME) ||
-                            getDraggedFilePath() !== null
-                          )
-                            e.preventDefault()
-                        }}
-                        onDrop={(e) => {
-                          const path =
-                            e.dataTransfer.getData(DRAG_PATH_MIME) || getDraggedFilePath()
-                          if (path) {
-                            e.preventDefault()
-                            setPlanCsv(path)
-                          }
-                        }}
-                      />
-                      <button
-                        type="button"
-                        className="btn-plain"
-                        disabled={!planCsv.trim()}
-                        title="Build one row per cohort subject from a plan_batch manifest"
-                        onClick={() => void fillFromPlan(d.name)}
-                      >
-                        Fill from cohort plan
-                      </button>
-                    </div>
-                  </div>
-                  {planSkipped && planSkipped.length > 0 && (
-                    <div className="wf-hint wf-plan-skipped">
-                      {planSkipped.length} item(s) flagged and left out. Resolve them in the plan,
-                      then re-fill:
-                      <ul className="wf-manual-list">
-                        {planSkipped.map((s, i) => (
-                          <li key={i}>
-                            <code>
-                              {s.subject}
-                              {s.session ? `/${s.session}` : ''}
-                            </code>{' '}
-                            · {s.status}: {s.reason}
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  )}
-                  {completeRows.length > 0 && (
-                    <div className="wf-hint">
-                      {completeRows.length} run{completeRows.length === 1 ? '' : 's'} ready
-                      {m.rows.length > completeRows.length
-                        ? ` (${m.rows.length - completeRows.length} incomplete row(s) skipped)`
-                        : ''}
-                      .
-                    </div>
-                  )}
-                </>
-              )}
-
-              <div className="wf-actions">
-                <button className="btn-primary" type="submit" disabled={previewDisabled}>
-                  Preview steps
-                </button>
-                <button
-                  className="btn-plain"
-                  type="button"
-                  onClick={() => setMode({ kind: 'view' })}
-                >
-                  Cancel
-                </button>
-              </div>
-            </form>
-          )
-        })(mode)}
-
-      {mode.kind === 'preview' && (
-        <div className="wf-form">
-          <div className="wf-hint">
-            Replay will run these exact steps. No LLM, no permission prompts. Review before
-            running.
-          </div>
-          {mode.runs.length > 1 && (
-            <div className="wf-hint">
-              Batch: {mode.runs.length} runs. The steps below show the first. All runs:
-              <span className="wf-batch-chips">
-                {mode.runs.map((_run, i) => (
-                  <code key={i}>{itemLabel(mode.runs, i)}</code>
-                ))}
-              </span>
-            </div>
-          )}
-          <ol className="wf-steps">
-            {mode.steps.map((s) => (
-              <li key={s.index}>
-                <code>
-                  {s.server}:{s.tool}
-                </code>
-                <pre className="wf-args">{JSON.stringify(s.arguments)}</pre>
-              </li>
-            ))}
-          </ol>
-          <div className="wf-actions">
-            <button
-              className="btn-primary"
-              onClick={() => startRun(d.name, mode.runs, d.steps.length, Date.now())}
-            >
-              <PlayIcon size={12} /> Run now
-            </button>
-            <button
-              className="btn-plain"
-              onClick={() =>
-                d.inputs.length > 0
-                  ? setMode({
-                      kind: 'inputs',
-                      batch: mode.batch,
-                      values: mode.values,
-                      rows: mode.rows,
-                    })
-                  : setMode({ kind: 'view' })
-              }
-            >
-              Back
-            </button>
-          </div>
-        </div>
-      )}
-
+      {mode.kind === 'run' && renderEditor(d, mode)}
     </div>
   )
 
@@ -1360,12 +1552,15 @@ export const WorkflowPanel = memo(function WorkflowPanel({
             <span className="status-dot busy" /> {busy}
           </div>
         )}
-        {(mode.kind === 'running' || mode.kind === 'done') && (
+        {run && (
           <div className="wf-run-card">
             <div className="wf-run-card-head">
-              <PlayIcon size={12} /> {mode.name}
+              <PlayIcon size={12} /> {run.workflow}
+              <span className="wf-recent-muted wf-run-card-id" title={run.runId}>
+                {run.total > 1 ? `${run.total} items` : 'single run'}
+              </span>
             </div>
-            {mode.kind === 'running' ? renderRunning(mode) : renderDone(mode)}
+            {renderRun(run)}
           </div>
         )}
         {workflows !== null && workflows.length === 0 && !busy && (
@@ -1375,25 +1570,25 @@ export const WorkflowPanel = memo(function WorkflowPanel({
           </div>
         )}
         {workflows?.map((w) => (
-            <div key={w.name} className="wf-item">
-              <button className="wf-row" onClick={() => void openDetail(w.name)}>
-                <ChevronRightIcon
-                  size={12}
-                  className={expanded === w.name ? 'wf-chevron open' : 'wf-chevron'}
-                />
-                <span className="wf-name">{w.name}</span>
-                <span className={`wf-chip wf-chip-${w.kind}`}>{w.kind}</span>
-              </button>
-              {expanded === w.name &&
-                (detail ? (
-                  renderDetail(detail)
-                ) : (
-                  <div className="wf-busy">
-                    <span className="status-dot busy" /> Loading…
-                  </div>
-                ))}
-            </div>
-          ))}
+          <div key={w.name} className="wf-item">
+            <button className="wf-row" onClick={() => void openDetail(w.name)}>
+              <ChevronRightIcon
+                size={12}
+                className={expanded === w.name ? 'wf-chevron open' : 'wf-chevron'}
+              />
+              <span className="wf-name">{w.name}</span>
+              <span className={`wf-chip wf-chip-${w.kind}`}>{w.kind}</span>
+            </button>
+            {expanded === w.name &&
+              (detail ? (
+                renderDetail(detail)
+              ) : (
+                <div className="wf-busy">
+                  <span className="status-dot busy" /> Loading…
+                </div>
+              ))}
+          </div>
+        ))}
       </div>
     </div>
   )

--- a/frontend/src/components/WorkflowPanel.tsx
+++ b/frontend/src/components/WorkflowPanel.tsx
@@ -10,11 +10,8 @@ import {
   fetchWorkflows,
   fetchWorkspaceRoot,
   importWorkflow,
-  promoteWorkflow,
-  refineWorkflow,
   renameWorkflow,
   replayPreview,
-  unpromoteWorkflow,
 } from '../api'
 import { getDraggedFilePath } from '../dragState'
 import type {
@@ -54,7 +51,6 @@ type Row = { values: Record<string, string> }
 type Mode =
   | { kind: 'view' }
   | { kind: 'rename'; value: string }
-  | { kind: 'refine'; value: string }
   | { kind: 'run'; source: RunSource; rows: Row[]; resultsDir: string }
 
 /** Where a run's inputs come from: files picked by hand (the default, prefilled
@@ -531,8 +527,8 @@ function placeFiles(
 
 /**
  * Personal-workflows panel: save the current chat as a reusable workflow,
- * review/promote/refine drafts, and run a recipe deterministically (no LLM)
- * on new inputs. A run is a server-side job: it keeps going if this page goes
+ * rename/share it, and run its recipe deterministically (no LLM) on new
+ * inputs. A run is a server-side job: it keeps going if this page goes
  * away, and the page reattaches to it on reload.
  */
 // Memoized: App bumps `fsVersion` on every completed tool call / turn end to
@@ -833,42 +829,28 @@ export const WorkflowPanel = memo(function WorkflowPanel({
     }
   }
 
-  const showDraft = (draft: WorkflowDetail) => {
-    detailForRef.current = draft.name
-    setExpanded(draft.name)
-    setDetail(draft)
+  const showWorkflow = (wf: WorkflowDetail) => {
+    detailForRef.current = wf.name
+    setExpanded(wf.name)
+    setDetail(wf)
     setMode({ kind: 'view' })
   }
 
   const saveChat = () =>
-    withBusy('Distilling the chat into a workflow (local model)…', async () => {
+    withBusy('Saving the chat as a workflow…', async () => {
       if (!distillSessionId) return
-      const draft = await distillSession(distillSessionId)
+      const wf = await distillSession(distillSessionId)
       await reload()
-      showDraft(draft)
-    })
-
-  const promote = (name: string) =>
-    withBusy('Promoting…', async () => {
-      await promoteWorkflow(name)
-      await reload()
-      setDetail(await fetchWorkflowDetail(name))
+      showWorkflow(wf)
     })
 
   const exportFile = (name: string) => withBusy('Exporting…', () => exportWorkflow(name))
 
   const importFile = (file: File) =>
     withBusy('Importing workflow…', async () => {
-      const draft = await importWorkflow(await file.text())
+      const wf = await importWorkflow(await file.text())
       await reload()
-      showDraft(draft)
-    })
-
-  const unpromote = (name: string) =>
-    withBusy('Moving back to draft…', async () => {
-      await unpromoteWorkflow(name)
-      await reload()
-      setDetail(await fetchWorkflowDetail(name))
+      showWorkflow(wf)
     })
 
   const remove = (name: string) => {
@@ -889,14 +871,6 @@ export const WorkflowPanel = memo(function WorkflowPanel({
       detailForRef.current = slug
       setExpanded(slug)
       setDetail(await fetchWorkflowDetail(slug))
-      setMode({ kind: 'view' })
-    })
-
-  const refine = (name: string, instruction: string) =>
-    withBusy('Refining the description (local model)…', async () => {
-      await refineWorkflow(name, instruction)
-      await reload()
-      setDetail(await fetchWorkflowDetail(name))
       setMode({ kind: 'view' })
     })
 
@@ -1398,41 +1372,13 @@ export const WorkflowPanel = memo(function WorkflowPanel({
             >
               <PlayIcon size={12} /> Run
             </button>
-            {d.kind === 'draft' && (
-              <button
-                className="btn-plain"
-                title="Mark as reviewed and keep permanently"
-                onClick={() => void promote(d.name)}
-              >
-                Promote
-              </button>
-            )}
             <span className="wf-actions-secondary">
-              {d.kind === 'draft' ? (
-                <>
-                  <button
-                    className="btn-text"
-                    onClick={() => setMode({ kind: 'rename', value: d.name })}
-                  >
-                    Rename
-                  </button>
-                  <button
-                    className="btn-text"
-                    title="Rewrite the description with a plain-language instruction"
-                    onClick={() => setMode({ kind: 'refine', value: '' })}
-                  >
-                    Refine
-                  </button>
-                </>
-              ) : (
-                <button
-                  className="btn-text"
-                  title="Move back to draft for renaming/refining"
-                  onClick={() => void unpromote(d.name)}
-                >
-                  Edit
-                </button>
-              )}
+              <button
+                className="btn-text"
+                onClick={() => setMode({ kind: 'rename', value: d.name })}
+              >
+                Rename
+              </button>
               <button
                 className="btn-text"
                 title="Export as a shareable .workflow.yaml file"
@@ -1465,33 +1411,6 @@ export const WorkflowPanel = memo(function WorkflowPanel({
           <div className="wf-actions">
             <button className="btn-primary" type="submit">
               Rename
-            </button>
-            <button className="btn-plain" type="button" onClick={() => setMode({ kind: 'view' })}>
-              Cancel
-            </button>
-          </div>
-        </form>
-      )}
-
-      {mode.kind === 'refine' && (
-        <form
-          className="wf-form"
-          onSubmit={(e) => {
-            e.preventDefault()
-            if (mode.value.trim()) void refine(d.name, mode.value.trim())
-          }}
-        >
-          <textarea
-            className="wf-input"
-            autoFocus
-            rows={3}
-            placeholder="e.g. Mention that the input must be a T1-weighted scan"
-            value={mode.value}
-            onChange={(e) => setMode({ kind: 'refine', value: e.target.value })}
-          />
-          <div className="wf-actions">
-            <button className="btn-primary" type="submit">
-              Refine
             </button>
             <button className="btn-plain" type="button" onClick={() => setMode({ kind: 'view' })}>
               Cancel
@@ -1577,7 +1496,6 @@ export const WorkflowPanel = memo(function WorkflowPanel({
                 className={expanded === w.name ? 'wf-chevron open' : 'wf-chevron'}
               />
               <span className="wf-name">{w.name}</span>
-              <span className={`wf-chip wf-chip-${w.kind}`}>{w.kind}</span>
             </button>
             {expanded === w.name &&
               (detail ? (

--- a/frontend/src/components/icons.tsx
+++ b/frontend/src/components/icons.tsx
@@ -249,3 +249,15 @@ export function RecenterIcon(props: IconProps) {
     </Icon>
   )
 }
+
+/** A small table/grid — a cohort plan, one row per subject. */
+export function TableIcon(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <rect x="3" y="4" width="18" height="16" rx="2" />
+      <line x1="3" y1="10" x2="21" y2="10" />
+      <line x1="3" y1="15" x2="21" y2="15" />
+      <line x1="10" y1="10" x2="10" y2="20" />
+    </Icon>
+  )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1940,28 +1940,6 @@ button:hover {
   white-space: nowrap;
 }
 
-.wf-chip {
-  margin-left: auto;
-  flex-shrink: 0;
-  font-size: 10px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  padding: 1px 7px;
-  border-radius: 99px;
-  border: 1px solid;
-}
-
-.wf-chip-draft {
-  color: var(--warn);
-  border-color: rgba(251, 191, 36, 0.4);
-}
-
-.wf-chip-active {
-  color: var(--ok);
-  border-color: rgba(74, 222, 128, 0.4);
-}
-
 .wf-detail {
   padding: 2px 8px 12px 27px;
   display: flex;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2102,8 +2102,9 @@ textarea.wf-input {
 
 .wf-requires {
   display: flex;
-  flex-direction: column;
-  gap: 3px;
+  align-items: baseline;
+  gap: 8px;
+  flex-wrap: wrap;
   font-size: 12px;
 }
 
@@ -2122,6 +2123,16 @@ textarea.wf-input {
   display: flex;
   flex-direction: column;
   gap: 2px;
+}
+
+/* Requirements read as one line: "REQUIRES ✓ medmcp-neuro"; the pin is a tooltip. */
+.wf-requires-list {
+  margin: 0;
+  padding-left: 0;
+  list-style: none;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 2px 12px;
 }
 
 .wf-req-pin {
@@ -2282,33 +2293,6 @@ textarea.wf-input {
   border: 1px solid var(--border2);
   border-radius: 5px;
   background: var(--card);
-}
-
-.wf-mode-toggle {
-  display: inline-flex;
-  align-self: flex-start;
-  border: 1px solid var(--border2);
-  border-radius: 6px;
-  overflow: hidden;
-}
-
-.wf-mode-toggle button {
-  font: inherit;
-  font-size: 12px;
-  padding: 4px 12px;
-  background: transparent;
-  color: var(--muted);
-  border: none;
-  cursor: pointer;
-}
-
-.wf-mode-toggle button + button {
-  border-left: 1px solid var(--border2);
-}
-
-.wf-mode-toggle button.active {
-  background: var(--blue);
-  color: #fff;
 }
 
 .wf-batch-table {
@@ -2482,6 +2466,278 @@ textarea.wf-input {
 .wf-output-link:hover {
   text-decoration: underline;
 }
+
+/* Produced files as chips: name only, path on hover, click opens the viewer. */
+.wf-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.wf-file-chip {
+  font: inherit;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--blue-xl);
+  background: var(--card);
+  border: 1px solid var(--border2);
+  border-radius: 5px;
+  padding: 1px 7px;
+  cursor: pointer;
+  max-width: 100%;
+  text-align: left;
+  /* Long imaging names wrap rather than truncate: a cut name is a wrong name. */
+  white-space: normal;
+  word-break: break-all;
+}
+
+.wf-file-chip:hover {
+  border-color: var(--blue-l);
+}
+
+.wf-file-chip.static {
+  color: var(--muted2);
+  cursor: default;
+}
+
+/* One line per step / per item in the run card. */
+.wf-steprows,
+.wf-itemrows {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  font-size: 12px;
+}
+
+.wf-steprow {
+  display: flex;
+  align-items: baseline;
+  gap: 7px;
+  flex-wrap: wrap;
+}
+
+.wf-steprow code,
+.wf-itemrow-label {
+  font-family: var(--mono);
+  font-size: 11.5px;
+}
+
+.wf-steprow.queued .status-dot,
+.wf-itemrow.queued .status-dot {
+  background: var(--border2);
+}
+
+.wf-itemrow-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.wf-itemrow {
+  display: flex;
+  align-items: baseline;
+  gap: 7px;
+  width: 100%;
+  min-width: 0;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  font-size: 12px;
+  text-align: left;
+  padding: 2px 0;
+  cursor: pointer;
+}
+
+.wf-itemrow.queued {
+  cursor: default;
+}
+
+.wf-itemrow-label {
+  flex-shrink: 0;
+}
+
+.wf-itemrow-note {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wf-itemrow-wrap .wf-steprows,
+.wf-itemrow-wrap .wf-chips {
+  padding-left: 15px;
+}
+
+.wf-more {
+  padding: 0 2px;
+  font-size: 11px;
+  text-decoration: underline;
+}
+
+.wf-error-full {
+  margin: 4px 0 0;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--muted2);
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 160px;
+  overflow: auto;
+}
+
+/* Resolved arguments of a step in the editor's "what will run" list. */
+.wf-args-inline {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px 10px;
+  margin-left: 6px;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--muted);
+  word-break: break-all;
+}
+
+.wf-actions-secondary {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 2px;
+  margin-left: auto;
+}
+
+.wf-actions-secondary .btn-text {
+  font-size: 11.5px;
+  padding: 3px 6px;
+}
+
+/* Where the inputs come from: two option cards, files by hand or a cohort plan.
+   Cards rather than a text toggle so each choice can say in a few words what
+   it is for; only the chosen editor renders below. */
+.wf-source-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+  gap: 6px;
+}
+
+.wf-source-card {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  padding: 7px 9px;
+  text-align: left;
+  font: inherit;
+  color: var(--muted2);
+  background: var(--dark2);
+  border: 1px solid var(--border2);
+  border-radius: 7px;
+  cursor: pointer;
+}
+
+.wf-source-card:hover {
+  color: var(--text);
+  border-color: var(--border-strong, var(--blue-l));
+}
+
+.wf-source-card.active {
+  color: var(--text);
+  border-color: var(--blue-l);
+  background: rgba(43, 79, 163, 0.18);
+  box-shadow: inset 0 0 0 1px rgba(127, 168, 245, 0.25);
+}
+
+.wf-source-icon {
+  display: inline-flex;
+  flex: none;
+  color: var(--muted);
+}
+
+.wf-source-card.active .wf-source-icon {
+  color: var(--blue-xl);
+}
+
+.wf-source-text {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  line-height: 1.25;
+}
+
+.wf-source-title {
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.wf-source-hint {
+  font-size: 11px;
+  color: var(--muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Per-row pre-flight verdict in the run editor (✓ ready, ⚠ overwrite, ✗ missing). */
+.wf-batch-status {
+  width: 16px;
+  flex: none;
+  text-align: center;
+  font-size: 12px;
+  line-height: 16px;
+}
+
+.wf-batch-status.ok {
+  color: var(--ok);
+}
+
+.wf-batch-status.warn {
+  color: var(--warn);
+}
+
+.wf-batch-status.fail {
+  color: var(--red-tint);
+}
+
+.wf-row-problems {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  font-size: 11.5px;
+  line-height: 1.4;
+}
+
+.wf-nearest {
+  color: var(--muted);
+}
+
+.wf-nearest code {
+  font-family: var(--mono);
+  font-size: 11px;
+}
+
+.wf-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.wf-runstep.live {
+  color: var(--muted2);
+}
+
+.wf-run-card-id {
+  margin-left: auto;
+  font-weight: 500;
+}
+
+.wf-recent-muted {
+  color: var(--text);
+}
+
+.wf-recent-muted {
+  color: var(--muted);
+  font-size: 11.5px;
+}
+
 
 /* ── Context meter (chat header) ────────────────────────── */
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -134,7 +134,6 @@ export interface GpuInfo {
 export interface WorkflowListEntry {
   name: string
   description: string
-  kind: 'active' | 'draft'
 }
 
 /** A stack the workflow needs, pinned for reproducibility. */
@@ -152,7 +151,6 @@ export interface StackRequirement {
 /** Full recipe detail from GET /api/workflows/{name}. */
 export interface WorkflowDetail {
   name: string
-  kind: 'active' | 'draft'
   description: string
   inputs: { name: string; example: string; description: string; default?: string }[]
   steps: { server: string; tool: string; arguments: Record<string, unknown> }[]

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -188,8 +188,59 @@ export interface ReplayPreviewStep {
   arguments: Record<string, unknown>
 }
 
+/** Pre-flight verdict on one run item, before anything is executed. */
+export interface ReplayPreviewItem {
+  index: number
+  ok: boolean
+  error: string | null
+  findings: PathFinding[]
+}
+
+/** Result of POST /api/workflows/{name}/replay-preview. */
+export interface ReplayPreviewResult {
+  ok: boolean
+  error: string | null
+  /** The resolved steps of the first item that can run. */
+  steps: ReplayPreviewStep[]
+  items: ReplayPreviewItem[]
+}
+
+export type RunStatus = 'running' | 'done' | 'failed' | 'cancelled'
+
+/** One row from GET /api/runs. */
+export interface RunSummary {
+  id: string
+  workflow: string
+  status: RunStatus
+  started_at: string
+  finished_at: string
+  error: string | null
+  total: number
+  succeeded: number
+  failed: number
+  steps_per_item: number
+}
+
 /** Frames the server sends over /ws/replay. */
 export type ReplayFrame =
+  | {
+      type: 'started'
+      run_id: string
+      workflow: string
+      total: number
+      steps_per_item: number
+      started_at: string
+      runs: Record<string, string>[]
+    }
+  | {
+      type: 'step_started'
+      item: number
+      index: number
+      server: string
+      tool: string
+      /** When the tool was called, so a late attach shows the real elapsed time. */
+      started_at?: string
+    }
   | {
       type: 'step'
       /** Batch item index this step belongs to (0 for single runs). */
@@ -200,9 +251,18 @@ export type ReplayFrame =
       ok: boolean
       error?: string | null
       produced: Record<string, string>
+      started_at?: string
+      finished_at?: string
     }
   | { type: 'item_result'; item: number; ok: boolean; error?: string | null; outputs: string[] }
-  | { type: 'result'; ok: boolean; error?: string | null; outputs?: string[] }
+  | {
+      type: 'result'
+      ok: boolean
+      error?: string | null
+      outputs?: string[]
+      status?: RunStatus
+      finished_at?: string
+    }
 
 /** One task in the agent's plan, from the `todo` tool's arguments. */
 export interface TodoItem {

--- a/justfile
+++ b/justfile
@@ -31,7 +31,7 @@ clean-chats:
     rm -rf .vibe/provenance
     rm -rf .vibe/workflows/draft
 
-# Remove ALL distilled workflows, including promoted ones under active/
+# Remove ALL distilled workflows
 clean-workflows:
     rm -rf .vibe/workflows
 
@@ -142,21 +142,16 @@ provenance-list:
 report SESSION:
     uv run medmcp report {{SESSION}}
 
-# Distill a reusable workflow (recipe.yaml + SKILL.md) from a session's raw log
-# Usage: just distill <session-id>   (add --no-llm to skip the narrative pass)
-distill SESSION *ARGS:
-    uv run medmcp distill {{SESSION}} {{ARGS}}
+# Distill a replayable workflow (recipe.yaml) from a session's raw log
+# Usage: just distill <session-id>
+distill SESSION:
+    uv run medmcp distill {{SESSION}}
 
-# Promote a reviewed draft workflow into active/ (marks it reviewed; replay-only)
-# Usage: just promote <workflow-name>
-promote NAME:
-    uv run medmcp promote {{NAME}}
-
-# List personal workflows (draft + promoted)
+# List personal workflows
 workflows:
     uv run medmcp workflows
 
-# Delete a personal workflow (draft or active) by name
+# Delete a personal workflow by name
 # Usage: just delete-workflow <workflow-name>
 delete-workflow NAME:
     uv run medmcp delete {{NAME}}
@@ -166,7 +161,7 @@ delete-workflow NAME:
 export-workflow NAME *ARGS:
     uv run medmcp export {{NAME}} {{ARGS}}
 
-# Import a shared workflow file as a reviewable draft
+# Import a shared workflow file as a new workflow
 # Usage: just import-workflow <file.workflow.yaml>
 import-workflow FILE:
     uv run medmcp import {{FILE}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "medmcp"
-version = "0.2.2"
+version = "0.2.3"
 description = "A local medical imaging agent"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/medmcp/distill.py
+++ b/src/medmcp/distill.py
@@ -1,49 +1,33 @@
-"""Tier-2 distillation: turn a session's raw log into a reusable workflow.
+"""Tier-2 distillation: turn a session's raw log into a replayable workflow.
 
 Reads vibe-acp's ``messages.jsonl`` (the authoritative record of exact tool
 names, arguments, and structured results), filters out exploratory/failed
 calls, and lifts concrete file paths into named placeholders to produce a
-:class:`~medmcp.workflow.Recipe`. The recipe is emitted two ways from one
-distillation (Option C):
+:class:`~medmcp.workflow.Recipe`, written as ``recipe.yaml`` — the one file a
+workflow consists of. No model takes part: the recipe is a recording, and the
+replay engine (:mod:`medmcp.replay`) is the only thing that runs it. The
+workflow is named after the chat it came from (the caller passes the chat's
+title; the request that opened the chat is the fallback, and its description).
 
-- ``recipe.yaml`` — machine-readable + replayable; what the replay engine runs.
-- ``SKILL.md``    — frontmatter + ``## Steps`` / ``## Gotchas``: the human-facing
-  description of the workflow, shown in the UI and carried by an export.
-
-The prose (workflow name, description, narrative steps, gotchas) is written by a
-hybrid pass: the step sequence is extracted deterministically, then the local
-Ollama model is asked to write the human-facing narrative. If the model is
-unavailable the narrative falls back to a mechanical rendering so distillation
-never hard-fails.
-
-Output lands in ``.vibe/workflows/draft/<name>/`` for human review; promoting it
-to ``active/`` — marking it reviewed and worth keeping — is a separate,
-deliberate step. Neither directory is ever loaded as a skill: a workflow runs
-through :mod:`medmcp.replay`, never by the agent deciding to invoke it.
+Output lands in ``.vibe/workflows/<name>/``. Nothing there is ever loaded as a
+skill: a workflow runs through the replay engine, never by the agent deciding
+to invoke it.
 """
 
 from __future__ import annotations
 
 import json
-import os
 import re
 import shutil
 from collections.abc import Collection
 from pathlib import Path, PurePosixPath
 from typing import Any, cast
 
-import httpx
-import yaml
-
-from medmcp import provenance
+from medmcp import provenance, workflow
 from medmcp.workflow import Recipe, RecipeStep, StackRequirement, WorkflowInput
 from medmcp.workspace_note import display_content_text, strip_workspace_note
 
 JsonDict = dict[str, Any]
-
-OLLAMA_BASE_URL: str = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434")
-OLLAMA_MODEL: str = os.environ.get("OLLAMA_MODEL", "muse-medmcp")
-PROSE_TIMEOUT: float = 60.0
 
 # Read-only / orchestration tools that carry no reusable workflow meaning; they
 # are dropped from the distilled recipe so it captures the actual pipeline.
@@ -401,287 +385,32 @@ def build_requirements(recipe: Recipe, manifest: JsonDict | None) -> list[StackR
     return requires
 
 
-# ── Hybrid prose pass ────────────────────────────────────────────────────────
+# ── Workflow directories ─────────────────────────────────────────────────────
 
 
-def _prose_prompt(recipe: Recipe, context: str) -> str:
-    """Build the prompt that asks the model to narrate the distilled steps."""
-    steps_desc = "\n".join(
-        f"{i}. {s.server}:{s.tool} arguments={json.dumps(s.arguments)}"
-        for i, s in enumerate(recipe.steps, start=1)
-    )
-    manual_note = ""
-    if recipe.manual_steps:
-        manual_note = (
-            "\n\nManual steps (built-in tools that were used but CANNOT be replayed "
-            "automatically) — call these out in gotchas_markdown so the reader performs "
-            "them by hand:\n" + "\n".join(f"- {m}" for m in recipe.manual_steps)
-        )
-    return (
-        "You are documenting a medical-imaging workflow so a colleague can reuse it "
-        "on their own data. Below is the original user request and the exact sequence "
-        "of tool calls that were executed. Write a concise, reusable workflow.\n\n"
-        "GENERALIZE — this is the most important rule. The workflow must be reusable "
-        "beyond the specific scan it was run on:\n"
-        "- Describe inputs at the imaging-modality / anatomy level, NOT the specific "
-        "contrast, sequence, or filename. For example, a workflow run on a T1 scan is a "
-        "brain MRI workflow; refer to 'a brain MRI scan', not 'a T1 scan' or "
-        "'t1n_3d.nii.gz'.\n"
-        "- Only mention a specific contrast/sequence (T1, FLAIR, T2, b0, …) when a step "
-        "genuinely depends on it; otherwise keep it generic.\n"
-        "- The name and description must be modality-level and not tied to one dataset, "
-        "subject, or path.\n\n"
-        "NAME THE TOOLS — every step in steps_markdown MUST explicitly name the exact "
-        "tool it uses, written in backticks as `server:tool` (e.g. `medmcp-neuro:skull_strip`, "
-        "or `builtin:bash` for a built-in tool). This tells the reader precisely which "
-        "tool/skill to call. Never omit, invent, or rephrase a tool name — use only the "
-        "tools listed under 'Executed steps' below, exactly as written. Keep the surrounding "
-        "description generic, but the tool name itself must be verbatim.\n\n"
-        "Respond with ONLY a JSON object — no markdown fences, no extra text:\n"
-        '{"name": "<short-kebab-case-name>", "description": "<one sentence>", '
-        '"steps_markdown": "<numbered markdown list; each step names its `server:tool`>", '
-        '"gotchas_markdown": "<markdown bullet list of caveats, or empty string>"}\n\n'
-        f"Original request:\n{context}\n\n"
-        f"Executed steps (tool names are authoritative — reuse them verbatim):\n{steps_desc}\n"
-        f"{manual_note}"
-    )
+def resolve_root(override: Path | None = None) -> Path:
+    """Return the workflows root (``.vibe/workflows`` unless *override*), migrated.
 
-
-def _parse_prose_response(raw_text: str) -> JsonDict | None:
-    """Extract the prose JSON object from the model reply (strips code fences)."""
-    text = raw_text.strip()
-    if text.startswith("```"):
-        text = re.sub(r"^```[a-zA-Z]*\n?", "", text)
-        text = re.sub(r"\n?```$", "", text).strip()
-    try:
-        parsed = json.loads(text)
-    except json.JSONDecodeError:
-        # Greedy match so nested braces in the markdown body aren't truncated.
-        match = re.search(r"\{.*\}", text, re.DOTALL)
-        if not match:
-            return None
-        try:
-            parsed = json.loads(match.group(0))
-        except json.JSONDecodeError:
-            return None
-    return cast("JsonDict", parsed) if isinstance(parsed, dict) else None
-
-
-def generate_prose(recipe: Recipe, context: str) -> JsonDict | None:
-    """Ask the local model to narrate *recipe*; return prose dict or ``None``.
-
-    Failures are swallowed and reported as ``None`` so distillation can fall
-    back to a mechanical rendering rather than blocking.
+    Every function here that takes a ``workflows_root`` keyword goes through
+    this, so the old ``draft/``/``active/`` layout is folded in before any
+    lookup or write (see :func:`medmcp.workflow.migrate_layout`).
     """
-    prompt = _prose_prompt(recipe, context)
-    try:
-        with httpx.Client(timeout=PROSE_TIMEOUT) as client:
-            resp = client.post(
-                f"{OLLAMA_BASE_URL}/api/chat",
-                json={
-                    "model": OLLAMA_MODEL,
-                    "messages": [{"role": "user", "content": prompt}],
-                    "stream": False,
-                    "think": False,
-                    "options": {"temperature": 0.3, "num_predict": 2048},
-                },
-            )
-            resp.raise_for_status()
-            data = cast("JsonDict", resp.json())
-            message = cast("JsonDict", data.get("message") or {})
-            raw_text = str(message.get("content") or "").strip()
-    except Exception:
-        return None
-    return _parse_prose_response(raw_text)
+    root = override if override is not None else provenance.VIBE_HOME / "workflows"
+    workflow.migrate_layout(root)
+    return root
 
 
-# ── SKILL.md rendering ───────────────────────────────────────────────────────
+def load_recipe(directory: Path) -> Recipe:
+    """Reconstruct a :class:`Recipe` from a workflow directory's ``recipe.yaml``."""
+    return workflow.read_recipe(directory)
 
 
-def _mechanical_steps_markdown(recipe: Recipe) -> str:
-    """Render a plain numbered list of steps when no LLM narrative is available."""
-    lines: list[str] = []
-    for i, step in enumerate(recipe.steps, start=1):
-        args = json.dumps(step.arguments)
-        lines.append(f"{i}. **`{step.server}:{step.tool}`** — `{args}`")
-    return "\n".join(lines) or "_No reusable steps were extracted._"
-
-
-def _required_tools(recipe: Recipe) -> list[tuple[str, str]]:
-    """Return the distinct ``(server, tool)`` pairs the recipe uses, first-seen order."""
-    seen: list[tuple[str, str]] = []
-    for step in recipe.steps:
-        pair = (step.server, step.tool)
-        if pair not in seen:
-            seen.append(pair)
-    return seen
-
-
-def _manual_steps_markdown(recipe: Recipe) -> str:
-    """Render the note about manual (built-in) steps replay can't run, or ``""``."""
-    if not recipe.manual_steps:
-        return ""
-    lines = [
-        "This workflow originally included manual steps using built-in tools that "
-        "the replay engine cannot run automatically. Perform them by hand where the "
-        "pipeline needs them:",
-    ]
-    lines += [f"- `{m}`" for m in recipe.manual_steps]
-    return "\n".join(lines)
-
-
-def _requirements_markdown(recipe: Recipe) -> str:
-    """Render the stacks the workflow needs, pinned for reproducibility.
-
-    Derived from the recipe's ``requires`` (captured at distillation): container
-    stacks show their image (+ digest when resolved), uv-tool stacks their version.
-    """
-    lines: list[str] = []
-    for req in recipe.requires:
-        if req.image:
-            pin = f"image `{req.image}`" + (f" (`{req.digest}`)" if req.digest else "")
-        elif req.version:
-            pin = f"version `{req.version}`"
-        else:
-            pin = ""
-        lines.append(f"- `{req.stack}`" + (f" — {pin}" if pin else ""))
-    return "\n".join(lines)
-
-
-def _tools_markdown(recipe: Recipe) -> str:
-    """Render the explicit list of tools/skills the workflow requires.
-
-    Derived directly from the recipe (not the LLM) so it is always accurate: each
-    line names a ``server:tool`` and the stack it comes from.
-    """
-    lines: list[str] = []
-    for server, tool in _required_tools(recipe):
-        if server == "builtin":
-            lines.append(f"- `{tool}` — built-in tool")
-        else:
-            lines.append(f"- `{server}:{tool}` — from the `{server}` stack")
-    return "\n".join(lines)
-
-
-def render_skill_md(recipe: Recipe, prose: JsonDict | None) -> str:
-    """Render the ``SKILL.md`` document for *recipe* (using *prose* if present)."""
-    description = recipe.description
-    steps_md = _mechanical_steps_markdown(recipe)
-    gotchas_md = ""
-    if prose is not None:
-        description = str(prose.get("description") or description)
-        steps_md = str(prose.get("steps_markdown") or steps_md)
-        gotchas_md = str(prose.get("gotchas_markdown") or "")
-
-    # Always surface dropped manual steps (deterministic), ahead of any LLM gotchas.
-    manual_md = _manual_steps_markdown(recipe)
-    gotchas_md = "\n\n".join(part for part in (manual_md, gotchas_md.strip()) if part)
-
-    title = recipe.name.replace("-", " ").strip().capitalize()
-    parts: list[str] = [
-        "---",
-        f"name: {recipe.name}",
-        f"description: {description}",
-        "---",
-        "",
-        f"# {title} workflow",
-    ]
-    tools_md = _tools_markdown(recipe)
-    if tools_md:
-        parts += ["", "## Tools", "", tools_md]
-    reqs_md = _requirements_markdown(recipe)
-    if reqs_md:
-        parts += ["", "## Requirements", "", reqs_md]
-    parts += ["", "## Steps", "", steps_md]
-    if gotchas_md.strip():
-        parts += ["", "## Gotchas", "", gotchas_md.strip()]
-    if recipe.inputs:
-        parts += ["", "## Inputs", ""]
-        for i in recipe.inputs:
-            desc = f" — {i.description}" if i.description else ""
-            parts.append(f"- `{{{{{i.name}}}}}`{desc} (e.g. `{i.example}`)")
-    return "\n".join(parts).rstrip() + "\n"
-
-
-# ── Draft persistence & editing ──────────────────────────────────────────────
-
-
-def _workflows_root(workflows_root: Path | None) -> Path:
-    """Resolve the workflows root, defaulting to ``.vibe/workflows``."""
-    return workflows_root if workflows_root is not None else provenance.VIBE_HOME / "workflows"
-
-
-def _draft_dir(name: str, workflows_root: Path | None) -> Path:
-    """Return the draft directory for workflow *name*."""
-    return _workflows_root(workflows_root) / "draft" / name
-
-
-def _write_draft(draft_dir: Path, recipe: Recipe, prose: JsonDict | None) -> None:
-    """Write ``recipe.yaml``, ``SKILL.md`` and ``prose.json`` for a draft.
-
-    ``prose.json`` caches the LLM narrative so rename/refine can re-render the
-    ``SKILL.md`` without re-running distillation.
-    """
-    draft_dir.mkdir(parents=True, exist_ok=True)
-    recipe_yaml = yaml.safe_dump(recipe.to_dict(), sort_keys=False, allow_unicode=True)
-    (draft_dir / "recipe.yaml").write_text(recipe_yaml, encoding="utf-8")
-    (draft_dir / "SKILL.md").write_text(render_skill_md(recipe, prose), encoding="utf-8")
-    (draft_dir / "prose.json").write_text(
-        json.dumps(prose) if prose is not None else "null", encoding="utf-8"
-    )
-
-
-def _read_prose(draft_dir: Path) -> JsonDict | None:
-    """Read the cached prose for a draft, or ``None`` if absent/mechanical."""
-    path = draft_dir / "prose.json"
-    if not path.exists():
-        return None
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
-        return None
-    return cast("JsonDict", data) if isinstance(data, dict) else None
-
-
-def load_recipe(draft_dir: Path) -> Recipe:
-    """Reconstruct a :class:`Recipe` from a draft's ``recipe.yaml``."""
-    data = cast("JsonDict", yaml.safe_load((draft_dir / "recipe.yaml").read_text(encoding="utf-8")))
-    inputs = [
-        WorkflowInput(
-            name=str(i.get("name", "")),
-            example=str(i.get("example", "")),
-            description=str(i.get("description", "")),
-            default=str(i.get("default", "")),
-        )
-        for i in cast("list[JsonDict]", data.get("inputs", []))
-    ]
-    steps = [
-        RecipeStep(
-            server=str(s.get("server", "")),
-            tool=str(s.get("tool", "")),
-            arguments=cast("JsonDict", s.get("arguments", {})),
-            produces=cast("dict[str, str]", s.get("produces", {})),
-        )
-        for s in cast("list[JsonDict]", data.get("steps", []))
-    ]
-    requires = [
-        StackRequirement(
-            stack=str(r.get("stack", "")),
-            version=str(r.get("version", "")),
-            image=str(r.get("image", "")),
-            digest=str(r.get("digest", "")),
-        )
-        for r in cast("list[JsonDict]", data.get("requires", []))
-    ]
-    manual_steps = [str(m) for m in cast("list[Any]", data.get("manual_steps", []))]
-    return Recipe(
-        name=str(data.get("name", "")),
-        description=str(data.get("description", "")),
-        inputs=inputs,
-        steps=steps,
-        requires=requires,
-        manual_steps=manual_steps,
-    )
+def _require_dir(name: str, root: Path) -> Path:
+    """Return workflow *name*'s directory under *root* or raise ``FileNotFoundError``."""
+    d = workflow.workflow_dir(root, name)
+    if d is None:
+        raise FileNotFoundError(f"no workflow named {name!r} (looked in {root})")
+    return d
 
 
 # ── Top-level distillation ───────────────────────────────────────────────────
@@ -690,19 +419,23 @@ def load_recipe(draft_dir: Path) -> Recipe:
 def distill_session(
     session_id: str,
     *,
-    use_llm: bool = True,
+    name_hint: str = "",
     workflows_root: Path | None = None,
     chain_stop_ids: Collection[str] = (),
 ) -> Path:
-    """Distill *session_id* into a draft workflow directory and return its path.
+    """Distill *session_id* into a workflow directory and return its path.
 
     Reads the session's ``messages.jsonl`` — concatenated across the session's
     compaction chain (vibe rolls a compacted conversation over to a new dir;
     see :func:`provenance.find_vibe_session_dirs`), so tool calls made after a
     compaction distill too — ``chain_stop_ids`` keeps the walk out of forks
-    (pass the UI session registry's ids) — builds a parameterized recipe, adds a (hybrid)
-    prose narrative, and writes ``recipe.yaml`` + ``SKILL.md`` into
-    ``<workflows_root>/draft/<name>/`` for human review.
+    (pass the UI session registry's ids) — builds a parameterized recipe and
+    writes it as ``<workflows_root>/<name>/recipe.yaml``.
+
+    The workflow is named from *name_hint* — the chat's title, which the caller
+    looks up — falling back to the request that opened the chat; that request
+    is also the description. A name already in use gets a numeric suffix rather
+    than replacing another workflow.
 
     Raises ``FileNotFoundError`` if the session's raw log cannot be located.
     """
@@ -722,126 +455,53 @@ def distill_session(
     )
 
     context = _first_user_message(messages)
-    fallback_name = slugify(context) if context else f"workflow-{session_id[:8]}"
+    if name_hint.strip():
+        base = slugify(name_hint)
+    elif context:
+        base = slugify(context)
+    else:
+        base = f"workflow-{session_id[:8]}"
     recipe = build_recipe(
         messages,
         server_names=server_names,
-        name=fallback_name,
+        name=base,
         description=context[:120] if context else "Distilled MedMCP workflow",
     )
-
     recipe.requires = build_requirements(recipe, manifest)
 
-    prose = generate_prose(recipe, context) if use_llm else None
-    if prose is not None and isinstance(prose.get("name"), str):
-        recipe.name = slugify(str(prose["name"]))
-        recipe.description = str(prose.get("description") or recipe.description)
-
-    draft_dir = _draft_dir(recipe.name, workflows_root)
-    _write_draft(draft_dir, recipe, prose)
-    return draft_dir
-
-
-def promote_draft(name: str, *, workflows_root: Path | None = None) -> Path:
-    """Move draft workflow *name* into ``active/`` and return the new path.
-
-    Promotion marks the workflow as reviewed and worth keeping; both directories
-    are replayable, and neither is loaded as a skill. Raises ``FileNotFoundError``
-    if no such draft exists.
-    """
-    src = _draft_dir(name, workflows_root)
-    if not (src / "SKILL.md").exists():
-        raise FileNotFoundError(f"no draft workflow named {name!r} (looked in {src})")
-    dst = _workflows_root(workflows_root) / "active" / name
-    dst.parent.mkdir(parents=True, exist_ok=True)
-    if dst.exists():
-        shutil.rmtree(dst)
-    shutil.move(str(src), str(dst))
-    return dst
-
-
-def unpromote_workflow(name: str, *, workflows_root: Path | None = None) -> Path:
-    """Move a promoted workflow from ``active/`` back to ``draft/`` for editing.
-
-    The inverse of :func:`promote_draft`: it returns the workflow to the draft
-    state so it can be renamed/refined/re-tested, then promoted again. Returns the
-    draft path. Raises ``FileNotFoundError`` if no promoted workflow has that name.
-    """
-    src = _workflows_root(workflows_root) / "active" / name
-    if not (src / "SKILL.md").exists():
-        raise FileNotFoundError(f"no promoted workflow named {name!r} (looked in {src})")
-    dst = _draft_dir(name, workflows_root)
-    dst.parent.mkdir(parents=True, exist_ok=True)
-    if dst.exists():
-        shutil.rmtree(dst)
-    shutil.move(str(src), str(dst))
-    return dst
-
-
-def discard_draft(name: str, *, workflows_root: Path | None = None) -> None:
-    """Delete a draft workflow. Raises ``FileNotFoundError`` if it doesn't exist."""
-    src = _draft_dir(name, workflows_root)
-    if not (src / "SKILL.md").exists():
-        raise FileNotFoundError(f"no draft workflow named {name!r} (looked in {src})")
-    shutil.rmtree(src)
+    root = resolve_root(workflows_root)
+    recipe.name = workflow.unique_name(root, base)
+    target = root / recipe.name
+    workflow.write_recipe(target, recipe)
+    return target
 
 
 def delete_workflow(name: str, *, workflows_root: Path | None = None) -> Path:
-    """Delete a personal workflow by *name* from ``active/`` or ``draft/``.
+    """Delete workflow *name*; return the directory that was removed.
 
-    Returns the directory that was removed. Raises ``FileNotFoundError`` if no
-    workflow with that name exists in either location.
+    Raises ``FileNotFoundError`` if no workflow with that name exists.
     """
-    root = _workflows_root(workflows_root)
-    for kind in ("active", "draft"):
-        target = root / kind / name
-        if (target / "SKILL.md").exists():
-            shutil.rmtree(target)
-            return target
-    raise FileNotFoundError(f"no workflow named {name!r} in {root}")
+    target = _require_dir(name, resolve_root(workflows_root))
+    shutil.rmtree(target)
+    return target
 
 
-def rename_draft(name: str, new_name: str, *, workflows_root: Path | None = None) -> Path:
-    """Rename a draft workflow (its name, files, and directory). Returns the new dir."""
-    src = _draft_dir(name, workflows_root)
-    if not (src / "SKILL.md").exists():
-        raise FileNotFoundError(f"no draft workflow named {name!r} (looked in {src})")
+def rename_workflow(name: str, new_name: str, *, workflows_root: Path | None = None) -> Path:
+    """Rename a workflow (its name in the recipe and its directory); return the new dir.
+
+    Raises ``FileNotFoundError`` if *name* does not exist and ``FileExistsError``
+    if the slug of *new_name* already belongs to another workflow — a rename
+    never replaces one.
+    """
+    root = resolve_root(workflows_root)
+    src = _require_dir(name, root)
     new_slug = slugify(new_name)
+    dst = root / new_slug
+    if dst != src and dst.exists():
+        raise FileExistsError(f"a workflow named {new_slug!r} already exists")
     recipe = load_recipe(src)
     recipe.name = new_slug
-    prose = _read_prose(src)
-    if prose is not None:
-        prose["name"] = new_slug
-    # Rewrite in place (so name fields update), then relocate if the slug changed.
-    _write_draft(src, recipe, prose)
-    dst = src.parent / new_slug
+    workflow.write_recipe(src, recipe)
     if dst != src:
-        if dst.exists():
-            shutil.rmtree(dst)
         shutil.move(str(src), str(dst))
     return dst
-
-
-def refine_draft(name: str, instruction: str, *, workflows_root: Path | None = None) -> Path:
-    """Regenerate a draft's narrative from a plain-language *instruction*.
-
-    Re-runs the prose model with the user's instruction, keeping the workflow's
-    identity (name) and step recipe unchanged. Raises ``FileNotFoundError`` if the
-    draft is missing, or ``RuntimeError`` if the model returns nothing.
-    """
-    src = _draft_dir(name, workflows_root)
-    if not (src / "SKILL.md").exists():
-        raise FileNotFoundError(f"no draft workflow named {name!r} (looked in {src})")
-    recipe = load_recipe(src)
-    context = (
-        f"Current workflow description: {recipe.description}\n"
-        f"Revise the workflow per this instruction: {instruction}"
-    )
-    prose = generate_prose(recipe, context)
-    if prose is None:
-        raise RuntimeError("the model did not return a refined workflow")
-    # Refine content only; keep the existing name/identity.
-    prose["name"] = recipe.name
-    recipe.description = str(prose.get("description") or recipe.description)
-    _write_draft(src, recipe, prose)
-    return src

--- a/src/medmcp/provcli.py
+++ b/src/medmcp/provcli.py
@@ -4,15 +4,13 @@ Exposed as the ``medmcp`` console script::
 
     medmcp list                 # list sessions with a provenance record
     medmcp report  <session>    # (re)render report.md and print its path
-    medmcp distill <session>    # distill a draft workflow from the raw log
-    medmcp distill <session> --no-llm   # skip the LLM narrative pass
-    medmcp promote <name>       # move a reviewed draft into active/ (reusable)
+    medmcp distill <session>    # save a replayable workflow from the raw log
     medmcp replay  <name> -i in_1=path ...       # replay a workflow on new inputs
     medmcp replay  <name> --batch batch_plan.csv # roll it out over a cohort manifest
-    medmcp workflows            # list personal workflows (draft + promoted)
-    medmcp delete   <name>      # delete a personal workflow (draft or active)
+    medmcp workflows            # list personal workflows
+    medmcp delete   <name>      # delete a personal workflow
     medmcp export   <name>      # write a shareable <name>.workflow.yaml
-    medmcp import   <file>      # import a shared workflow file as a draft
+    medmcp import   <file>      # import a shared workflow file
 """
 
 from __future__ import annotations
@@ -23,7 +21,7 @@ import os
 import sys
 from pathlib import Path
 
-from medmcp import batchplan, distill, provenance, share
+from medmcp import batchplan, distill, provenance, sessions, share, workflow
 
 
 def _list_sessions() -> int:
@@ -54,27 +52,17 @@ def _report(session_id: str, *, to_stdout: bool) -> int:
     return 0
 
 
-def _distill(session_id: str, *, use_llm: bool) -> int:
-    """Distill a draft workflow for *session_id*."""
+def _distill(session_id: str) -> int:
+    """Save a replayable workflow for *session_id*, named after the chat."""
     try:
-        draft_dir = distill.distill_session(session_id, use_llm=use_llm)
+        target = distill.distill_session(
+            session_id, name_hint=sessions.chat_title(session_id) or ""
+        )
     except FileNotFoundError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
-    print(f"Draft workflow written to: {draft_dir}")
-    print("Review and edit it, then promote it to keep it.")
-    return 0
-
-
-def _promote(name: str) -> int:
-    """Move a reviewed draft workflow into ``active/``."""
-    try:
-        dst = distill.promote_draft(name)
-    except FileNotFoundError as exc:
-        print(f"error: {exc}", file=sys.stderr)
-        return 1
-    print(f"Promoted workflow to: {dst}")
-    print("Run it from the workspace UI's workflow panel.")
+    print(f"Workflow written to: {target}")
+    print(f"Run it from the workspace UI's workflow panel or `medmcp replay {target.name}`.")
     return 0
 
 
@@ -90,13 +78,8 @@ def _parse_bindings(pairs: list[str]) -> dict[str, str]:
 
 
 def _workflow_dir(name: str) -> Path | None:
-    """Resolve a workflow name to its recipe directory (active first, then draft)."""
-    root = provenance.VIBE_HOME / "workflows"
-    for kind in ("active", "draft"):
-        candidate = root / kind / name
-        if (candidate / "recipe.yaml").exists():
-            return candidate
-    return None
+    """Resolve a workflow name to its recipe directory."""
+    return workflow.workflow_dir(distill.resolve_root(), name)
 
 
 def _replay(
@@ -166,23 +149,16 @@ def _replay(
 
 def _list_workflows() -> int:
     """Print personal workflows discovered under ``.vibe/workflows/``."""
-    root = provenance.VIBE_HOME / "workflows"
-    found = False
-    for kind in ("active", "draft"):
-        base = root / kind
-        if not base.is_dir():
-            continue
-        for d in sorted(base.iterdir()):
-            if (d / "SKILL.md").exists():
-                found = True
-                print(f"{d.name}\t{kind}")
-    if not found:
+    rows = workflow.list_workflows(distill.resolve_root())
+    for row in rows:
+        print(f"{row['name']}\t{row['description']}")
+    if not rows:
         print("No personal workflows found.", file=sys.stderr)
     return 0
 
 
 def _delete(name: str) -> int:
-    """Delete a personal workflow (from active/ or draft/) by name."""
+    """Delete a personal workflow by name."""
     try:
         removed = distill.delete_workflow(name)
     except FileNotFoundError as exc:
@@ -206,7 +182,7 @@ def _export(name: str, out: str | None) -> int:
 
 
 def _import(path: str) -> int:
-    """Import a shared workflow file as a reviewable draft."""
+    """Import a shared workflow file as a new workflow."""
     try:
         text = Path(path).read_text(encoding="utf-8")
     except OSError as exc:
@@ -217,8 +193,7 @@ def _import(path: str) -> int:
     except share.WorkflowShareError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
-    print(f"Imported workflow as draft: {draft}")
-    print("Review it, then promote it to reuse.")
+    print(f"Imported workflow: {draft}")
     return 0
 
 
@@ -235,14 +210,8 @@ def main(argv: list[str] | None = None) -> int:
         "--print", dest="to_stdout", action="store_true", help="print to stdout instead of writing"
     )
 
-    distill_p = sub.add_parser("distill", help="distill a reusable workflow from a session")
+    distill_p = sub.add_parser("distill", help="save a replayable workflow from a session")
     distill_p.add_argument("session_id")
-    distill_p.add_argument(
-        "--no-llm", dest="use_llm", action="store_false", help="skip the LLM narrative pass"
-    )
-
-    promote_p = sub.add_parser("promote", help="move a reviewed draft workflow into active/")
-    promote_p.add_argument("name")
 
     replay_p = sub.add_parser("replay", help="replay a workflow on new inputs (single or batch)")
     replay_p.add_argument("name")
@@ -267,7 +236,7 @@ def main(argv: list[str] | None = None) -> int:
         help="explicit recipe-input -> manifest-column mapping (repeatable)",
     )
 
-    sub.add_parser("workflows", help="list personal workflows (draft + promoted)")
+    sub.add_parser("workflows", help="list personal workflows")
 
     delete_p = sub.add_parser("delete", help="delete a personal workflow by name")
     delete_p.add_argument("name")
@@ -276,7 +245,7 @@ def main(argv: list[str] | None = None) -> int:
     export_p.add_argument("name")
     export_p.add_argument("--out", help="output path (default <name>.workflow.yaml)")
 
-    import_p = sub.add_parser("import", help="import a shared workflow file as a draft")
+    import_p = sub.add_parser("import", help="import a shared workflow file")
     import_p.add_argument("file")
 
     args = parser.parse_args(argv)
@@ -285,9 +254,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "report":
         return _report(args.session_id, to_stdout=args.to_stdout)
     if args.command == "distill":
-        return _distill(args.session_id, use_llm=args.use_llm)
-    if args.command == "promote":
-        return _promote(args.name)
+        return _distill(args.session_id)
     if args.command == "replay":
         try:
             inputs = _parse_bindings(args.input)

--- a/src/medmcp/replay.py
+++ b/src/medmcp/replay.py
@@ -43,6 +43,9 @@ JsonDict = dict[str, Any]
 # A callable that runs one tool and returns (ok, structured_output, error_text).
 ToolCaller = Callable[[str, str, JsonDict], Awaitable[tuple[bool, JsonDict, "str | None"]]]
 
+# Notified just before a step's tool is called: ``(step_index, server, tool)``.
+StepStartHook = Callable[[int, str, str], Awaitable[None]]
+
 _PLACEHOLDER_RE = re.compile(r"\{\{([^{}]+)\}\}")
 # A derived reference: ``{{dir(<ref>)}}`` is the directory holding whatever
 # ``<ref>`` resolves to. Distillation emits these instead of declaring a second
@@ -389,11 +392,14 @@ async def replay_with_caller(
     *,
     caller: ToolCaller,
     on_step: Callable[[StepResult], Awaitable[None]] | None = None,
+    on_step_start: StepStartHook | None = None,
 ) -> ReplayResult:
     """Execute *recipe* step-by-step using *caller*; abort on the first failure.
 
     *inputs* maps placeholder names (``in_1`` …) to concrete values. Outputs a
     step produces are captured and bound as ``{{stepM.<key>}}`` for later steps.
+    ``on_step_start`` fires just before each tool call, so a caller can show
+    which step is in flight.
     """
     # Defaults are filled here, the one place every replay path funnels through
     # (single run and each batch item alike), so no caller can forget them.
@@ -419,6 +425,8 @@ async def replay_with_caller(
                 await on_step(step_result)
             break
 
+        if on_step_start is not None:
+            await on_step_start(index, step.server, step.tool)
         try:
             ok, structured, error = await caller(step.server, step.tool, args)
         except Exception as exc:
@@ -490,6 +498,7 @@ async def run_batch(
     tool_timeout_sec: float = DEFAULT_TOOL_TIMEOUT_SEC,
     on_step: Callable[[int, StepResult], Awaitable[None]] | None = None,
     on_item: Callable[[int, ReplayResult], Awaitable[None]] | None = None,
+    on_step_start: Callable[[int, int, str, str], Awaitable[None]] | None = None,
 ) -> list[ReplayResult]:
     """Replay *recipe* once per input binding in *runs*, sharing one set of stacks.
 
@@ -504,7 +513,9 @@ async def run_batch(
 
     The MCP servers are shared across items for speed, but one that crashes is
     re-spawned for the next item (see :func:`mcp_caller`), so a single failure does
-    not cascade to the rest of the batch.
+    not cascade to the rest of the batch. ``on_step_start`` fires as
+    ``(item, step_index, server, tool)`` just before a tool is called, so a caller
+    can show which step is in flight.
     """
     pre = [validate(recipe, inputs, servers) for inputs in runs]
     results: list[ReplayResult] = []
@@ -532,7 +543,17 @@ async def run_batch(
                     if on_step is not None:
                         await on_step(_item, sr)
 
-                res = await replay_with_caller(recipe, inputs, caller=caller, on_step=_step)
+                async def _start(index: int, server: str, tool: str, _item: int = item) -> None:
+                    if on_step_start is not None:
+                        await on_step_start(_item, index, server, tool)
+
+                res = await replay_with_caller(
+                    recipe,
+                    inputs,
+                    caller=caller,
+                    on_step=_step,
+                    on_step_start=_start,
+                )
                 await _emit(item, res)
     except ReplayError as exc:
         # Engine-level failure mid-batch (e.g. a stack teardown error): fail the

--- a/src/medmcp/runs.py
+++ b/src/medmcp/runs.py
@@ -1,0 +1,644 @@
+"""Replay runs that outlive the browser: a record on disk, a task in the server.
+
+Before this module a replay lived and died with its WebSocket: the socket *was*
+the run, so a page reload, a laptop lid, or a flaky proxy aborted a two-hour
+cohort roll-out at whatever step it was on, and the only trace afterwards was
+whatever the browser still had in memory. That is the wrong shape for imaging
+pipelines, where a single step can take ten minutes and a batch an afternoon.
+
+A run is now a first-class thing with an id:
+
+- :class:`RunRecord` is the durable form — one JSON file per run under
+  ``.vibe/runs/`` (the same atomic-write discipline as the other state files),
+  updated after every step so a crash mid-run leaves an honest partial record.
+- :class:`RunManager` owns the live ones. It starts a run as a background task,
+  fans its progress frames out to any number of attached sockets, and keeps
+  running when the last one goes away. Stopping is an explicit request, never a
+  side effect of a disconnect.
+
+The record's frames are reconstructible from the record itself
+(:meth:`RunRecord.frames`), so attaching to a finished run and attaching to a
+live one look identical to the client.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import os
+import secrets
+import tempfile
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, cast
+
+from medmcp import replay
+from medmcp.acp import VIBE_HOME
+from medmcp.workflow import Recipe
+
+JsonDict = dict[str, Any]
+
+log = logging.getLogger(__name__)
+
+RUNS_DIR: Path = VIBE_HOME / "runs"
+
+RunStatus = str  # "running" | "done" | "failed" | "cancelled"
+
+# How many output files an item reports at most (a prefix can fan out).
+OUTPUT_FILES_LIMIT: int = 24
+
+
+def _now_iso() -> str:
+    # Full precision: a step's finish time is compared against file mtimes, and a
+    # second-resolution stamp would call an input written in the same second
+    # "newer than the step" and throw away a perfectly good cache entry.
+    return datetime.now(UTC).isoformat(timespec="microseconds")
+
+
+def _iso_to_ts(value: str) -> float:
+    """Epoch seconds for an ISO timestamp we wrote; 0 for anything unparsable."""
+    try:
+        return datetime.fromisoformat(value).timestamp()
+    except ValueError:
+        return 0.0
+
+
+def new_run_id() -> str:
+    """A run id that sorts chronologically and cannot collide within a second."""
+    return f"{datetime.now(UTC).strftime('%Y%m%d-%H%M%S')}-{secrets.token_hex(3)}"
+
+
+# ── The durable record ───────────────────────────────────────────────────────
+
+
+@dataclass
+class StepRecord:
+    """One executed step of one item."""
+
+    index: int
+    server: str
+    tool: str
+    arguments: JsonDict
+    ok: bool
+    error: str | None = None
+    produced: dict[str, str] = field(default_factory=dict[str, str])
+    started_at: str = ""
+    finished_at: str = ""
+
+    def to_dict(self) -> JsonDict:
+        """Plain-dict form for the JSON record."""
+        return {
+            "index": self.index,
+            "server": self.server,
+            "tool": self.tool,
+            "arguments": self.arguments,
+            "ok": self.ok,
+            "error": self.error,
+            "produced": self.produced,
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+        }
+
+    @classmethod
+    def from_dict(cls, data: JsonDict) -> StepRecord:
+        """Rebuild from the JSON record; missing fields take their defaults."""
+        produced = cast("JsonDict", data.get("produced") or {})
+        return cls(
+            index=int(data.get("index", 0)),
+            server=str(data.get("server", "")),
+            tool=str(data.get("tool", "")),
+            arguments=cast("JsonDict", data.get("arguments") or {}),
+            ok=bool(data.get("ok", False)),
+            error=cast("str | None", data.get("error")),
+            produced={str(k): str(v) for k, v in produced.items()},
+            started_at=str(data.get("started_at", "")),
+            finished_at=str(data.get("finished_at", "")),
+        )
+
+
+@dataclass
+class ItemRecord:
+    """One input binding of a run and what happened to it."""
+
+    inputs: dict[str, str]
+    ok: bool | None = None
+    """``None`` until the item has finished (still running, or never reached)."""
+    error: str | None = None
+    steps: list[StepRecord] = field(default_factory=list[StepRecord])
+
+    @property
+    def outputs(self) -> list[str]:
+        """Every value the item's steps produced, in step order (raw, for chaining)."""
+        return [v for s in self.steps for v in s.produced.values()]
+
+    def files(self, *, limit: int = OUTPUT_FILES_LIMIT) -> list[str]:
+        """The output *files* the item left behind — what a person wants to open.
+
+        A tool's structured result names more than its outputs: it echoes its
+        inputs, returns a template it read, or a *prefix* several files hang
+        off. All of those are worth recording for chaining, none are files to
+        open, so this keeps only produced values that are not one of the step's
+        own arguments and that exist on disk as a file — and expands a prefix
+        to the files it names, so a registration's transforms show up under it.
+        """
+        out: list[str] = []
+        seen: set[str] = set()
+        for step in self.steps:
+            inputs = set(_string_values(step.arguments))
+            for value in step.produced.values():
+                if value in inputs or not value:
+                    continue
+                for path in _files_for(value):
+                    if path not in seen:
+                        seen.add(path)
+                        out.append(path)
+                    if len(out) >= limit:
+                        return out
+        return out
+
+    def to_dict(self) -> JsonDict:
+        """Plain-dict form for the JSON record."""
+        return {
+            "inputs": self.inputs,
+            "ok": self.ok,
+            "error": self.error,
+            "steps": [s.to_dict() for s in self.steps],
+        }
+
+    @classmethod
+    def from_dict(cls, data: JsonDict) -> ItemRecord:
+        """Rebuild from the JSON record."""
+        inputs = cast("JsonDict", data.get("inputs") or {})
+        steps = cast("list[JsonDict]", data.get("steps") or [])
+        return cls(
+            inputs={str(k): str(v) for k, v in inputs.items()},
+            ok=cast("bool | None", data.get("ok")),
+            error=cast("str | None", data.get("error")),
+            steps=[StepRecord.from_dict(s) for s in steps],
+        )
+
+
+@dataclass
+class RunRecord:
+    """A replay run: which workflow, on which inputs, and how far it got."""
+
+    id: str
+    workflow: str
+    steps_per_item: int
+    items: list[ItemRecord]
+    status: RunStatus = "running"
+    started_at: str = field(default_factory=_now_iso)
+    finished_at: str = ""
+    error: str | None = None
+
+    @property
+    def finished(self) -> bool:
+        """Whether the run has reached a terminal status."""
+        return self.status != "running"
+
+    def summary(self) -> JsonDict:
+        """The list-view shape: counts and times, no per-step detail."""
+        done = [i for i in self.items if i.ok is not None]
+        return {
+            "id": self.id,
+            "workflow": self.workflow,
+            "status": self.status,
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "error": self.error,
+            "total": len(self.items),
+            "succeeded": sum(1 for i in done if i.ok),
+            "failed": sum(1 for i in done if not i.ok),
+            "steps_per_item": self.steps_per_item,
+        }
+
+    def to_dict(self) -> JsonDict:
+        """The full JSON record: the summary plus every item and step."""
+        return {
+            **self.summary(),
+            "items": [i.to_dict() for i in self.items],
+        }
+
+    @classmethod
+    def from_dict(cls, data: JsonDict) -> RunRecord:
+        """Rebuild from the JSON record."""
+        items = cast("list[JsonDict]", data.get("items") or [])
+        return cls(
+            id=str(data.get("id", "")),
+            workflow=str(data.get("workflow", "")),
+            steps_per_item=int(data.get("steps_per_item", 0)),
+            items=[ItemRecord.from_dict(i) for i in items],
+            status=str(data.get("status", "running")),
+            started_at=str(data.get("started_at", "")),
+            finished_at=str(data.get("finished_at", "")),
+            error=cast("str | None", data.get("error")),
+        )
+
+    def frames(self) -> list[JsonDict]:
+        """The streaming frames a client attached from the start would have seen.
+
+        Derived from the record rather than logged separately, so there is one
+        source of truth and a finished run can be "attached" exactly like a live
+        one.
+        """
+        out: list[JsonDict] = [
+            {
+                "type": "started",
+                "run_id": self.id,
+                "workflow": self.workflow,
+                "total": len(self.items),
+                "steps_per_item": self.steps_per_item,
+                "started_at": self.started_at,
+                "runs": [i.inputs for i in self.items],
+            }
+        ]
+        for index, item in enumerate(self.items):
+            for step in item.steps:
+                out.append(step_frame(index, step))
+            if item.ok is not None:
+                out.append(item_frame(index, item))
+        if self.finished:
+            out.append(self.result_frame())
+        return out
+
+    def result_frame(self) -> JsonDict:
+        """The terminal frame (``ok`` only for a run where every item succeeded)."""
+        return {
+            "type": "result",
+            "status": self.status,
+            "ok": self.status == "done",
+            "error": self.error,
+            "outputs": [v for i in self.items for v in i.files()],
+            "finished_at": self.finished_at,
+        }
+
+
+def _string_values(value: object) -> list[str]:
+    """Every string anywhere inside a (possibly nested) argument value."""
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, dict):
+        return [s for v in cast("JsonDict", value).values() for s in _string_values(v)]
+    if isinstance(value, list):
+        return [s for v in cast("list[Any]", value) for s in _string_values(v)]
+    return []
+
+
+def _files_for(value: str) -> list[str]:
+    """The files a produced value stands for: itself, or what a prefix expands to."""
+    try:
+        path = Path(value)
+        if path.is_file():
+            return [value]
+        if path.is_dir() or not path.parent.is_dir():
+            return []
+        matches = sorted(p for p in path.parent.glob(f"{path.name}*") if p.is_file())
+        return [str(p) for p in matches]
+    except OSError:
+        return []
+
+
+def step_frame(item: int, step: StepRecord) -> JsonDict:
+    """The ``step`` frame for one finished step of *item*."""
+    return {
+        "type": "step",
+        "item": item,
+        "index": step.index,
+        "server": step.server,
+        "tool": step.tool,
+        "ok": step.ok,
+        "error": step.error,
+        "produced": step.produced,
+        "started_at": step.started_at,
+        "finished_at": step.finished_at,
+    }
+
+
+def item_frame(index: int, item: ItemRecord) -> JsonDict:
+    """The ``item_result`` frame for a finished item."""
+    return {
+        "type": "item_result",
+        "item": index,
+        "ok": bool(item.ok),
+        "error": item.error,
+        "outputs": item.files(),
+    }
+
+
+# ── Storage ──────────────────────────────────────────────────────────────────
+
+
+def _runs_root(root: Path | None) -> Path:
+    return root if root is not None else RUNS_DIR
+
+
+def run_path(run_id: str, *, root: Path | None = None) -> Path:
+    """Where *run_id*'s record lives."""
+    return _runs_root(root) / f"{run_id}.json"
+
+
+def save_run(record: RunRecord, *, root: Path | None = None) -> None:
+    """Write the record atomically (a reader never sees a half-written file)."""
+    path = run_path(record.id, root=root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(record.to_dict(), fh)
+        os.replace(tmp_name, path)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_name)
+        raise
+
+
+def load_run(run_id: str, *, root: Path | None = None) -> RunRecord | None:
+    """Read one record; ``None`` when absent or unreadable."""
+    path = run_path(run_id, root=root)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return RunRecord.from_dict(cast("JsonDict", data)) if isinstance(data, dict) else None
+
+
+def list_runs(
+    *, workflow: str | None = None, limit: int = 50, root: Path | None = None
+) -> list[RunRecord]:
+    """Past and present runs, newest first; unreadable files are skipped."""
+    base = _runs_root(root)
+    if not base.is_dir():
+        return []
+    out: list[RunRecord] = []
+    for path in sorted(base.glob("*.json"), reverse=True):
+        record = load_run(path.stem, root=root)
+        if record is None or (workflow is not None and record.workflow != workflow):
+            continue
+        out.append(record)
+        if len(out) >= limit:
+            break
+    return out
+
+
+def delete_run(run_id: str, *, root: Path | None = None) -> bool:
+    """Remove a record; ``False`` when there was none."""
+    try:
+        run_path(run_id, root=root).unlink()
+    except FileNotFoundError:
+        return False
+    return True
+
+
+def reconcile_interrupted(*, root: Path | None = None) -> int:
+    """Mark runs left ``running`` by a previous server process as failed.
+
+    A record is only ``running`` while a task in *this* process drives it; on
+    start-up there is none, so any such record was cut off by a crash or a
+    restart. Left alone it would look live forever. Returns how many were fixed.
+    """
+    fixed = 0
+    for record in list_runs(limit=10_000, root=root):
+        if record.status != "running":
+            continue
+        record.status = "failed"
+        record.error = "interrupted: the workspace server stopped while it was running"
+        record.finished_at = record.finished_at or _now_iso()
+        for item in record.items:
+            if item.ok is None and item.steps:
+                item.ok = False
+                item.error = record.error
+        save_run(record, root=root)
+        fixed += 1
+    return fixed
+
+
+# ── Live runs ────────────────────────────────────────────────────────────────
+
+Frame = JsonDict
+_END: Frame = {}  # sentinel put on a subscriber queue when the run is over
+
+
+@dataclass
+class _LiveRun:
+    record: RunRecord
+    task: asyncio.Task[None]
+    frames: list[Frame] = field(default_factory=list[Frame])
+    subscribers: set[asyncio.Queue[Frame]] = field(default_factory=set["asyncio.Queue[Frame]"])
+    # The step currently being executed, if any: (item, index, server, tool,
+    # started_at) — the time travels with it so a late attach shows the real
+    # elapsed time of the step, not the time since attaching.
+    current: tuple[int, int, str, str, str] | None = None
+
+
+class RunManager:
+    """Owns the runs in flight in this process and fans their frames out.
+
+    The manager is deliberately thin over :func:`medmcp.replay.run_batch`: it
+    adds identity (a run id), durability (the record is saved after every step)
+    and detachment (sockets subscribe and unsubscribe; the task neither knows nor
+    cares). Callers must still do the confirmation the engine's docstring asks
+    for — nothing here adds a permission prompt.
+    """
+
+    def __init__(self, *, root: Path | None = None) -> None:
+        """Create an empty manager; *root* overrides the records directory (tests)."""
+        self._root = root
+        self._live: dict[str, _LiveRun] = {}
+
+    # ── lifecycle ──
+
+    def start(
+        self,
+        *,
+        recipe: Recipe,
+        runs: list[dict[str, str]],
+        servers: list[JsonDict],
+        cwd: str | None,
+        tool_timeout_sec: float = replay.DEFAULT_TOOL_TIMEOUT_SEC,
+        on_finished: Callable[[RunRecord], None] | None = None,
+    ) -> RunRecord:
+        """Begin a run as a background task and return its (already saved) record."""
+        record = RunRecord(
+            id=new_run_id(),
+            workflow=recipe.name,
+            steps_per_item=len(recipe.steps),
+            items=[ItemRecord(inputs=dict(r)) for r in runs],
+        )
+        save_run(record, root=self._root)
+        live = _LiveRun(record=record, task=cast("asyncio.Task[None]", None))
+        live.frames.append(record.frames()[0])  # the "started" frame
+        self._live[record.id] = live
+        live.task = asyncio.create_task(
+            self._execute(live, recipe, runs, servers, cwd, tool_timeout_sec, on_finished),
+            name=f"replay-run-{record.id}",
+        )
+        return record
+
+    async def _execute(
+        self,
+        live: _LiveRun,
+        recipe: Recipe,
+        runs: list[dict[str, str]],
+        servers: list[JsonDict],
+        cwd: str | None,
+        tool_timeout_sec: float,
+        on_finished: Callable[[RunRecord], None] | None,
+    ) -> None:
+        record = live.record
+
+        async def _on_step_start(item: int, index: int, server: str, tool: str) -> None:
+            live.current = (item, index, server, tool, _now_iso())
+            self._broadcast(live, _step_started_frame(*live.current))
+
+        async def _on_step(item: int, sr: replay.StepResult) -> None:
+            started = live.current[4] if live.current is not None else ""
+            live.current = None
+            step = StepRecord(
+                index=sr.index,
+                server=sr.server,
+                tool=sr.tool,
+                arguments=sr.arguments,
+                ok=sr.ok,
+                error=sr.error,
+                produced=dict(sr.produced),
+                started_at=started,
+                finished_at=_now_iso(),
+            )
+            record.items[item].steps.append(step)
+            self._save(record)
+            self._broadcast(live, step_frame(item, step))
+
+        async def _on_item(item: int, res: replay.ReplayResult) -> None:
+            entry = record.items[item]
+            entry.ok = res.ok
+            entry.error = res.error
+            self._save(record)
+            self._broadcast(live, item_frame(item, entry))
+
+        try:
+            results = await replay.run_batch(
+                recipe,
+                runs,
+                servers=servers,
+                cwd=cwd,
+                tool_timeout_sec=tool_timeout_sec,
+                on_step=_on_step,
+                on_item=_on_item,
+                on_step_start=_on_step_start,
+            )
+            failed = sum(1 for r in results if not r.ok)
+            record.status = "done" if failed == 0 else "failed"
+            record.error = None if failed == 0 else f"{failed} of {len(runs)} item(s) failed"
+        except asyncio.CancelledError:
+            record.status = "cancelled"
+            record.error = "stopped"
+            for entry in record.items:
+                if entry.ok is None and entry.steps:
+                    entry.ok = False
+                    entry.error = "stopped"
+            raise
+        except Exception as exc:  # an engine bug must still leave an honest record
+            log.exception("replay run %s crashed", record.id)
+            record.status = "failed"
+            record.error = f"engine error: {exc}"
+        finally:
+            live.current = None
+            record.finished_at = _now_iso()
+            self._save(record)
+            self._broadcast(live, record.result_frame())
+            for queue in list(live.subscribers):
+                queue.put_nowait(_END)
+            self._live.pop(record.id, None)
+            if on_finished is not None:
+                with contextlib.suppress(Exception):
+                    on_finished(record)
+
+    def _save(self, record: RunRecord) -> None:
+        try:
+            save_run(record, root=self._root)
+        except OSError:  # a full disk must not kill a run that is otherwise fine
+            log.warning("could not persist run %s", record.id, exc_info=True)
+
+    def _broadcast(self, live: _LiveRun, frame: Frame) -> None:
+        live.frames.append(frame)
+        for queue in list(live.subscribers):
+            queue.put_nowait(frame)
+
+    # ── observation ──
+
+    def is_live(self, run_id: str) -> bool:
+        """Whether *run_id* is being driven by this process right now."""
+        return run_id in self._live
+
+    def live_ids(self) -> list[str]:
+        """The ids of every run in flight."""
+        return list(self._live)
+
+    def attach(self, run_id: str) -> tuple[list[Frame], asyncio.Queue[Frame] | None] | None:
+        """Everything that happened so far, plus a queue for what follows.
+
+        The queue is ``None`` for a finished run (its frames are complete). A
+        finished run's frames are read from disk, so a run from a previous server
+        process can be opened the same way. ``None`` altogether means no such run.
+        """
+        live = self._live.get(run_id)
+        if live is not None:
+            queue: asyncio.Queue[Frame] = asyncio.Queue()
+            live.subscribers.add(queue)
+            frames = list(live.frames)
+            if live.current is not None:
+                frames.append(_step_started_frame(*live.current))
+            return frames, queue
+        record = load_run(run_id, root=self._root)
+        if record is None:
+            return None
+        return record.frames(), None
+
+    def detach(self, run_id: str, queue: asyncio.Queue[Frame]) -> None:
+        """Stop feeding *queue*; the run itself is unaffected."""
+        live = self._live.get(run_id)
+        if live is not None:
+            live.subscribers.discard(queue)
+
+    async def cancel(self, run_id: str) -> bool:
+        """Stop a live run; the in-flight tool call is killed with its stack."""
+        live = self._live.get(run_id)
+        if live is None:
+            return False
+        live.task.cancel()
+        with contextlib.suppress(asyncio.CancelledError, Exception):
+            await live.task
+        return True
+
+    async def shutdown(self) -> None:
+        """Cancel every live run (server shutdown)."""
+        for run_id in list(self._live):
+            await self.cancel(run_id)
+
+
+def _step_started_frame(item: int, index: int, server: str, tool: str, started_at: str) -> Frame:
+    return {
+        "type": "step_started",
+        "item": item,
+        "index": index,
+        "server": server,
+        "tool": tool,
+        "started_at": started_at,
+    }
+
+
+def is_end(frame: Frame) -> bool:
+    """Whether a queued frame is the end-of-run sentinel rather than a real frame."""
+    return frame is _END
+
+
+def elapsed_seconds(record: RunRecord) -> float:
+    """Wall-clock seconds the run took (or has taken so far)."""
+    start = _iso_to_ts(record.started_at)
+    end = _iso_to_ts(record.finished_at) if record.finished_at else time.time()
+    return max(0.0, end - start) if start else 0.0

--- a/src/medmcp/server.py
+++ b/src/medmcp/server.py
@@ -620,17 +620,13 @@ async def ws_stack_install(ws: WebSocket) -> None:
 # ── Workflow API ───────────────────────────────────────────
 #
 # Drives the provenance→distill→replay pipeline (Tier 2/3) from the workspace
-# UI: save the current chat as a draft workflow, review/promote/refine it, and
-# replay its recipe deterministically (no LLM) on new inputs.
+# UI: save the current chat as a workflow, rename/share it, and replay its
+# recipe deterministically (no LLM) on new inputs.
 
 
 def _workflow_dir(name: str) -> Path | None:
-    """Return the on-disk dir for workflow *name* (active wins over draft)."""
-    for kind in ("active", "draft"):
-        d = VIBE_HOME / "workflows" / kind / name
-        if (d / "recipe.yaml").exists():
-            return d
-    return None
+    """Return the on-disk dir for workflow *name*, or ``None``."""
+    return workflow.workflow_dir(VIBE_HOME / "workflows", name)
 
 
 def _requirement_statuses(recipe: workflow.Recipe, servers: list[JsonDict]) -> list[JsonDict]:
@@ -670,7 +666,6 @@ def _workflow_detail(name: str) -> JsonDict:
     replay_error = replay.validate(recipe, examples, servers)
     return {
         "name": recipe.name,
-        "kind": d.parent.name,
         "description": recipe.description,
         "inputs": [i.to_dict() for i in recipe.inputs],
         "steps": [
@@ -852,21 +847,20 @@ class DistillPayload(BaseModel):
 
 @app.post("/api/workflows/distill")
 async def post_distill(payload: DistillPayload) -> JsonDict:
-    """Distill a chat session into a draft workflow and return its detail.
-
-    Runs the hybrid prose pass against the local model, so this can take a
-    while; distillation itself never hard-fails on a model outage.
-    """
+    """Distill a chat session into a workflow, named after the chat, and return its detail."""
+    sid = payload.session_id
     try:
-        draft_dir = await asyncio.to_thread(
+        target = await asyncio.to_thread(
             lambda: distill.distill_session(
-                payload.session_id, chain_stop_ids=_chain_stop_ids(payload.session_id)
+                sid,
+                name_hint=sessions.chat_title(sid) or "",
+                chain_stop_ids=_chain_stop_ids(sid),
             )
         )
     except FileNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
-    _audit.info("workflow distilled: %s", draft_dir.name)
-    return await asyncio.to_thread(_workflow_detail, draft_dir.name)
+    _audit.info("workflow distilled: %s", target.name)
+    return await asyncio.to_thread(_workflow_detail, target.name)
 
 
 @app.get("/api/workflows/{name}")
@@ -878,64 +872,27 @@ async def get_workflow(name: str) -> JsonDict:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
-@app.post("/api/workflows/{name}/promote")
-async def post_promote_workflow(name: str) -> JsonDict:
-    """Promote a draft to active/, marking it reviewed and worth keeping."""
-    try:
-        await asyncio.to_thread(distill.promote_draft, name)
-    except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
-    _audit.info("workflow promoted: %s", name)
-    return {"ok": True}
-
-
-@app.post("/api/workflows/{name}/unpromote")
-async def post_unpromote_workflow(name: str) -> JsonDict:
-    """Move a promoted workflow back to draft/ for editing."""
-    try:
-        await asyncio.to_thread(distill.unpromote_workflow, name)
-    except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
-    return {"ok": True}
-
-
 class WorkflowRenamePayload(BaseModel):
-    """Request body for renaming a draft workflow."""
+    """Request body for renaming a workflow."""
 
     new_name: str
 
 
 @app.post("/api/workflows/{name}/rename")
 async def post_rename_workflow(name: str, payload: WorkflowRenamePayload) -> JsonDict:
-    """Rename a draft workflow; returns the new (slugified) name."""
+    """Rename a workflow; returns the new (slugified) name. 409 if that name is taken."""
     try:
-        new_dir = await asyncio.to_thread(distill.rename_draft, name, payload.new_name)
+        new_dir = await asyncio.to_thread(distill.rename_workflow, name, payload.new_name)
     except FileNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except FileExistsError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     return {"ok": True, "name": new_dir.name}
-
-
-class WorkflowRefinePayload(BaseModel):
-    """Request body for refining a draft's narrative."""
-
-    instruction: str
-
-
-@app.post("/api/workflows/{name}/refine")
-async def post_refine_workflow(name: str, payload: WorkflowRefinePayload) -> JsonDict:
-    """Regenerate a draft's narrative from a plain-language instruction (LLM)."""
-    try:
-        await asyncio.to_thread(distill.refine_draft, name, payload.instruction)
-    except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
-    except RuntimeError as exc:
-        raise HTTPException(status_code=502, detail=str(exc)) from exc
-    return {"ok": True}
 
 
 @app.delete("/api/workflows/{name}")
 async def delete_workflow(name: str) -> JsonDict:
-    """Delete a personal workflow (draft or active). The UI confirms first."""
+    """Delete a personal workflow. The UI confirms first."""
     try:
         await asyncio.to_thread(distill.delete_workflow, name)
     except FileNotFoundError as exc:
@@ -967,13 +924,13 @@ class WorkflowImportPayload(BaseModel):
 
 @app.post("/api/workflows/import")
 async def post_import_workflow(payload: WorkflowImportPayload) -> JsonDict:
-    """Import a shared workflow envelope as a reviewable draft; return its detail."""
+    """Import a shared workflow envelope as a new workflow; return its detail."""
     try:
-        draft_dir = await asyncio.to_thread(share.import_workflow, payload.content)
+        target = await asyncio.to_thread(share.import_workflow, payload.content)
     except share.WorkflowShareError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
-    _audit.info("workflow imported: %s", draft_dir.name)
-    return await asyncio.to_thread(_workflow_detail, draft_dir.name)
+    _audit.info("workflow imported: %s", target.name)
+    return await asyncio.to_thread(_workflow_detail, target.name)
 
 
 def _resolve_input_path(value: str) -> str:

--- a/src/medmcp/server.py
+++ b/src/medmcp/server.py
@@ -60,6 +60,7 @@ from medmcp import (
     pathguard,
     provenance,
     replay,
+    runs,
     sessions,
     settings,
     share,
@@ -113,6 +114,10 @@ _TREE_MAX_ENTRIES_PER_DIR: int = 500
 _pool: BackendPool | None = None
 _broker: BackendBroker | None = None
 
+# Replay runs in flight (see ``runs.py``). A run is a task in this process with a
+# record on disk; sockets attach to it and detach from it without affecting it.
+_runs: runs.RunManager = runs.RunManager()
+
 
 def _resolve_backend_spec(name: str) -> BackendSpec | None:
     """Map an active stack name to its persistent-backend launch spec (pool callback)."""
@@ -135,6 +140,10 @@ def _resolve_backend_spec(name: str) -> BackendSpec | None:
 async def _lifespan(_app: FastAPI) -> AsyncGenerator[None]:
     """Start the stack pool + broker on boot (when enabled); tear them down on exit."""
     global _pool, _broker
+    # A run record still marked "running" was cut off by the previous process.
+    interrupted = await asyncio.to_thread(runs.reconcile_interrupted)
+    if interrupted:
+        _audit.warning("marked %d interrupted replay run(s) as failed", interrupted)
     if settings.stack_pool_enabled():
         # Proxy children read MEDMCP_WORKSPACE for their fallback cwd; export it.
         os.environ.setdefault("MEDMCP_WORKSPACE", str(WORKSPACE_ROOT))
@@ -150,6 +159,7 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None]:
     try:
         yield
     finally:
+        await _runs.shutdown()
         if _broker is not None:
             await _broker.aclose()
         if _pool is not None:
@@ -1026,9 +1036,61 @@ def _confined_input_paths(inputs: dict[str, str]) -> dict[str, str]:
 
 
 class ReplayPreviewPayload(BaseModel):
-    """Request body for previewing a replay's resolved steps."""
+    """Request body for previewing a replay's resolved steps.
 
-    inputs: dict[str, str]
+    ``runs`` carries every item's input binding (the batch); ``inputs`` is the
+    older single-item form and is treated as a one-item batch.
+    """
+
+    inputs: dict[str, str] | None = None
+    runs: list[dict[str, str]] | None = None
+
+
+def _input_argument_names(recipe: workflow.Recipe) -> dict[str, str]:
+    """Map each ``in_N`` to the argument name it is first used as.
+
+    The path checker classifies a path by its *parameter name* — ``input_path``
+    must exist, ``output_dir`` need not — and the input's own name (``in_1``)
+    says nothing. The first step argument that references the placeholder gives
+    the role the tool assigns it.
+    """
+    names: dict[str, str] = {}
+    for step in recipe.steps:
+        for key, value in step.arguments.items():
+            if not isinstance(value, str):
+                continue
+            for ref in replay.unresolved_refs(value):
+                inner = ref[4:-1].strip() if ref.startswith("dir(") and ref.endswith(")") else ref
+                names.setdefault(inner, key)
+    return names
+
+
+def _preflight_item(
+    recipe: workflow.Recipe,
+    inputs: dict[str, str],
+    servers: list[JsonDict],
+    arg_names: dict[str, str],
+) -> JsonDict:
+    """Everything the run screen wants to say about one item before it runs.
+
+    ``error`` is the engine's own validation (a missing input, an uninstalled
+    stack). ``findings`` are the path checks on the *bound inputs* — the files
+    the person just pointed at — reported with the role the tool gives them, so
+    a missing scan is an error and an output folder that already holds results
+    is a warning about overwriting, not a false alarm.
+    """
+    error = replay.validate(recipe, inputs, servers)
+    if error is not None:
+        return {"ok": False, "error": error, "findings": []}
+    bound = replay.apply_input_defaults(recipe, inputs)
+    checked = {arg_names.get(name, name): value for name, value in bound.items()}
+    findings = pathcheck.check_tool_call_paths(checked, WORKSPACE_ROOT, containerized=True)
+    blocking = any(f["severity"] == "error" for f in findings)
+    return {
+        "ok": not blocking,
+        "error": next((f["note"] for f in findings if f["severity"] == "error"), None),
+        "findings": findings,
+    }
 
 
 @app.post("/api/workflows/{name}/replay-preview")
@@ -1036,7 +1098,9 @@ async def post_replay_preview(name: str, payload: ReplayPreviewPayload) -> JsonD
     """Validate a replay and return its resolved steps for user confirmation.
 
     Inputs are bound now; cross-step refs (``{{stepM.*}}``) resolve at runtime,
-    so they intentionally still show as placeholders in the preview.
+    so they intentionally still show as placeholders in the preview. Every item
+    is pre-flighted (see :func:`_preflight_item`) so a typo in one of forty rows
+    is caught here rather than by the tool, after the stacks were spawned.
     """
 
     def _preview() -> JsonDict:
@@ -1044,13 +1108,21 @@ async def post_replay_preview(name: str, payload: ReplayPreviewPayload) -> JsonD
         if d is None:
             raise FileNotFoundError(f"no workflow named {name!r}")
         recipe = distill.load_recipe(d)
-        inputs = _confined_input_paths(dict(payload.inputs))
-        error = replay.validate(recipe, inputs, settings.active_servers())
-        if error is not None:
-            return {"ok": False, "error": error, "steps": []}
+        raw_runs = payload.runs if payload.runs is not None else [payload.inputs or {}]
+        bindings_list = [_confined_input_paths(dict(r)) for r in raw_runs]
+        servers = settings.active_servers()
+        arg_names = _input_argument_names(recipe)
+        items = [
+            {"index": i, **_preflight_item(recipe, b, servers, arg_names)}
+            for i, b in enumerate(bindings_list)
+        ]
+        first_ok = next((i for i, item in enumerate(items) if item["error"] is None), None)
+        if first_ok is None and items:
+            return {"ok": False, "error": items[0]["error"], "steps": [], "items": items}
         # Same defaults the run will use, so the preview shows what will actually
         # be sent rather than an unresolved placeholder the user never filled in.
-        bindings: dict[str, Any] = replay.apply_input_defaults(recipe, inputs)
+        first = bindings_list[first_ok] if first_ok is not None else {}
+        bindings: dict[str, Any] = replay.apply_input_defaults(recipe, first)
         steps = [
             {
                 "index": i,
@@ -1060,7 +1132,13 @@ async def post_replay_preview(name: str, payload: ReplayPreviewPayload) -> JsonD
             }
             for i, s in enumerate(recipe.steps, start=1)
         ]
-        return {"ok": True, "error": None, "steps": steps}
+        ready = sum(1 for item in items if item["ok"])
+        return {
+            "ok": ready > 0,
+            "error": None if ready > 0 else "no item can run",
+            "steps": steps,
+            "items": items,
+        }
 
     try:
         return await asyncio.to_thread(_preview)
@@ -1116,131 +1194,178 @@ async def post_batch_from_plan(name: str, payload: BatchFromPlanPayload) -> Json
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
+class ReplayStartRequest(BaseModel):
+    """The first client message on ``/ws/replay``: start a run, or attach to one."""
+
+    name: str = ""
+    runs: list[dict[str, str]] = Field(default_factory=list[dict[str, str]])
+    attach: str = ""
+
+
 @app.websocket("/ws/replay")
 async def ws_replay(ws: WebSocket) -> None:
-    """Run a deterministic replay — single or batch — streaming status frames.
+    """Start a replay run — or attach to one — and stream its progress.
 
-    First client message: ``{"name": str, "runs": [{in_N: value}, ...]}``;
-    each entry is one full input binding and the recipe runs once per entry,
-    sequentially. A failed item does not stop the remaining items. The server
-    streams ``{"type": "step", "item": int, ...}`` per executed step,
-    ``{"type": "item_result", "item": int, "ok": bool, "error": str|null,
-    "outputs": [...]}`` per finished item, and a final ``{"type": "result",
-    "ok": bool, "error": str|null, "outputs": [...]}`` over all items.
-    Closing the socket aborts the run immediately: a concurrent watcher task
-    observes the disconnect and cancels the batch, unwinding the engine's
-    exit stack — which shuts down the spawned MCP servers, killing the
-    in-flight tool step.
+    First client message, one of:
+
+    - ``{"name": str, "runs": [{in_N: value}, ...]}`` starts a new run;
+
+      each entry is one full input binding and the recipe runs once per
+      entry, sequentially. A failed item does not stop the remaining items.
+    - ``{"attach": run_id}`` replays everything the run has done so far and then
+      streams the rest (a finished run streams its record and closes).
+
+    Frames: ``started`` (carries the ``run_id``), ``step_started``, ``step``,
+    ``item_result`` and a final ``result``. **Closing the socket does not stop
+    the run** — a reload or a dropped connection merely detaches, and the page
+    reattaches by id. Stopping is an explicit ``{"type": "cancel"}`` message,
+    which kills the in-flight tool call together with its stack.
 
     SECURITY: the replay engine calls MCP tools directly, bypassing the
     vibe-acp permission flow — the client must show the resolved-steps preview
-    (``/replay-preview``) and get an explicit confirmation before connecting.
+    (``/replay-preview``) and get an explicit confirmation before starting.
     Inputs are confined to the workspace here regardless (see
     :func:`_confined_input_path`), since a binding arriving on this socket has
     had no permission prompt between it and the tool call.
     """
     await ws.accept()
+    run_id = ""
+    queue: asyncio.Queue[runs.Frame] | None = None
     try:
-        first = cast("JsonDict", await ws.receive_json())
-        name = str(first.get("name") or "")
         try:
-            runs = [
-                _confined_input_paths({str(k): str(v) for k, v in cast("JsonDict", r).items()})
-                for r in cast("list[object]", first.get("runs") or [])
-                if isinstance(r, dict)
-            ]
+            first = ReplayStartRequest.model_validate(await ws.receive_json())
         except ValueError as exc:
-            _audit.warning("replay refused: %s", exc)
-            await ws.send_json({"type": "result", "ok": False, "error": str(exc)})
+            await ws.send_json({"type": "result", "ok": False, "error": f"bad request: {exc}"})
             return
-        d = _workflow_dir(name)
-        if d is None or not runs:
-            error = f"no workflow named {name!r}" if d is None else "no inputs to run"
-            await ws.send_json({"type": "result", "ok": False, "error": error})
-            return
-        recipe = await asyncio.to_thread(distill.load_recipe, d)
-        servers = await asyncio.to_thread(settings.active_servers)
-        _audit.info(
-            "replay started: %s (%d item(s) x %d steps)", name, len(runs), len(recipe.steps)
-        )
 
-        async def _run_batch() -> None:
-            async def _on_step(item: int, sr: replay.StepResult) -> None:
+        if first.attach:
+            attached = _runs.attach(first.attach)
+            if attached is None:
                 await ws.send_json(
-                    {
-                        "type": "step",
-                        "item": item,
-                        "index": sr.index,
-                        "server": sr.server,
-                        "tool": sr.tool,
-                        "ok": sr.ok,
-                        "error": sr.error,
-                        "produced": sr.produced,
-                    }
+                    {"type": "result", "ok": False, "error": f"no run {first.attach!r}"}
                 )
-
-            async def _on_item(item: int, result: replay.ReplayResult) -> None:
-                await ws.send_json(
-                    {
-                        "type": "item_result",
-                        "item": item,
-                        "ok": result.ok,
-                        "error": result.error,
-                        "outputs": [v for sr in result.steps for v in sr.produced.values()],
-                    }
-                )
-
-            # One shared set of stacks across all items (spawned once, not per item).
-            results = await replay.run_batch(
-                recipe,
-                runs,
+                return
+            run_id = first.attach
+            past, queue = attached
+        else:
+            try:
+                bindings = [_confined_input_paths(dict(r)) for r in first.runs]
+            except ValueError as exc:
+                _audit.warning("replay refused: %s", exc)
+                await ws.send_json({"type": "result", "ok": False, "error": str(exc)})
+                return
+            d = _workflow_dir(first.name)
+            if d is None or not bindings:
+                error = f"no workflow named {first.name!r}" if d is None else "no inputs to run"
+                await ws.send_json({"type": "result", "ok": False, "error": error})
+                return
+            recipe = await asyncio.to_thread(distill.load_recipe, d)
+            servers = await asyncio.to_thread(settings.active_servers)
+            record = _runs.start(
+                recipe=recipe,
+                runs=bindings,
                 servers=servers,
                 cwd=str(WORKSPACE_ROOT),
-                on_step=_on_step,
-                on_item=_on_item,
+                on_finished=lambda r: _audit.info(
+                    "replay finished: %s run=%s status=%s", r.workflow, r.id, r.status
+                ),
             )
-            all_outputs = [v for r in results for sr in r.steps for v in sr.produced.values()]
-            failed = sum(1 for r in results if not r.ok)
-            ok = failed == 0
-            batch_error = None if ok else f"{failed} of {len(runs)} item(s) failed"
-            _audit.info("replay finished: %s ok=%s", name, ok)
-            await ws.send_json(
-                {"type": "result", "ok": ok, "error": batch_error, "outputs": all_outputs}
+            _audit.info(
+                "replay started: %s run=%s (%d item(s) x %d steps)",
+                recipe.name,
+                record.id,
+                len(bindings),
+                len(recipe.steps),
             )
+            run_id = record.id
+            attached = _runs.attach(run_id)
+            past, queue = attached if attached is not None else ([], None)
 
-        # Race the batch against a socket watcher. The client sends nothing
-        # after the first message, so anything receive returns — and above all
-        # a disconnect — means "abort". Cancelling the batch task unwinds
-        # run_batch's shared exit stack, killing the in-flight MCP server and its
-        # running tool; without the watcher, Stop would only take effect at
-        # the next frame send, after the current step finished.
-        batch_task = asyncio.create_task(_run_batch())
-        watch_task = asyncio.create_task(ws.receive_text())
+        for frame in past:
+            await ws.send_json(frame)
+        if queue is None:
+            return  # a finished run: its record was the whole story
+
+        # Two concurrent loops: frames out, control messages in. A disconnect
+        # ends both and leaves the run alone; only an explicit cancel stops it.
+        async def _pump() -> None:
+            assert queue is not None
+            while True:
+                frame = await queue.get()
+                if runs.is_end(frame):
+                    return
+                await ws.send_json(frame)
+
+        async def _control() -> None:
+            while True:
+                msg = cast("JsonDict", await ws.receive_json())
+                if msg.get("type") == "cancel":
+                    _audit.info("replay cancel requested: run=%s", run_id)
+                    await _runs.cancel(run_id)
+
+        pump_task = asyncio.create_task(_pump())
+        control_task = asyncio.create_task(_control())
         try:
             done, _pending = await asyncio.wait(
-                {batch_task, watch_task}, return_when=asyncio.FIRST_COMPLETED
+                {pump_task, control_task}, return_when=asyncio.FIRST_COMPLETED
             )
-            if batch_task in done:
-                watch_task.cancel()
-                with contextlib.suppress(asyncio.CancelledError, WebSocketDisconnect):
-                    await watch_task
-                batch_task.result()  # propagate batch errors (e.g. send on closed socket)
-            else:
-                batch_task.cancel()
-                with contextlib.suppress(asyncio.CancelledError):
-                    await batch_task
-                _audit.info("replay aborted by client; in-flight step cancelled")
-                with contextlib.suppress(WebSocketDisconnect):
-                    await watch_task
+            for task in (pump_task, control_task):
+                if task not in done:
+                    task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError, WebSocketDisconnect):
+                        await task
+            for task in done:
+                task.result()  # surface a send failure / disconnect
         except asyncio.CancelledError:
-            batch_task.cancel()
-            watch_task.cancel()
+            pump_task.cancel()
+            control_task.cancel()
             raise
     except WebSocketDisconnect:
-        _audit.info("replay socket closed by client; run aborted")
+        _audit.info("replay socket closed by client; run=%s keeps running", run_id or "-")
     finally:
+        if queue is not None and run_id:
+            _runs.detach(run_id, queue)
         with contextlib.suppress(Exception):
             await ws.close()
+
+
+@app.get("/api/runs")
+async def get_runs(workflow: str | None = None, limit: int = 20) -> JsonDict:
+    """Recent replay runs (newest first), optionally for one workflow.
+
+    ``live`` lists the ids in flight in this process, so a page can reattach to
+    a run it started before a reload.
+    """
+    records = await asyncio.to_thread(runs.list_runs, workflow=workflow, limit=max(1, limit))
+    return {"runs": [r.summary() for r in records], "live": _runs.live_ids()}
+
+
+@app.get("/api/runs/{run_id}")
+async def get_run(run_id: str) -> JsonDict:
+    """One run's full record: every item, every step, what each produced."""
+    record = await asyncio.to_thread(runs.load_run, run_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail=f"no run {run_id!r}")
+    return {**record.to_dict(), "live": _runs.is_live(run_id)}
+
+
+@app.post("/api/runs/{run_id}/cancel")
+async def post_cancel_run(run_id: str) -> JsonDict:
+    """Stop a live run (the REST twin of the socket's ``cancel`` message)."""
+    if not await _runs.cancel(run_id):
+        raise HTTPException(status_code=404, detail=f"no live run {run_id!r}")
+    _audit.info("replay cancelled: run=%s", run_id)
+    return {"ok": True}
+
+
+@app.delete("/api/runs/{run_id}")
+async def delete_run(run_id: str) -> JsonDict:
+    """Forget a finished run's record. A live run must be stopped first."""
+    if _runs.is_live(run_id):
+        raise HTTPException(status_code=409, detail="run is still in progress")
+    if not await asyncio.to_thread(runs.delete_run, run_id):
+        raise HTTPException(status_code=404, detail=f"no run {run_id!r}")
+    return {"ok": True}
 
 
 # ── WebSocket chat ─────────────────────────────────────────

--- a/src/medmcp/sessions.py
+++ b/src/medmcp/sessions.py
@@ -20,6 +20,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any, cast
 
+from medmcp import provenance
 from medmcp.acp import VIBE_HOME
 
 JsonDict = dict[str, Any]
@@ -62,6 +63,20 @@ def _save_registry(registry: dict[str, JsonDict]) -> None:
 def get_entry(session_id: str) -> JsonDict:
     """Return the stored metadata for *session_id* (empty dict if none)."""
     return load_registry().get(session_id, {})
+
+
+def chat_title(session_id: str) -> str | None:
+    """The chat's current name, or ``None`` if it has none yet.
+
+    The registry title comes first, generated or user-set; failing that, the
+    user-set title vibe recorded in its own session metadata (the registry lives
+    in the container layer and may have been reset). Used to name what is
+    derived from a chat — a distilled workflow — after the chat itself.
+    """
+    title = get_entry(session_id).get("title")
+    if isinstance(title, str) and title.strip():
+        return title.strip()
+    return provenance.vibe_manual_session_title(session_id)
 
 
 def _update(session_id: str, mutate: Callable[[JsonDict], None]) -> None:

--- a/src/medmcp/settings.py
+++ b/src/medmcp/settings.py
@@ -7,13 +7,13 @@ same state:
 - **Stack discovery** (:func:`load_mcp_servers`) — uv tool environments with a
   ``[medmcp.stacks]`` entry point, plus manual ``[[mcp_servers]]`` entries in
   ``.vibe/config.toml``.
-- **Active sets** — which stacks/workflows are enabled, persisted as JSON under
+- **Active sets** — which stacks are enabled, persisted as JSON under
   ``.vibe/`` (all active when the file is absent).
-- **Feature toggles** — provenance capture, personal workflows, tool-call
-  explanations; each defaults to on.
+- **Feature toggles** — provenance capture and tool-call explanations; each
+  defaults to on.
 - **Config sync** (:func:`sync_servers_to_vibe_config`) — writes the resolved
-  server list and workflow skill paths into ``.vibe/config.toml`` before each
-  session, because vibe-acp reads that file directly.
+  server list and the stacks' skill paths into ``.vibe/config.toml`` before
+  each session, because vibe-acp reads that file directly.
 """
 
 from __future__ import annotations
@@ -42,6 +42,7 @@ import httpx
 import tomli_w
 
 from medmcp.acp import PROJECT_ROOT, VIBE_HOME, JsonDict
+from medmcp.workflow import list_workflows
 
 log: logging.Logger = logging.getLogger(__name__)
 
@@ -1468,40 +1469,9 @@ def load_catalog() -> list[JsonDict]:
     return out
 
 
-def read_skill_description(skill_md: Path) -> str:
-    """Return the ``description:`` frontmatter value from a SKILL.md, or ``''``."""
-    try:
-        lines = skill_md.read_text(encoding="utf-8").splitlines()
-    except OSError:
-        return ""
-    for line in lines[:15]:
-        if line.startswith("description:"):
-            return line.split(":", 1)[1].strip()
-    return ""
-
-
 def discover_workflows() -> list[JsonDict]:
-    """Discover personal workflows from ``draft/`` and ``active/``.
-
-    Returns ``{name, description, kind}`` dicts, deduplicated by name (an active
-    workflow shadows a draft of the same name). ``kind`` is ``"active"`` for
-    promoted workflows and ``"draft"`` for unpromoted ones.
-    """
-    found: dict[str, JsonDict] = {}
-    for kind in ("active", "draft"):
-        base = VIBE_HOME / "workflows" / kind
-        if not base.is_dir():
-            continue
-        for d in sorted(base.iterdir()):
-            skill = d / "SKILL.md"
-            if not d.is_dir() or not skill.is_file() or d.name in found:
-                continue
-            found[d.name] = {
-                "name": d.name,
-                "description": read_skill_description(skill),
-                "kind": kind,
-            }
-    return list(found.values())
+    """The personal workflows under ``.vibe/workflows`` as ``{name, description}`` rows."""
+    return list_workflows(VIBE_HOME / "workflows")
 
 
 def _load_flag(path: Path) -> bool:

--- a/src/medmcp/share.py
+++ b/src/medmcp/share.py
@@ -1,18 +1,14 @@
 """Export / import a distilled workflow as a single self-contained YAML file.
 
-A workflow normally lives as a directory under
-``.vibe/workflows/{draft,active}/<name>/`` (``recipe.yaml`` + ``SKILL.md`` +
-``prose.json``). To share one with a colleague we serialize it into a single
-inline ``<name>.workflow.yaml`` envelope that carries everything needed to
-reproduce and document it:
+A workflow lives as ``.vibe/workflows/<name>/recipe.yaml``. To share one with a
+colleague we serialize it into a single ``<name>.workflow.yaml`` envelope: the
+recipe's ``inputs`` and ``steps``, the ``requires`` block (stacks pinned by
+version or image+digest), and its name and description — what the replay
+engine needs, and nothing else. Files written by earlier releases also carried
+a ``documentation`` block and cached ``prose``; both are ignored on import.
 
-- the replayable ``steps`` and ``inputs`` (the recipe),
-- the ``requires`` block (stacks pinned by version or image+digest),
-- a human-readable ``documentation`` block (what the workflow does), and
-- the cached ``prose`` so the narrative can still be refined after import.
-
-Import always lands the workflow as a **draft** for review before promotion, and
-never overwrites an existing one (names collide → a unique suffix is added).
+Import lands the workflow beside the existing ones and never overwrites one
+(names collide → a unique suffix is added).
 
 This module has no UI/vibe-acp dependency (like the rest of the distill cluster)
 so it can be driven from the server or the ``medmcp`` CLI alike.
@@ -20,14 +16,12 @@ so it can be driven from the server or the ``medmcp`` CLI alike.
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import Any, cast
 
 import yaml
 
-from medmcp import distill, provenance
-from medmcp.workflow import Recipe, RecipeStep, StackRequirement, WorkflowInput
+from medmcp import distill, workflow
 
 JsonDict = dict[str, Any]
 
@@ -44,60 +38,21 @@ class WorkflowShareError(Exception):
     """Raised when an import payload is malformed or an unknown format version."""
 
 
-def _workflows_root(workflows_root: Path | None) -> Path:
-    """Resolve the workflows root, defaulting to ``.vibe/workflows``."""
-    return workflows_root if workflows_root is not None else provenance.VIBE_HOME / "workflows"
-
-
-def _find_workflow_dir(name: str, workflows_root: Path | None) -> Path:
-    """Return the dir for workflow *name* (active preferred, then draft).
-
-    Raises ``FileNotFoundError`` if neither location has it.
-    """
-    root = _workflows_root(workflows_root)
-    for kind in ("active", "draft"):
-        candidate = root / kind / name
-        if (candidate / "recipe.yaml").exists():
-            return candidate
-    raise FileNotFoundError(f"no workflow named {name!r} in {root}")
-
-
-def _skill_body(skill_md: str) -> str:
-    """Strip the leading YAML frontmatter from a ``SKILL.md``, returning the body."""
-    if skill_md.startswith("---"):
-        end = skill_md.find("\n---", 3)
-        if end != -1:
-            newline = skill_md.find("\n", end + 1)
-            if newline != -1:
-                return skill_md[newline + 1 :].lstrip("\n")
-    return skill_md
-
-
-def _read_prose(workflow_dir: Path) -> JsonDict | None:
-    """Read a workflow's cached ``prose.json`` (``None`` if absent/mechanical)."""
-    path = workflow_dir / "prose.json"
-    if not path.exists():
-        return None
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
-        return None
-    return cast("JsonDict", data) if isinstance(data, dict) else None
-
-
 # ── Export ────────────────────────────────────────────────────────────────────
 
 
 def export_workflow(name: str, *, workflows_root: Path | None = None) -> str:
     """Serialize workflow *name* into a single inline-YAML envelope (returns text).
 
-    Pulls the recipe, the human-readable documentation (the rendered ``SKILL.md``
-    body), and the cached prose. Any required image without a digest is resolved
-    best-effort at export time so the shared file pins as tightly as possible.
+    Any required image without a digest is resolved best-effort at export time
+    so the shared file pins as tightly as possible.
 
-    Raises ``FileNotFoundError`` if no draft/active workflow has that name.
+    Raises ``FileNotFoundError`` if no workflow has that name.
     """
-    workflow_dir = _find_workflow_dir(name, workflows_root)
+    root = distill.resolve_root(workflows_root)
+    workflow_dir = workflow.workflow_dir(root, name)
+    if workflow_dir is None:
+        raise FileNotFoundError(f"no workflow named {name!r} in {root}")
     recipe = distill.load_recipe(workflow_dir)
 
     # Tighten the pin: fill any missing digests now (the image may not have been
@@ -106,102 +61,20 @@ def export_workflow(name: str, *, workflows_root: Path | None = None) -> str:
         if req.image and not req.digest:
             req.digest = distill.resolve_digest(req.image)
 
-    skill_path = workflow_dir / "SKILL.md"
-    documentation = (
-        _skill_body(skill_path.read_text(encoding="utf-8")) if skill_path.exists() else ""
-    )
-
-    envelope: JsonDict = {
-        FORMAT_KEY: FORMAT_VERSION,
-        "name": recipe.name,
-        "description": recipe.description,
-    }
-    if recipe.requires:
-        envelope["requires"] = [r.to_dict() for r in recipe.requires]
-    envelope["inputs"] = [i.to_dict() for i in recipe.inputs]
-    envelope["steps"] = [s.to_dict() for s in recipe.steps]
-    if recipe.manual_steps:
-        envelope["manual_steps"] = list(recipe.manual_steps)
-    if documentation:
-        envelope["documentation"] = documentation
-    prose = _read_prose(workflow_dir)
-    if prose is not None:
-        envelope["prose"] = prose
-
+    envelope: JsonDict = {FORMAT_KEY: FORMAT_VERSION, **recipe.to_dict()}
     return yaml.safe_dump(envelope, sort_keys=False, allow_unicode=True)
 
 
 # ── Import ────────────────────────────────────────────────────────────────────
 
 
-def _recipe_from_envelope(env: JsonDict) -> Recipe:
-    """Reconstruct a :class:`Recipe` from a validated envelope dict."""
-    inputs = [
-        WorkflowInput(
-            name=str(i.get("name", "")),
-            example=str(i.get("example", "")),
-            description=str(i.get("description", "")),
-            # Without this a shared workflow loses its derived defaults on
-            # import, handing the recipient back the very input the default
-            # exists to spare them — and silently, since export writes it.
-            default=str(i.get("default", "")),
-        )
-        for i in cast("list[JsonDict]", env.get("inputs", []))
-    ]
-    steps = [
-        RecipeStep(
-            server=str(s.get("server", "")),
-            tool=str(s.get("tool", "")),
-            arguments=cast("JsonDict", s.get("arguments", {})),
-            produces=cast("dict[str, str]", s.get("produces", {})),
-        )
-        for s in cast("list[JsonDict]", env.get("steps", []))
-    ]
-    requires = [
-        StackRequirement(
-            stack=str(r.get("stack", "")),
-            version=str(r.get("version", "")),
-            image=str(r.get("image", "")),
-            digest=str(r.get("digest", "")),
-        )
-        for r in cast("list[JsonDict]", env.get("requires", []))
-    ]
-    manual_steps = [str(m) for m in cast("list[Any]", env.get("manual_steps", []))]
-    return Recipe(
-        name=distill.slugify(str(env.get("name", ""))),
-        description=str(env.get("description", "")),
-        inputs=inputs,
-        steps=steps,
-        requires=requires,
-        manual_steps=manual_steps,
-    )
-
-
-def _unique_draft_name(base: str, workflows_root: Path | None) -> str:
-    """Return a draft name not already used by a draft or active workflow."""
-    root = _workflows_root(workflows_root)
-
-    def taken(candidate: str) -> bool:
-        return any((root / kind / candidate).exists() for kind in ("draft", "active"))
-
-    if not taken(base):
-        return base
-    suffixed = f"{base}-imported"
-    if not taken(suffixed):
-        return suffixed
-    n = 2
-    while taken(f"{suffixed}-{n}"):
-        n += 1
-    return f"{suffixed}-{n}"
-
-
 def import_workflow(yaml_text: str, *, workflows_root: Path | None = None) -> Path:
-    """Import a shared workflow envelope as a new **draft**; return its directory.
+    """Import a shared workflow envelope as a new workflow; return its directory.
 
-    Validates the envelope (format version + a non-empty step list), reconstructs
-    the recipe, and writes ``recipe.yaml`` + ``SKILL.md`` + ``prose.json`` into a
-    fresh ``draft/<name>/``. A name already in use gets a unique suffix so an
-    import never clobbers an existing workflow.
+    Validates the envelope (format version + a non-empty step list),
+    reconstructs the recipe, and writes ``recipe.yaml`` into a fresh
+    ``<name>/``. A name already in use gets a unique suffix so an import never
+    clobbers an existing workflow.
 
     Raises ``WorkflowShareError`` on a malformed payload or unknown version.
     """
@@ -223,20 +96,9 @@ def import_workflow(yaml_text: str, *, workflows_root: Path | None = None) -> Pa
     if not isinstance(env.get("steps"), list) or not env["steps"]:
         raise WorkflowShareError("workflow file has no steps")
 
-    recipe = _recipe_from_envelope(env)
-    recipe.name = _unique_draft_name(recipe.name, workflows_root)
-
-    draft_dir = _workflows_root(workflows_root) / "draft" / recipe.name
-    draft_dir.mkdir(parents=True, exist_ok=True)
-    prose = env.get("prose") if isinstance(env.get("prose"), dict) else None
-    prose_dict = cast("JsonDict | None", prose)
-
-    recipe_yaml = yaml.safe_dump(recipe.to_dict(), sort_keys=False, allow_unicode=True)
-    (draft_dir / "recipe.yaml").write_text(recipe_yaml, encoding="utf-8")
-    (draft_dir / "SKILL.md").write_text(
-        distill.render_skill_md(recipe, prose_dict), encoding="utf-8"
-    )
-    (draft_dir / "prose.json").write_text(
-        json.dumps(prose_dict) if prose_dict is not None else "null", encoding="utf-8"
-    )
-    return draft_dir
+    root = distill.resolve_root(workflows_root)
+    recipe = workflow.Recipe.from_dict(env)
+    recipe.name = workflow.unique_name(root, distill.slugify(recipe.name), tag="imported")
+    target = root / recipe.name
+    workflow.write_recipe(target, recipe)
+    return target

--- a/src/medmcp/workflow.py
+++ b/src/medmcp/workflow.py
@@ -1,23 +1,43 @@
-"""Schema for distilled, reusable MedMCP workflows (Tier 2).
+"""Schema and on-disk layout of distilled, replayable MedMCP workflows (Tier 2).
 
 A :class:`Recipe` is the machine-readable, replayable form of a workflow
 distilled from a session's provenance record (see :mod:`medmcp.distill`). It is
-emitted as ``recipe.yaml`` next to a human/LLM-facing ``SKILL.md`` so the same
-distillation feeds both a deterministic re-run and the existing skill system.
+the whole workflow: one ``recipe.yaml`` in one directory, ``<root>/<name>/``,
+which the replay engine runs, the UI lists, and an export wraps. Nothing else
+is written there, and nothing there is ever loaded as an agent skill.
 
 Concrete file paths and devices captured during a session are lifted into named
 placeholders so the recipe can be replayed against new inputs:
 
 - ``{{in_N}}``        — an input the workflow consumes but did not itself produce
 - ``{{stepM.<key>}}`` — an output produced by an earlier step and reused later
+
+Earlier releases kept workflows in ``draft/`` and ``active/`` subdirectories
+(promotion marked a draft reviewed, back when a promoted workflow was loaded as
+a skill) beside a rendered ``SKILL.md`` and a cached ``prose.json``.
+:func:`migrate_layout` folds that layout into this one the first time a root is
+touched, so every accessor here calls it.
 """
 
 from __future__ import annotations
 
+import shutil
 from dataclasses import dataclass, field
-from typing import Any
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
 
 JsonDict = dict[str, Any]
+
+RECIPE_FILE = "recipe.yaml"
+"""The one file a workflow directory holds."""
+
+_LEGACY_KINDS: tuple[str, ...] = ("active", "draft")
+"""Pre-0.3 subdirectories of the workflows root; ``active`` is folded in first."""
+
+_LEGACY_FILES: tuple[str, ...] = ("SKILL.md", "prose.json")
+"""Generated files earlier releases wrote next to the recipe; removed on migration."""
 
 
 @dataclass
@@ -114,11 +134,11 @@ class Recipe:
     steps: list[RecipeStep] = field(default_factory=list[RecipeStep])
     requires: list[StackRequirement] = field(default_factory=list[StackRequirement])
     manual_steps: list[str] = field(default_factory=list[str])
-    """Built-in (non-MCP) steps dropped from the replayable recipe, kept as docs.
+    """Built-in (non-MCP) steps dropped from the replayable recipe, kept as a note.
 
     These are real actions from the session (e.g. ``builtin:edit``) that the replay
-    engine can't run deterministically; recording them here lets the workflow note
-    the manual work instead of silently losing it.
+    engine can't run deterministically; recording them lets a run say what it
+    will not do instead of silently losing it.
     """
 
     def to_dict(self) -> JsonDict:
@@ -134,3 +154,130 @@ class Recipe:
         if self.manual_steps:
             out["manual_steps"] = list(self.manual_steps)
         return out
+
+    @classmethod
+    def from_dict(cls, data: JsonDict) -> Recipe:
+        """Rebuild a recipe from its dict form (a ``recipe.yaml`` or a share envelope).
+
+        Only the known keys are read, so a mapping carrying extra fields — an
+        export envelope's format marker, or the blocks older exports included —
+        loads cleanly.
+        """
+        inputs = [
+            WorkflowInput(
+                name=str(i.get("name", "")),
+                example=str(i.get("example", "")),
+                description=str(i.get("description", "")),
+                default=str(i.get("default", "")),
+            )
+            for i in cast("list[JsonDict]", data.get("inputs") or [])
+        ]
+        steps = [
+            RecipeStep(
+                server=str(s.get("server", "")),
+                tool=str(s.get("tool", "")),
+                arguments=cast("JsonDict", s.get("arguments") or {}),
+                produces=cast("dict[str, str]", s.get("produces") or {}),
+            )
+            for s in cast("list[JsonDict]", data.get("steps") or [])
+        ]
+        requires = [
+            StackRequirement(
+                stack=str(r.get("stack", "")),
+                version=str(r.get("version", "")),
+                image=str(r.get("image", "")),
+                digest=str(r.get("digest", "")),
+            )
+            for r in cast("list[JsonDict]", data.get("requires") or [])
+        ]
+        manual_steps = [str(m) for m in cast("list[Any]", data.get("manual_steps") or [])]
+        return cls(
+            name=str(data.get("name", "")),
+            description=str(data.get("description", "")),
+            inputs=inputs,
+            steps=steps,
+            requires=requires,
+            manual_steps=manual_steps,
+        )
+
+
+# ── On-disk layout ───────────────────────────────────────────────────────────
+
+
+def read_recipe(directory: Path) -> Recipe:
+    """Load the recipe stored in workflow *directory*."""
+    data = yaml.safe_load((directory / RECIPE_FILE).read_text(encoding="utf-8"))
+    return Recipe.from_dict(cast("JsonDict", data) if isinstance(data, dict) else {})
+
+
+def write_recipe(directory: Path, recipe: Recipe) -> None:
+    """Write *recipe* as ``recipe.yaml`` into *directory* (created if missing)."""
+    directory.mkdir(parents=True, exist_ok=True)
+    text = yaml.safe_dump(recipe.to_dict(), sort_keys=False, allow_unicode=True)
+    (directory / RECIPE_FILE).write_text(text, encoding="utf-8")
+
+
+def unique_name(root: Path, base: str, *, tag: str = "") -> str:
+    """Return *base* if no workflow under *root* has it, else a suffixed variant.
+
+    With a *tag* the first alternative is ``<base>-<tag>``, then
+    ``<base>-<tag>-2`` and so on; without one it is ``<base>-2``, ``<base>-3``…
+    """
+    if not (root / base).exists():
+        return base
+    stem = f"{base}-{tag}" if tag else base
+    if tag and not (root / stem).exists():
+        return stem
+    n = 2
+    while (root / f"{stem}-{n}").exists():
+        n += 1
+    return f"{stem}-{n}"
+
+
+def migrate_layout(root: Path) -> None:
+    """Fold the pre-0.3 ``active/`` and ``draft/`` subdirectories of *root* into it.
+
+    Promoted workflows move first, so a draft that shared a name with one (it
+    was shadowed before, but not deleted) lands as ``<name>-draft`` rather than
+    replacing it. The generated ``SKILL.md`` and ``prose.json`` were only read to
+    render the skill document, which is gone, so they are removed on the way.
+    A root without the old subdirectories is left untouched.
+    """
+    for kind in _LEGACY_KINDS:
+        legacy = root / kind
+        if not legacy.is_dir():
+            continue
+        for src in sorted(p for p in legacy.iterdir() if p.is_dir()):
+            dst = root / unique_name(root, src.name, tag=kind if kind == "draft" else "")
+            shutil.move(str(src), str(dst))
+            for stale in _LEGACY_FILES:
+                (dst / stale).unlink(missing_ok=True)
+        shutil.rmtree(legacy, ignore_errors=True)
+
+
+def workflow_dir(root: Path, name: str) -> Path | None:
+    """Return ``<root>/<name>`` if it holds a recipe, else ``None``."""
+    migrate_layout(root)
+    candidate = root / name
+    return candidate if (candidate / RECIPE_FILE).is_file() else None
+
+
+def list_workflows(root: Path) -> list[JsonDict]:
+    """List the workflows under *root* as ``{name, description}`` rows, by name.
+
+    A directory whose recipe cannot be read is listed with an empty description
+    rather than hiding a workflow the user can still delete.
+    """
+    if not root.is_dir():
+        return []
+    migrate_layout(root)
+    rows: list[JsonDict] = []
+    for d in sorted(root.iterdir()):
+        if not (d / RECIPE_FILE).is_file():
+            continue
+        try:
+            description = read_recipe(d).description
+        except (yaml.YAMLError, OSError):
+            description = ""
+        rows.append({"name": d.name, "description": description})
+    return rows

--- a/tests/test_active_servers.py
+++ b/tests/test_active_servers.py
@@ -152,9 +152,9 @@ class TestWorkflowsAreNotSkills:
     """Workflows belong to the replay engine; vibe-acp never sees them."""
 
     def test_workflow_dirs_are_never_added_to_skill_paths(self, tmp_path: Path) -> None:
-        """Neither draft/ nor active/ reaches skill_paths, promoted or not."""
-        _make_workflow(tmp_path, "active", "wf-promoted")
-        _make_workflow(tmp_path, "draft", "wf-draft")
+        """No workflow directory reaches skill_paths."""
+        _make_workflow(tmp_path, "wf-one")
+        _make_workflow(tmp_path, "wf-two")
         cfg_path = tmp_path / "config.toml"
         with patch("medmcp.settings.VIBE_HOME", tmp_path):
             sync_servers_to_vibe_config([])
@@ -163,7 +163,7 @@ class TestWorkflowsAreNotSkills:
 
     def test_stack_skill_paths_still_load(self, tmp_path: Path) -> None:
         """A stack's own bundled skills are unaffected — only workflows are excluded."""
-        _make_workflow(tmp_path, "active", "wf-promoted")
+        _make_workflow(tmp_path, "wf-one")
         cfg_path = tmp_path / "config.toml"
         with patch("medmcp.settings.VIBE_HOME", tmp_path):
             sync_servers_to_vibe_config(
@@ -174,7 +174,7 @@ class TestWorkflowsAreNotSkills:
 
     def test_stale_workflow_names_are_dropped_from_disabled_skills(self, tmp_path: Path) -> None:
         """Names left in disabled_skills by the old gating are cleaned up."""
-        _make_workflow(tmp_path, "draft", "wf-draft")
+        _make_workflow(tmp_path, "wf-draft")
         cfg_path = tmp_path / "config.toml"
         cfg_path.write_text('disabled_skills = ["wf-draft", "skill-creator"]\n')
         with patch("medmcp.settings.VIBE_HOME", tmp_path):
@@ -389,32 +389,34 @@ class TestSyncServersToVibeConfig:
 # ── Personal workflows: discovery & disabled_skills sync ──────────────────────
 
 
-def _make_workflow(root: Path, kind: str, name: str, description: str = "") -> None:
-    """Create a minimal <root>/workflows/<kind>/<name>/SKILL.md."""
-    d = root / "workflows" / kind / name
+def _make_workflow(root: Path, name: str, description: str = "") -> None:
+    """Create a minimal <root>/workflows/<name>/recipe.yaml."""
+    d = root / "workflows" / name
     d.mkdir(parents=True)
-    front = f"---\nname: {name}\ndescription: {description}\n---\n# {name}\n"
-    (d / "SKILL.md").write_text(front)
+    (d / "recipe.yaml").write_text(f"name: {name}\ndescription: {description}\n")
 
 
 class TestDiscoverWorkflows:
-    """discover_workflows scans draft/ and active/ for SKILL.md entries."""
+    """discover_workflows lists every recipe under .vibe/workflows."""
 
-    def test_finds_active_and_draft(self, tmp_path: Path) -> None:
-        """Both promoted and draft workflows are discovered with their kind."""
-        _make_workflow(tmp_path, "active", "brain-mri", "skull strip")
-        _make_workflow(tmp_path, "draft", "spine-seg", "segment spine")
+    def test_lists_workflows_with_descriptions(self, tmp_path: Path) -> None:
+        """Each workflow directory becomes one row carrying the recipe's description."""
+        _make_workflow(tmp_path, "brain-mri", "skull strip")
+        _make_workflow(tmp_path, "spine-seg", "segment spine")
         with patch("medmcp.settings.VIBE_HOME", tmp_path):
-            found = {w["name"]: w for w in discover_workflows()}
-        assert found["brain-mri"]["kind"] == "active"
-        assert found["brain-mri"]["description"] == "skull strip"
-        assert found["spine-seg"]["kind"] == "draft"
+            found = discover_workflows()
+        assert found == [
+            {"name": "brain-mri", "description": "skull strip"},
+            {"name": "spine-seg", "description": "segment spine"},
+        ]
 
-    def test_active_shadows_draft_of_same_name(self, tmp_path: Path) -> None:
-        """A name present in both dirs resolves to the active entry."""
-        _make_workflow(tmp_path, "active", "dup")
-        _make_workflow(tmp_path, "draft", "dup")
+    def test_legacy_draft_and_active_entries_are_folded_in(self, tmp_path: Path) -> None:
+        """Workflows from the draft/active era are listed after the one-time fold."""
+        for kind, name in (("active", "dup"), ("draft", "dup"), ("draft", "spine-seg")):
+            d = tmp_path / "workflows" / kind / name
+            d.mkdir(parents=True)
+            (d / "recipe.yaml").write_text(f"name: {name}\ndescription: {kind}\n")
         with patch("medmcp.settings.VIBE_HOME", tmp_path):
-            found = [w for w in discover_workflows() if w["name"] == "dup"]
-        assert len(found) == 1
-        assert found[0]["kind"] == "active"
+            found = {w["name"]: w["description"] for w in discover_workflows()}
+        # The promoted one keeps its name; the shadowed draft survives under a suffix.
+        assert found == {"dup": "active", "dup-draft": "draft", "spine-seg": "draft"}

--- a/tests/test_distill.py
+++ b/tests/test_distill.py
@@ -11,7 +11,7 @@ import pytest
 import yaml
 
 # pyright: reportPrivateUsage=false
-from medmcp import distill, provcli, provenance
+from medmcp import distill, provenance
 from medmcp.workflow import Recipe, RecipeStep, StackRequirement
 
 JsonDict = dict[str, Any]
@@ -196,24 +196,6 @@ class TestBuildRecipe:
         assert [s.tool for s in recipe.steps] == ["skull_strip", "register_to_template"]
 
 
-class TestProseParsing:
-    """_parse_prose_response handles fenced and inline JSON."""
-
-    def test_plain_json(self) -> None:
-        """A bare JSON object parses."""
-        parsed = distill._parse_prose_response('{"name": "x", "description": "y"}')
-        assert parsed == {"name": "x", "description": "y"}
-
-    def test_fenced_json(self) -> None:
-        """A ```json fenced block is unwrapped."""
-        parsed = distill._parse_prose_response('```json\n{"name": "x"}\n```')
-        assert parsed == {"name": "x"}
-
-    def test_garbage_returns_none(self) -> None:
-        """Unparseable text returns None."""
-        assert distill._parse_prose_response("not json at all") is None
-
-
 def test_slugify() -> None:
     """Slugs are lowercased, hyphenated, and bounded."""
     assert distill.slugify("Skull Strip & Register!") == "skull-strip-register"
@@ -281,74 +263,19 @@ class TestFirstUserMessage:
         assert distill._first_user_message(messages) == "Register this scan"
 
 
-class TestRenderSkillMd:
-    """render_skill_md produces a valid SKILL.md with or without prose."""
-
-    def test_mechanical_fallback(self) -> None:
-        """Without prose, steps render mechanically and inputs are listed."""
-        recipe = distill.build_recipe(
-            _MESSAGES, server_names=["medmcp-neuro"], name="my-flow", description="desc"
-        )
-        md = distill.render_skill_md(recipe, None)
-        assert md.startswith("---\nname: my-flow\n")
-        assert "## Steps" in md
-        assert "`medmcp-neuro:skull_strip`" in md
-        assert "## Inputs" in md
-
-    def test_uses_prose_when_present(self) -> None:
-        """Prose name/description/steps override the mechanical defaults."""
-        recipe = distill.build_recipe(
-            _MESSAGES, server_names=["medmcp-neuro"], name="my-flow", description="desc"
-        )
-        prose: JsonDict = {
-            "description": "A nicer description.",
-            "steps_markdown": "1. Do the thing.",
-            "gotchas_markdown": "- Mind the gap.",
-        }
-        md = distill.render_skill_md(recipe, prose)
-        assert "A nicer description." in md
-        assert "Do the thing." in md
-        assert "## Gotchas" in md
-
-    def test_lists_required_tools(self) -> None:
-        """A ## Tools section names every server:tool the workflow needs."""
-        recipe = distill.build_recipe(
-            _MESSAGES, server_names=["medmcp-neuro"], name="my-flow", description="desc"
-        )
-        md = distill.render_skill_md(recipe, None)
-        assert "## Tools" in md
-        assert "`medmcp-neuro:skull_strip` — from the `medmcp-neuro` stack" in md
-        assert "`medmcp-neuro:register_to_template`" in md
-
-    def test_required_tools_dedup(self) -> None:
-        """Distinct MCP tools are listed once, in first-seen order."""
-        recipe = Recipe(name="f", description="d")
-        recipe.steps = [
-            RecipeStep(server="medmcp-neuro", tool="skull_strip", arguments={}),
-            RecipeStep(server="medmcp-neuro", tool="skull_strip", arguments={}),
-            RecipeStep(server="medmcp-neuro", tool="coregister", arguments={}),
-        ]
-        assert distill._required_tools(recipe) == [
-            ("medmcp-neuro", "skull_strip"),
-            ("medmcp-neuro", "coregister"),
-        ]
-
-    def test_builtin_calls_recorded_as_manual_steps(self) -> None:
-        """Built-in (non-MCP) calls are dropped but surfaced as manual steps in Gotchas."""
-        messages: list[JsonDict] = [
-            _assistant_call("b0", "bash", {"command": "convert a b"}),
-            _tool_result("b0", "ok: True"),
-        ]
-        recipe = distill.build_recipe(messages, server_names=[], name="f", description="d")
-        assert distill._required_tools(recipe) == []
-        assert recipe.manual_steps == ["builtin:bash `convert a b`"]
-        md = distill.render_skill_md(recipe, None)
-        assert "## Gotchas" in md
-        assert "builtin:bash `convert a b`" in md
+def test_builtin_calls_recorded_as_manual_steps() -> None:
+    """Built-in (non-MCP) calls are dropped from the steps but kept as manual steps."""
+    messages: list[JsonDict] = [
+        _assistant_call("b0", "bash", {"command": "convert a b"}),
+        _tool_result("b0", "ok: True"),
+    ]
+    recipe = distill.build_recipe(messages, server_names=[], name="f", description="d")
+    assert recipe.steps == []
+    assert recipe.manual_steps == ["builtin:bash `convert a b`"]
 
 
 class TestRequirements:
-    """build_requirements + the ## Requirements rendering."""
+    """build_requirements pins the stacks a recipe uses."""
 
     def test_filters_to_used_stacks_and_pins(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Only stacks the recipe uses are required; container→image+digest, uv→version."""
@@ -379,20 +306,6 @@ class TestRequirements:
         recipe.steps = [RecipeStep(server="medmcp-x", tool="t", arguments={})]
         assert distill.build_requirements(recipe, None) == [StackRequirement(stack="medmcp-x")]
 
-    def test_requirements_rendered_in_skill_md(self) -> None:
-        """## Requirements pins each stack by image(+digest) or version."""
-        recipe = Recipe(name="w", description="d")
-        recipe.requires = [
-            StackRequirement(
-                stack="medmcp-neuro", image="ghcr.io/medmcp/neuro:main", digest="sha256:abc"
-            ),
-            StackRequirement(stack="medmcp-dicom", version="0.1.0"),
-        ]
-        md = distill.render_skill_md(recipe, None)
-        assert "## Requirements" in md
-        assert "image `ghcr.io/medmcp/neuro:main` (`sha256:abc`)" in md
-        assert "version `0.1.0`" in md
-
 
 def _write_fake_session(root: Path) -> None:
     """Create a minimal vibe session log dir under *root* (a VIBE_HOME)."""
@@ -405,30 +318,50 @@ def _write_fake_session(root: Path) -> None:
 
 
 def test_distill_session_end_to_end(tmp_path: Path) -> None:
-    """distill_session writes recipe.yaml + SKILL.md from a session's raw log."""
+    """distill_session writes one recipe.yaml, named from the opening request."""
     _write_fake_session(tmp_path)
     workflows_root = tmp_path / "workflows"
     with patch.object(provenance, "VIBE_HOME", tmp_path):
-        draft_dir = distill.distill_session(
-            SESSION_ID, use_llm=False, workflows_root=workflows_root
-        )
+        target = distill.distill_session(SESSION_ID, workflows_root=workflows_root)
 
-    assert (draft_dir / "SKILL.md").exists()
-    recipe_yaml = (draft_dir / "recipe.yaml").read_text()
-    recipe = yaml.safe_load(recipe_yaml)
+    assert target == workflows_root / "skull-strip-and-register-the-t1"
+    assert sorted(p.name for p in target.iterdir()) == ["recipe.yaml"]
+    recipe = yaml.safe_load((target / "recipe.yaml").read_text())
+    assert recipe["name"] == "skull-strip-and-register-the-t1"
+    assert recipe["description"] == "Skull strip and register the T1"
     assert [s["tool"] for s in recipe["steps"]] == ["skull_strip", "register_to_template"]
     assert recipe["steps"][1]["arguments"]["input_path"] == "{{step1.brain_path}}"
+
+
+def test_distill_names_the_workflow_after_the_chat(tmp_path: Path) -> None:
+    """A chat title names the workflow; the opening request stays the description."""
+    _write_fake_session(tmp_path)
+    with patch.object(provenance, "VIBE_HOME", tmp_path):
+        target = distill.distill_session(
+            SESSION_ID,
+            name_hint="Brain MRI: strip & register",
+            workflows_root=tmp_path / "workflows",
+        )
+    assert target.name == "brain-mri-strip-register"
+    assert distill.load_recipe(target).description == "Skull strip and register the T1"
+
+
+def test_distill_never_replaces_an_existing_workflow(tmp_path: Path) -> None:
+    """Two chats with the same title give two workflows, not one overwriting the other."""
+    _write_fake_session(tmp_path)
+    root = tmp_path / "workflows"
+    with patch.object(provenance, "VIBE_HOME", tmp_path):
+        first = distill.distill_session(SESSION_ID, name_hint="Strip", workflows_root=root)
+        second = distill.distill_session(SESSION_ID, name_hint="Strip", workflows_root=root)
+    assert (first.name, second.name) == ("strip", "strip-2")
+    assert distill.load_recipe(second).name == "strip-2"
 
 
 def test_distill_session_missing_log_raises(tmp_path: Path) -> None:
     """A session with no raw log raises FileNotFoundError."""
     (tmp_path / "logs" / "session").mkdir(parents=True)
-    with patch.object(provenance, "VIBE_HOME", tmp_path):
-        try:
-            distill.distill_session(SESSION_ID, use_llm=False)
-        except FileNotFoundError:
-            return
-    raise AssertionError("expected FileNotFoundError")
+    with patch.object(provenance, "VIBE_HOME", tmp_path), pytest.raises(FileNotFoundError):
+        distill.distill_session(SESSION_ID)
 
 
 def test_distill_session_spans_compaction_chain(tmp_path: Path) -> None:
@@ -460,11 +393,9 @@ def test_distill_session_spans_compaction_chain(tmp_path: Path) -> None:
             f.write(json.dumps(msg) + "\n")
 
     with patch.object(provenance, "VIBE_HOME", tmp_path):
-        draft_dir = distill.distill_session(
-            SESSION_ID, use_llm=False, workflows_root=tmp_path / "workflows"
-        )
+        target = distill.distill_session(SESSION_ID, workflows_root=tmp_path / "workflows")
 
-    recipe = yaml.safe_load((draft_dir / "recipe.yaml").read_text())
+    recipe = yaml.safe_load((target / "recipe.yaml").read_text())
     assert [s["tool"] for s in recipe["steps"]] == [
         "skull_strip",
         "register_to_template",
@@ -472,172 +403,83 @@ def test_distill_session_spans_compaction_chain(tmp_path: Path) -> None:
     ]
 
 
-def test_promote_moves_draft_to_active(tmp_path: Path) -> None:
-    """Promote relocates a reviewed draft into active/ for skill discovery."""
-    draft = tmp_path / "workflows" / "draft" / "my-flow"
-    draft.mkdir(parents=True)
-    (draft / "SKILL.md").write_text("---\nname: my-flow\n---\n")
-    (draft / "recipe.yaml").write_text("name: my-flow\n")
-    with patch.object(provenance, "VIBE_HOME", tmp_path):
-        rc = provcli._promote("my-flow")
-
-    assert rc == 0
-    active = tmp_path / "workflows" / "active" / "my-flow"
-    assert (active / "SKILL.md").exists()
-    assert not draft.exists()
+# ── Rename / delete ──────────────────────────────────────────────────────────
 
 
-def test_promote_missing_draft_errors(tmp_path: Path) -> None:
-    """Promoting a non-existent draft returns a non-zero exit code."""
-    with patch.object(provenance, "VIBE_HOME", tmp_path):
-        assert provcli._promote("nope") == 1
-
-
-# ── Draft editing: rename / refine / discard ─────────────────────────────────
-
-
-def _make_draft(tmp_path: Path) -> tuple[Path, Path]:
-    """Distill a real (no-LLM) draft; return (workflows_root, draft_dir)."""
+def _make_workflow(tmp_path: Path) -> tuple[Path, Path]:
+    """Distill a real workflow; return (workflows_root, workflow_dir)."""
     _write_fake_session(tmp_path)
     workflows_root = tmp_path / "workflows"
     with patch.object(provenance, "VIBE_HOME", tmp_path):
-        draft_dir = distill.distill_session(
-            SESSION_ID, use_llm=False, workflows_root=workflows_root
-        )
-    return workflows_root, draft_dir
+        target = distill.distill_session(SESSION_ID, workflows_root=workflows_root)
+    return workflows_root, target
 
 
-def test_rename_draft_relocates_and_rewrites(tmp_path: Path) -> None:
-    """Rename moves the draft dir and updates the name in recipe.yaml + SKILL.md."""
-    workflows_root, draft_dir = _make_draft(tmp_path)
-    old_name = draft_dir.name
+def test_rename_workflow_relocates_and_rewrites(tmp_path: Path) -> None:
+    """Rename moves the directory and updates the name in recipe.yaml."""
+    workflows_root, wf_dir = _make_workflow(tmp_path)
 
-    new_dir = distill.rename_draft(old_name, "Fancy New Name!", workflows_root=workflows_root)
+    new_dir = distill.rename_workflow(wf_dir.name, "Fancy New Name!", workflows_root=workflows_root)
 
-    assert new_dir.name == "fancy-new-name"
-    assert not draft_dir.exists()  # old dir gone
+    assert new_dir == workflows_root / "fancy-new-name"
+    assert not wf_dir.exists()
     recipe = distill.load_recipe(new_dir)
     assert recipe.name == "fancy-new-name"
     assert recipe.steps  # the pipeline is preserved across the rename
-    assert (new_dir / "SKILL.md").read_text().startswith("---\nname: fancy-new-name\n")
 
 
-def test_rename_draft_missing_raises(tmp_path: Path) -> None:
-    """Renaming a draft that doesn't exist raises FileNotFoundError."""
-    workflows_root = tmp_path / "workflows"
-    try:
-        distill.rename_draft("nope", "x", workflows_root=workflows_root)
-    except FileNotFoundError:
-        return
-    raise AssertionError("expected FileNotFoundError")
+def test_rename_workflow_missing_raises(tmp_path: Path) -> None:
+    """Renaming a workflow that doesn't exist raises FileNotFoundError."""
+    with pytest.raises(FileNotFoundError):
+        distill.rename_workflow("nope", "x", workflows_root=tmp_path / "workflows")
 
 
-def test_discard_draft_removes_dir(tmp_path: Path) -> None:
-    """Discard deletes the draft directory."""
-    workflows_root, draft_dir = _make_draft(tmp_path)
-    distill.discard_draft(draft_dir.name, workflows_root=workflows_root)
-    assert not draft_dir.exists()
+def test_rename_workflow_never_replaces_another(tmp_path: Path) -> None:
+    """Renaming onto a taken name is refused instead of overwriting that workflow."""
+    workflows_root, wf_dir = _make_workflow(tmp_path)
+    other = workflows_root / "other"
+    other.mkdir()
+    (other / "recipe.yaml").write_text("name: other\ndescription: keep me\n")
+
+    with pytest.raises(FileExistsError):
+        distill.rename_workflow(wf_dir.name, "Other", workflows_root=workflows_root)
+
+    assert distill.load_recipe(other).description == "keep me"
+    assert wf_dir.exists()
 
 
-def test_discard_draft_missing_raises(tmp_path: Path) -> None:
-    """Discarding a non-existent draft raises FileNotFoundError."""
-    try:
-        distill.discard_draft("nope", workflows_root=tmp_path / "workflows")
-    except FileNotFoundError:
-        return
-    raise AssertionError("expected FileNotFoundError")
+def test_rename_workflow_to_its_own_name_keeps_it(tmp_path: Path) -> None:
+    """A rename that slugifies to the current name changes nothing and does not raise."""
+    workflows_root, wf_dir = _make_workflow(tmp_path)
+    renamed = distill.rename_workflow(wf_dir.name, wf_dir.name, workflows_root=workflows_root)
+    assert renamed == wf_dir
+    assert wf_dir.exists()
 
 
-def test_refine_draft_rewrites_prose_keeps_identity(tmp_path: Path) -> None:
-    """Refine regenerates prose (mocked) while keeping the draft's name and steps."""
-    workflows_root, draft_dir = _make_draft(tmp_path)
-    name = draft_dir.name
-    new_prose: JsonDict = {
-        "name": "model-tried-to-rename",  # must be ignored — identity is preserved
-        "description": "Refined description.",
-        "steps_markdown": "1. Refined step.",
-        "gotchas_markdown": "",
-    }
-    with patch.object(distill, "generate_prose", return_value=new_prose):
-        out = distill.refine_draft(name, "make it generic", workflows_root=workflows_root)
-
-    assert out == draft_dir  # same dir; refine never relocates
-    recipe = distill.load_recipe(out)
-    assert recipe.name == name  # identity preserved despite the model's suggestion
-    assert recipe.description == "Refined description."
-    assert "Refined step." in (out / "SKILL.md").read_text()
-
-
-def test_unpromote_moves_active_back_to_draft(tmp_path: Path) -> None:
-    """unpromote_workflow returns a promoted workflow to draft/ for editing."""
-    active = tmp_path / "workflows" / "active" / "flow"
-    active.mkdir(parents=True)
-    (active / "SKILL.md").write_text("---\nname: flow\n---\n")
-    (active / "recipe.yaml").write_text("name: flow\n")
-
-    draft = distill.unpromote_workflow("flow", workflows_root=tmp_path / "workflows")
-
-    assert draft == tmp_path / "workflows" / "draft" / "flow"
-    assert (draft / "SKILL.md").exists()
-    assert not active.exists()
-
-
-def test_unpromote_missing_raises(tmp_path: Path) -> None:
-    """Unpromoting a non-promoted workflow raises FileNotFoundError."""
-    try:
-        distill.unpromote_workflow("nope", workflows_root=tmp_path / "workflows")
-    except FileNotFoundError:
-        return
-    raise AssertionError("expected FileNotFoundError")
-
-
-def test_promote_then_unpromote_round_trips(tmp_path: Path) -> None:
-    """A draft promoted and then unpromoted lands back in draft/ intact."""
-    _, draft_dir = _make_draft(tmp_path)
-    name = draft_dir.name
-    distill.promote_draft(name, workflows_root=tmp_path / "workflows")
-    assert not draft_dir.exists()
-    back = distill.unpromote_workflow(name, workflows_root=tmp_path / "workflows")
-    assert back == draft_dir
-    assert (back / "SKILL.md").exists()
-
-
-def test_delete_workflow_removes_active(tmp_path: Path) -> None:
-    """delete_workflow removes a promoted workflow from active/."""
-    active = tmp_path / "workflows" / "active" / "flow"
-    active.mkdir(parents=True)
-    (active / "SKILL.md").write_text("---\nname: flow\n---\n")
-    removed = distill.delete_workflow("flow", workflows_root=tmp_path / "workflows")
-    assert removed == active
-    assert not active.exists()
-
-
-def test_delete_workflow_removes_draft(tmp_path: Path) -> None:
-    """delete_workflow also removes an unpromoted draft."""
-    _, draft_dir = _make_draft(tmp_path)
-    removed = distill.delete_workflow(draft_dir.name, workflows_root=tmp_path / "workflows")
-    assert removed == draft_dir
-    assert not draft_dir.exists()
+def test_delete_workflow_removes_dir(tmp_path: Path) -> None:
+    """delete_workflow removes the workflow's directory and returns it."""
+    workflows_root, wf_dir = _make_workflow(tmp_path)
+    removed = distill.delete_workflow(wf_dir.name, workflows_root=workflows_root)
+    assert removed == wf_dir
+    assert not wf_dir.exists()
 
 
 def test_delete_workflow_missing_raises(tmp_path: Path) -> None:
     """Deleting a non-existent workflow raises FileNotFoundError."""
-    try:
+    with pytest.raises(FileNotFoundError):
         distill.delete_workflow("nope", workflows_root=tmp_path / "workflows")
-    except FileNotFoundError:
-        return
-    raise AssertionError("expected FileNotFoundError")
 
 
-def test_refine_draft_model_failure_raises(tmp_path: Path) -> None:
-    """When the model returns nothing, refine raises rather than silently no-op."""
-    workflows_root, draft_dir = _make_draft(tmp_path)
-    with patch.object(distill, "generate_prose", return_value=None):
-        try:
-            distill.refine_draft(draft_dir.name, "x", workflows_root=workflows_root)
-        except RuntimeError:
-            return
-    raise AssertionError("expected RuntimeError")
+def test_legacy_layout_is_folded_in_before_any_lookup(tmp_path: Path) -> None:
+    """A workflow saved under the old draft/ dir is found by name after the fold."""
+    root = tmp_path / "workflows"
+    legacy = root / "draft" / "strip"
+    legacy.mkdir(parents=True)
+    (legacy / "recipe.yaml").write_text("name: strip\ndescription: d\n")
+    (legacy / "SKILL.md").write_text("---\nname: strip\n---\n")
+
+    assert distill.delete_workflow("strip", workflows_root=root) == root / "strip"
+    assert not (root / "draft").exists()
 
 
 # ── derived defaults for container directories ───────────────────────────────

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -1,0 +1,248 @@
+"""Tests for persisted replay runs and the detached run manager."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import AsyncGenerator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from medmcp import replay, runs
+from medmcp.workflow import Recipe, RecipeStep, WorkflowInput
+
+# pyright: reportPrivateUsage=false
+
+JsonDict = dict[str, Any]
+
+
+def _recipe() -> Recipe:
+    return Recipe(
+        name="strip-register",
+        description="",
+        inputs=[WorkflowInput(name="in_1", example="/data/t1.nii.gz")],
+        steps=[
+            RecipeStep(
+                server="medmcp-neuro",
+                tool="skull_strip",
+                arguments={"input_path": "{{in_1}}"},
+                produces={"brain_path": "step1.brain_path"},
+            ),
+            RecipeStep(
+                server="medmcp-neuro",
+                tool="register_to_template",
+                arguments={"input_path": "{{step1.brain_path}}"},
+                produces={"registered_path": "step2.registered_path"},
+            ),
+        ],
+    )
+
+
+def _servers() -> list[JsonDict]:
+    return [{"name": "medmcp-neuro", "command": "x", "args": []}]
+
+
+def _fake_caller(calls: list[tuple[str, str, JsonDict]], outputs: dict[str, str]):  # noqa: ANN202
+    @contextlib.asynccontextmanager
+    async def _cm(*_args: object, **_kwargs: object) -> AsyncGenerator[replay.ToolCaller]:
+        async def _call(
+            server: str, tool: str, args: JsonDict
+        ) -> tuple[bool, JsonDict, str | None]:
+            calls.append((server, tool, args))
+            if tool == "skull_strip":
+                return True, {"brain_path": outputs["brain"]}, None
+            return True, {"registered_path": outputs["registered"]}, None
+
+        yield _call
+
+    return _cm
+
+
+# ── the record ────────────────────────────────────────────────────────────────
+
+
+def test_record_round_trips_and_derives_frames(tmp_path: Path) -> None:
+    """A saved record reloads identically and reconstructs the frames a client saw."""
+    out = tmp_path / "o1.nii.gz"
+    out.write_bytes(b"x")
+    record = runs.RunRecord(
+        id="20260101-000000-abc123",
+        workflow="w",
+        steps_per_item=2,
+        items=[runs.ItemRecord(inputs={"in_1": "/a"}), runs.ItemRecord(inputs={"in_1": "/b"})],
+    )
+    record.items[0].steps.append(
+        runs.StepRecord(1, "s", "t", {"x": "/a"}, True, produced={"step1.p": str(out)})
+    )
+    record.items[0].steps.append(runs.StepRecord(2, "s", "u", {"x": "/o1"}, True, produced={}))
+    record.items[0].ok = True
+    runs.save_run(record, root=tmp_path)
+
+    loaded = runs.load_run(record.id, root=tmp_path)
+    assert loaded is not None
+    assert loaded.to_dict() == record.to_dict()
+
+    kinds = [f["type"] for f in loaded.frames()]
+    assert kinds == ["started", "step", "step", "item_result"]  # not finished: no result frame
+    loaded.status = "done"
+    assert loaded.frames()[-1]["type"] == "result"
+    assert loaded.frames()[-1]["outputs"] == [str(out)]
+    assert loaded.summary()["succeeded"] == 1
+
+
+def test_item_files_keeps_only_output_files(tmp_path: Path) -> None:
+    """Echoed inputs, absent paths and directories are not outputs; a prefix expands."""
+    scan = tmp_path / "t1.nii.gz"
+    scan.write_bytes(b"x")
+    brain = tmp_path / "t1_brain.nii.gz"
+    brain.write_bytes(b"y")
+    for suffix in ("0GenericAffine.mat", "1Warp.nii.gz"):
+        (tmp_path / f"t1_to_MNI_{suffix}").write_bytes(b"z")
+    item = runs.ItemRecord(inputs={"in_1": str(scan)})
+    item.steps.append(
+        runs.StepRecord(
+            1,
+            "neuro",
+            "skull_strip",
+            {"input_path": str(scan)},
+            True,
+            produced={
+                "step1.input_path": str(scan),  # the tool echoing its input
+                "step1.brain_path": str(brain),
+                "step1.output_dir": str(tmp_path),  # a directory
+                "step1.template_path": "/root/.cache/template.nii.gz",  # not on this disk
+                "step1.transform_prefix": str(tmp_path / "t1_to_MNI_"),  # a prefix
+            },
+        )
+    )
+    assert item.files() == [
+        str(brain),
+        str(tmp_path / "t1_to_MNI_0GenericAffine.mat"),
+        str(tmp_path / "t1_to_MNI_1Warp.nii.gz"),
+    ]
+    assert len(item.outputs) == 5  # the raw record keeps everything for chaining
+
+
+def test_list_runs_newest_first_and_filtered(tmp_path: Path) -> None:
+    """Listing sorts by id (chronological) descending and filters by workflow."""
+    for rid, wf in [("20260101-000000-aaa", "w1"), ("20260102-000000-bbb", "w2")]:
+        runs.save_run(
+            runs.RunRecord(id=rid, workflow=wf, steps_per_item=1, items=[]), root=tmp_path
+        )
+    assert [r.id for r in runs.list_runs(root=tmp_path)] == [
+        "20260102-000000-bbb",
+        "20260101-000000-aaa",
+    ]
+    assert [r.workflow for r in runs.list_runs(workflow="w1", root=tmp_path)] == ["w1"]
+    assert runs.delete_run("20260101-000000-aaa", root=tmp_path) is True
+    assert runs.delete_run("20260101-000000-aaa", root=tmp_path) is False
+
+
+def test_reconcile_marks_orphaned_running_records_failed(tmp_path: Path) -> None:
+    """A record left 'running' by a dead process is closed out, not shown as live forever."""
+    record = runs.RunRecord(id="20260101-000000-abc", workflow="w", steps_per_item=1, items=[])
+    record.items.append(runs.ItemRecord(inputs={}, steps=[runs.StepRecord(1, "s", "t", {}, True)]))
+    runs.save_run(record, root=tmp_path)
+    assert runs.reconcile_interrupted(root=tmp_path) == 1
+    fixed = runs.load_run(record.id, root=tmp_path)
+    assert fixed is not None
+    assert fixed.status == "failed"
+    assert fixed.items[0].ok is False
+    assert runs.reconcile_interrupted(root=tmp_path) == 0  # idempotent
+
+
+# ── the run manager ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_manager_runs_detached_and_records_every_step(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A run survives its subscriber leaving; the record on disk tells the story."""
+    calls: list[tuple[str, str, JsonDict]] = []
+    monkeypatch.setattr(
+        replay, "mcp_caller", _fake_caller(calls, {"brain": "/b", "registered": "/r"})
+    )
+    manager = runs.RunManager(root=tmp_path)
+
+    record = manager.start(
+        recipe=_recipe(),
+        runs=[{"in_1": "/a"}, {"in_1": "/b"}],
+        servers=_servers(),
+        cwd=None,
+    )
+    assert manager.is_live(record.id)
+    attached = manager.attach(record.id)
+    assert attached is not None
+    past, queue = attached
+    assert past[0]["type"] == "started" and past[0]["run_id"] == record.id
+    assert queue is not None
+    manager.detach(record.id, queue)  # the browser goes away…
+
+    for _ in range(100):  # …and the run finishes anyway
+        if not manager.is_live(record.id):
+            break
+        await asyncio.sleep(0.01)
+    assert not manager.is_live(record.id)
+    assert len(calls) == 4
+
+    saved = runs.load_run(record.id, root=tmp_path)
+    assert saved is not None
+    assert saved.status == "done"
+    assert [i.ok for i in saved.items] == [True, True]
+    assert saved.items[1].outputs == ["/b", "/r"]  # raw produced values, files or not
+    # A late attach to the finished run replays the full story from disk.
+    late = manager.attach(record.id)
+    assert late is not None
+    frames, late_queue = late
+    assert late_queue is None
+    assert [f["type"] for f in frames] == [
+        "started",
+        "step",
+        "step",
+        "item_result",
+        "step",
+        "step",
+        "item_result",
+        "result",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_manager_cancel_stops_the_run_and_marks_the_record(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Cancel kills the in-flight step; the record says 'cancelled', not 'running'."""
+    started = asyncio.Event()
+
+    @contextlib.asynccontextmanager
+    async def slow_caller(*_a: object, **_k: object) -> AsyncGenerator[replay.ToolCaller]:
+        async def _call(
+            server: str, tool: str, args: JsonDict
+        ) -> tuple[bool, JsonDict, str | None]:
+            started.set()
+            await asyncio.sleep(60)
+            return True, {}, None
+
+        yield _call
+
+    monkeypatch.setattr(replay, "mcp_caller", slow_caller)
+    manager = runs.RunManager(root=tmp_path)
+    record = manager.start(recipe=_recipe(), runs=[{"in_1": "/a"}], servers=_servers(), cwd=None)
+    attached = manager.attach(record.id)
+    assert attached is not None
+    _past, queue = attached
+    assert queue is not None
+    await asyncio.wait_for(started.wait(), 2)
+    assert (await queue.get())["type"] == "step_started"
+
+    assert await manager.cancel(record.id) is True
+    assert not manager.is_live(record.id)
+    final = await queue.get()
+    assert final["type"] == "result" and final["status"] == "cancelled"
+    assert runs.is_end(await queue.get())
+    saved = runs.load_run(record.id, root=tmp_path)
+    assert saved is not None and saved.status == "cancelled"
+    assert await manager.cancel(record.id) is False

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -384,6 +384,22 @@ class TestWorkflowShareEndpoints:
         client = TestClient(server.app, base_url="http://127.0.0.1:8100")
         assert client.get("/api/workflows/nope/export").status_code == 404
 
+    def test_rename_onto_a_taken_name_is_409(self, vibe_home: Path) -> None:
+        """A rename never replaces another workflow."""
+        client = TestClient(server.app, base_url="http://127.0.0.1:8100")
+        first = client.post("/api/workflows/import", json={"content": self._envelope()})
+        assert first.status_code == 200
+        other = yaml.safe_load(self._envelope())
+        other["name"] = "other-flow"
+        second = client.post("/api/workflows/import", json={"content": yaml.safe_dump(other)})
+        assert second.status_code == 200
+
+        resp = client.post("/api/workflows/other-flow/rename", json={"new_name": "Demo Flow"})
+
+        assert resp.status_code == 409
+        assert client.get("/api/workflows/demo-flow").json()["description"] == "demo"
+        assert client.get("/api/workflows/other-flow").status_code == 200
+
 
 # ── Session resume helpers ───────────────────────────────────────────────────
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -947,3 +947,116 @@ class TestPathGuardDenialTagging:
     def test_another_hook_is_not_tagged(self) -> None:
         """Only this guard's denials are softened; someone else's stay visible."""
         assert not server._is_pathguard_denial("Tool 'x' was denied by hook 'other': no")
+
+
+# ── Replay runs: pre-flight preview, detached runs over the socket ───────────
+
+
+_WS_HEADERS = {"host": "127.0.0.1:8100", "origin": "http://127.0.0.1:8100"}
+
+
+class TestReplayRuns:
+    """The run screen's preview pre-flights every item; runs outlive the socket."""
+
+    @pytest.fixture
+    def env(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+        """A temp VIBE_HOME with one imported workflow, a temp workspace, temp runs."""
+        from medmcp import replay, runs
+
+        monkeypatch.setattr(server, "VIBE_HOME", tmp_path)
+        monkeypatch.setattr(provenance, "VIBE_HOME", tmp_path)
+        monkeypatch.setattr(runs, "RUNS_DIR", tmp_path / "runs")
+        workspace = (tmp_path / "ws").resolve()
+        workspace.mkdir()
+        monkeypatch.setattr(server, "WORKSPACE_ROOT", workspace)
+        neuro: list[dict[str, Any]] = [{"name": "medmcp-neuro", "command": "x", "args": []}]
+        monkeypatch.setattr(settings, "active_servers", lambda: neuro)
+        (workspace / "t1.nii.gz").write_bytes(b"x")
+        envelope = yaml.safe_dump(
+            {
+                "medmcp_workflow": 1,
+                "name": "strip",
+                "description": "demo",
+                "inputs": [{"name": "in_1", "example": "/d/a.nii.gz"}],
+                "steps": [
+                    {
+                        "server": "medmcp-neuro",
+                        "tool": "skull_strip",
+                        "arguments": {"input_path": "{{in_1}}"},
+                        "produces": {"brain_path": "step1.brain_path"},
+                    }
+                ],
+            }
+        )
+        client = TestClient(server.app, base_url="http://127.0.0.1:8100")
+        assert client.post("/api/workflows/import", json={"content": envelope}).status_code == 200
+
+        # The engine never spawns a real stack here.
+        import contextlib
+        from collections.abc import AsyncGenerator
+
+        @contextlib.asynccontextmanager
+        async def fake_caller(*_a: object, **_k: object) -> AsyncGenerator[replay.ToolCaller]:
+            async def _call(
+                srv: str, tool: str, args: dict[str, Any]
+            ) -> tuple[bool, dict[str, Any], str | None]:
+                return True, {"brain_path": str(workspace / "brain.nii.gz")}, None
+
+            yield _call
+
+        monkeypatch.setattr(replay, "mcp_caller", fake_caller)
+        return workspace
+
+    def test_preview_flags_a_missing_input_per_item(self, env: Path) -> None:
+        """A row pointing at a file that is not there is reported before anything runs."""
+        client = TestClient(server.app, base_url="http://127.0.0.1:8100")
+        resp = client.post(
+            "/api/workflows/strip/replay-preview",
+            json={"runs": [{"in_1": "t1.nii.gz"}, {"in_1": "typo.nii.gz"}]},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is True
+        items = body["items"]
+        assert [i["ok"] for i in items] == [True, False]
+        assert items[1]["findings"][0]["status"] == "missing"
+        assert items[1]["findings"][0]["role"] == "input"  # named after the tool's argument
+        assert body["steps"][0]["arguments"]["input_path"] == str(env / "t1.nii.gz")
+
+    def test_run_survives_disconnect_and_can_be_reattached(self, env: Path) -> None:
+        """Closing the socket detaches; the run finishes and a later attach replays it."""
+        client = TestClient(server.app, base_url="http://127.0.0.1:8100")
+        with client.websocket_connect("/ws/replay", headers=_WS_HEADERS) as ws:
+            ws.send_json({"name": "strip", "runs": [{"in_1": "t1.nii.gz"}]})
+            started = ws.receive_json()
+            assert started["type"] == "started"
+            run_id = started["run_id"]
+        # Detached — the run keeps going. Attach again and read the whole story.
+        with client.websocket_connect("/ws/replay", headers=_WS_HEADERS) as ws:
+            ws.send_json({"attach": run_id})
+            frames: list[dict[str, Any]] = []
+            while True:
+                frame = ws.receive_json()
+                frames.append(frame)
+                if frame["type"] == "result":
+                    break
+        assert frames[0]["type"] == "started" and frames[0]["run_id"] == run_id
+        assert frames[-1]["ok"] is True
+        assert any(f["type"] == "step" and f["ok"] for f in frames)
+
+        listing = client.get("/api/runs", params={"workflow": "strip"}).json()
+        assert [r["id"] for r in listing["runs"]] == [run_id]
+        assert listing["runs"][0]["status"] == "done"
+        detail = client.get(f"/api/runs/{run_id}").json()
+        assert detail["items"][0]["steps"][0]["produced"]["step1.brain_path"].endswith(
+            "brain.nii.gz"
+        )
+        assert client.delete(f"/api/runs/{run_id}").status_code == 200
+        assert client.get(f"/api/runs/{run_id}").status_code == 404
+
+    def test_bad_first_message_is_refused(self, env: Path) -> None:
+        """Neither a start nor an attach: the socket answers with an error and closes."""
+        client = TestClient(server.app, base_url="http://127.0.0.1:8100")
+        with client.websocket_connect("/ws/replay", headers=_WS_HEADERS) as ws:
+            ws.send_json({"attach": "nope"})
+            assert ws.receive_json()["ok"] is False

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -113,3 +113,33 @@ def test_pre_feature_title_counts_as_manual() -> None:
     """Entries written before generated titles existed carry no source: manual."""
     assert sessions.has_manual_title({"title": "Old"}) is True
     assert sessions.has_manual_title({}) is False
+
+
+# ── chat_title ───────────────────────────────────────────────────────────────
+
+
+def _vibe_title(_session_id: str) -> str | None:
+    return "vibe"
+
+
+def _no_vibe_title(_session_id: str) -> str | None:
+    return None
+
+
+def test_chat_title_prefers_the_registry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A registry title, generated or not, is the chat's name."""
+    sessions.set_auto_title("s1", "Brain MRI pipeline")
+    monkeypatch.setattr(sessions.provenance, "vibe_manual_session_title", _vibe_title)
+    assert sessions.chat_title("s1") == "Brain MRI pipeline"
+
+
+def test_chat_title_falls_back_to_vibes_manual_title(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With no registry entry, the user-set title vibe recorded is used."""
+    monkeypatch.setattr(sessions.provenance, "vibe_manual_session_title", _vibe_title)
+    assert sessions.chat_title("s1") == "vibe"
+
+
+def test_chat_title_none_when_unnamed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A chat nobody has named yet has no title."""
+    monkeypatch.setattr(sessions.provenance, "vibe_manual_session_title", _no_vibe_title)
+    assert sessions.chat_title("s1") is None

--- a/tests/test_share.py
+++ b/tests/test_share.py
@@ -7,20 +7,8 @@ from pathlib import Path
 import pytest
 import yaml
 
-from medmcp import distill, share
+from medmcp import distill, share, workflow
 from medmcp.workflow import Recipe, RecipeStep, StackRequirement, WorkflowInput
-
-
-def _make_draft(root: Path, recipe: Recipe) -> Path:
-    """Write a draft workflow dir (recipe.yaml + SKILL.md + prose.json) under *root*."""
-    draft = root / "draft" / recipe.name
-    draft.mkdir(parents=True)
-    (draft / "recipe.yaml").write_text(
-        yaml.safe_dump(recipe.to_dict(), sort_keys=False), encoding="utf-8"
-    )
-    (draft / "SKILL.md").write_text(distill.render_skill_md(recipe, None), encoding="utf-8")
-    (draft / "prose.json").write_text("null", encoding="utf-8")
-    return draft
 
 
 def _sample_recipe() -> Recipe:
@@ -54,21 +42,17 @@ class TestExport:
     """export_workflow serializes a workflow dir into the inline-YAML envelope."""
 
     def test_export_missing_raises(self, tmp_path: Path) -> None:
-        """Exporting a name with no draft/active dir raises FileNotFoundError."""
+        """Exporting a name with no workflow dir raises FileNotFoundError."""
         with pytest.raises(FileNotFoundError):
             share.export_workflow("nope", workflows_root=tmp_path)
 
-    def test_export_contains_envelope_and_docs(self, tmp_path: Path) -> None:
-        """Export emits the versioned envelope with steps, requires, and docs."""
-        _make_draft(tmp_path, _sample_recipe())
+    def test_export_is_the_versioned_recipe(self, tmp_path: Path) -> None:
+        """The envelope is the recipe's dict form behind a format marker — nothing else."""
+        workflow.write_recipe(tmp_path / "skull-strip-register", _sample_recipe())
         text = share.export_workflow("skull-strip-register", workflows_root=tmp_path)
         env = yaml.safe_load(text)
-        assert env[share.FORMAT_KEY] == share.FORMAT_VERSION
-        assert env["name"] == "skull-strip-register"
-        assert [s["tool"] for s in env["steps"]] == ["skull_strip", "register_to_template"]
-        assert env["requires"][0]["digest"] == "sha256:abc"
-        assert env["manual_steps"] == ["builtin:bash `convert a b`"]
-        assert "## Requirements" in env["documentation"]
+        assert env.pop(share.FORMAT_KEY) == share.FORMAT_VERSION
+        assert env == _sample_recipe().to_dict()
 
     def test_export_fills_missing_digest(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -78,7 +62,7 @@ class TestExport:
         recipe.requires = [
             StackRequirement(stack="medmcp-neuro", image="ghcr.io/medmcp/neuro:main")
         ]
-        _make_draft(tmp_path, recipe)
+        workflow.write_recipe(tmp_path / "skull-strip-register", recipe)
 
         def _fake_digest(_image: str) -> str:
             return "sha256:resolved"
@@ -89,19 +73,26 @@ class TestExport:
 
 
 class TestImport:
-    """import_workflow validates the envelope and reconstructs a reviewable draft."""
+    """import_workflow validates the envelope and reconstructs the workflow."""
 
     def test_round_trip_preserves_recipe(self, tmp_path: Path) -> None:
-        """Export → import reconstructs an equivalent recipe as a fresh draft."""
+        """Export → import reconstructs an equivalent recipe as a fresh workflow."""
         original = _sample_recipe()
-        _make_draft(tmp_path / "src", original)
+        workflow.write_recipe(tmp_path / "src" / "skull-strip-register", original)
         text = share.export_workflow("skull-strip-register", workflows_root=tmp_path / "src")
 
-        draft = share.import_workflow(text, workflows_root=tmp_path / "dst")
-        assert draft == tmp_path / "dst" / "draft" / "skull-strip-register"
-        imported = distill.load_recipe(draft)
-        assert imported.to_dict() == original.to_dict()
-        assert (draft / "SKILL.md").exists()
+        target = share.import_workflow(text, workflows_root=tmp_path / "dst")
+        assert target == tmp_path / "dst" / "skull-strip-register"
+        assert distill.load_recipe(target).to_dict() == original.to_dict()
+        assert sorted(p.name for p in target.iterdir()) == ["recipe.yaml"]
+
+    def test_import_ignores_the_blocks_older_exports_carried(self, tmp_path: Path) -> None:
+        """A file from a release that wrote documentation and prose still imports."""
+        env = {share.FORMAT_KEY: 1, **_sample_recipe().to_dict()}
+        env["documentation"] = "# Skull strip register workflow\n\n## Steps\n…"
+        env["prose"] = {"name": "x", "steps_markdown": "1. …"}
+        target = share.import_workflow(yaml.safe_dump(env), workflows_root=tmp_path)
+        assert distill.load_recipe(target).to_dict() == _sample_recipe().to_dict()
 
     def test_import_rejects_non_mapping(self, tmp_path: Path) -> None:
         """A payload that isn't a YAML mapping is rejected."""
@@ -122,12 +113,20 @@ class TestImport:
 
     def test_import_collision_gets_suffix(self, tmp_path: Path) -> None:
         """Importing the same workflow twice never clobbers — the second is suffixed."""
-        _make_draft(tmp_path, _sample_recipe())
+        workflow.write_recipe(tmp_path / "skull-strip-register", _sample_recipe())
         text = share.export_workflow("skull-strip-register", workflows_root=tmp_path)
-        draft = share.import_workflow(text, workflows_root=tmp_path)
-        assert draft.name == "skull-strip-register-imported"
+        first = share.import_workflow(text, workflows_root=tmp_path)
+        assert first.name == "skull-strip-register-imported"
         again = share.import_workflow(text, workflows_root=tmp_path)
         assert again.name == "skull-strip-register-imported-2"
+
+    def test_import_into_a_legacy_root_sees_its_workflows(self, tmp_path: Path) -> None:
+        """A name taken by an old draft/ entry is still a collision after the fold."""
+        workflow.write_recipe(tmp_path / "draft" / "skull-strip-register", _sample_recipe())
+        env = {share.FORMAT_KEY: 1, **_sample_recipe().to_dict()}
+        target = share.import_workflow(yaml.safe_dump(env), workflows_root=tmp_path)
+        assert target.name == "skull-strip-register-imported"
+        assert not (tmp_path / "draft").exists()
 
 
 def test_export_import_round_trips_a_derived_default(tmp_path: Path) -> None:
@@ -147,14 +146,11 @@ def test_export_import_round_trips_a_derived_default(tmp_path: Path) -> None:
         steps=[RecipeStep(server="s", tool="t", arguments={"p": "{{in_1}}", "o": "{{in_2}}"})],
     )
     root = tmp_path / "workflows"
-    src = root / "draft" / "wf"
-    src.mkdir(parents=True)
-    (src / "recipe.yaml").write_text(yaml.safe_dump(recipe.to_dict()), encoding="utf-8")
+    workflow.write_recipe(root / "wf", recipe)
 
     envelope = share.export_workflow("wf", workflows_root=root)
     assert "{{dir(in_1)}}" in envelope
 
-    dest_root = tmp_path / "dest"
-    draft = share.import_workflow(envelope, workflows_root=dest_root)
-    loaded = distill.load_recipe(draft)
+    target = share.import_workflow(envelope, workflows_root=tmp_path / "dest")
+    loaded = distill.load_recipe(target)
     assert [i.default for i in loaded.inputs] == ["", "{{dir(in_1)}}"]

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,0 +1,151 @@
+"""Tests for the workflow schema round trip and the on-disk layout."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from medmcp import workflow
+from medmcp.workflow import Recipe, RecipeStep, StackRequirement, WorkflowInput
+
+
+def _recipe(name: str = "strip") -> Recipe:
+    return Recipe(
+        name=name,
+        description="Skull strip a brain MRI.",
+        inputs=[
+            WorkflowInput(name="in_1", example="/d/t1.nii.gz", description="the scan"),
+            WorkflowInput(name="in_2", example="/d", default="{{dir(in_1)}}"),
+        ],
+        steps=[
+            RecipeStep(
+                server="medmcp-neuro",
+                tool="skull_strip",
+                arguments={"input_path": "{{in_1}}", "output_dir": "{{in_2}}"},
+                produces={"brain_path": "step1.brain_path"},
+            )
+        ],
+        requires=[StackRequirement(stack="medmcp-neuro", image="ghcr.io/x:main", digest="sha")],
+        manual_steps=["builtin:bash `ls`"],
+    )
+
+
+# ── schema ───────────────────────────────────────────────────────────────────
+
+
+def test_from_dict_round_trips_to_dict() -> None:
+    """to_dict → from_dict → to_dict is the identity, defaults and pins included."""
+    original = _recipe()
+    assert Recipe.from_dict(original.to_dict()) == original
+
+
+def test_from_dict_ignores_keys_it_does_not_know() -> None:
+    """An export envelope's marker and the blocks older exports carried load cleanly."""
+    data = _recipe().to_dict()
+    data.update({"medmcp_workflow": 1, "documentation": "# Steps", "prose": {"x": 1}})
+    assert Recipe.from_dict(data) == _recipe()
+
+
+def test_from_dict_of_an_empty_mapping_is_an_empty_recipe() -> None:
+    """A recipe.yaml with nothing in it loads rather than raising."""
+    recipe = Recipe.from_dict({})
+    assert (recipe.name, recipe.description, recipe.steps) == ("", "", [])
+
+
+def test_write_then_read_recipe(tmp_path: Path) -> None:
+    """write_recipe creates the directory and read_recipe gets the same recipe back."""
+    d = tmp_path / "wf"
+    workflow.write_recipe(d, _recipe())
+    assert sorted(p.name for p in d.iterdir()) == ["recipe.yaml"]
+    assert workflow.read_recipe(d) == _recipe()
+    # Field order is kept, so a diff of two recipe.yaml files reads naturally.
+    assert list(yaml.safe_load((d / "recipe.yaml").read_text())) == [
+        "name",
+        "description",
+        "inputs",
+        "steps",
+        "requires",
+        "manual_steps",
+    ]
+
+
+# ── naming ───────────────────────────────────────────────────────────────────
+
+
+def test_unique_name_numbers_a_taken_name(tmp_path: Path) -> None:
+    """A free name is returned as is; a taken one gets -2, then -3."""
+    assert workflow.unique_name(tmp_path, "strip") == "strip"
+    (tmp_path / "strip").mkdir()
+    assert workflow.unique_name(tmp_path, "strip") == "strip-2"
+    (tmp_path / "strip-2").mkdir()
+    assert workflow.unique_name(tmp_path, "strip") == "strip-3"
+
+
+def test_unique_name_with_a_tag(tmp_path: Path) -> None:
+    """With a tag the alternatives are -<tag>, then -<tag>-2."""
+    (tmp_path / "strip").mkdir()
+    assert workflow.unique_name(tmp_path, "strip", tag="imported") == "strip-imported"
+    (tmp_path / "strip-imported").mkdir()
+    assert workflow.unique_name(tmp_path, "strip", tag="imported") == "strip-imported-2"
+
+
+# ── layout ───────────────────────────────────────────────────────────────────
+
+
+def _legacy(root: Path, kind: str, name: str) -> Path:
+    d = root / kind / name
+    d.mkdir(parents=True)
+    workflow.write_recipe(d, Recipe(name=name, description=kind))
+    (d / "SKILL.md").write_text("---\nname: x\n---\n")
+    (d / "prose.json").write_text("null")
+    return d
+
+
+def test_migrate_layout_folds_active_and_draft_into_the_root(tmp_path: Path) -> None:
+    """Old active/ and draft/ entries move up; active wins a name, the draft is suffixed."""
+    _legacy(tmp_path, "active", "strip")
+    _legacy(tmp_path, "draft", "strip")
+    _legacy(tmp_path, "draft", "register")
+
+    workflow.migrate_layout(tmp_path)
+
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["register", "strip", "strip-draft"]
+    assert workflow.read_recipe(tmp_path / "strip").description == "active"
+    assert workflow.read_recipe(tmp_path / "strip-draft").description == "draft"
+    # The generated files of the skill era are gone; only the recipe remains.
+    for name in ("register", "strip", "strip-draft"):
+        assert sorted(p.name for p in (tmp_path / name).iterdir()) == ["recipe.yaml"]
+
+
+def test_migrate_layout_leaves_the_new_layout_alone(tmp_path: Path) -> None:
+    """A root already in the flat layout is untouched, and a missing root is fine."""
+    workflow.write_recipe(tmp_path / "strip", _recipe())
+    before = (tmp_path / "strip" / "recipe.yaml").stat().st_mtime_ns
+    workflow.migrate_layout(tmp_path)
+    assert (tmp_path / "strip" / "recipe.yaml").stat().st_mtime_ns == before
+    workflow.migrate_layout(tmp_path / "absent")
+    assert not (tmp_path / "absent").exists()
+
+
+def test_workflow_dir_requires_a_recipe(tmp_path: Path) -> None:
+    """Only a directory holding recipe.yaml counts as a workflow."""
+    workflow.write_recipe(tmp_path / "strip", _recipe())
+    (tmp_path / "junk").mkdir()
+    assert workflow.workflow_dir(tmp_path, "strip") == tmp_path / "strip"
+    assert workflow.workflow_dir(tmp_path, "junk") is None
+    assert workflow.workflow_dir(tmp_path, "nope") is None
+
+
+def test_list_workflows_rows(tmp_path: Path) -> None:
+    """Rows are sorted by name and carry the description; a broken recipe still lists."""
+    workflow.write_recipe(tmp_path / "strip", _recipe())
+    workflow.write_recipe(tmp_path / "align", Recipe(name="align", description="Align."))
+    (tmp_path / "broken").mkdir()
+    (tmp_path / "broken" / "recipe.yaml").write_text("name: [unclosed")
+    assert workflow.list_workflows(tmp_path) == [
+        {"name": "align", "description": "Align."},
+        {"name": "broken", "description": ""},
+        {"name": "strip", "description": "Skull strip a brain MRI."},
+    ]
+    assert workflow.list_workflows(tmp_path / "absent") == []

--- a/uv.lock
+++ b/uv.lock
@@ -740,7 +740,7 @@ wheels = [
 
 [[package]]
 name = "medmcp"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
Release 0.2.3. Workflow runs become server-side jobs that outlive the page, the run flow is one editor, and distillation is reduced to the single file the replay engine reads.

- **Runs**: a run keeps going when the page is closed or reloaded and the page reattaches to it; Stop is an explicit cancel; a run cut off by a server restart is marked failed on the next boot. Runs are recorded under `.vibe/runs/`, persisted by a new `vibe-runs` volume in both compose files, and reachable through `/api/runs`.
- **Run editor**: one screen replaces the Single/Batch switch and the separate preview. Inputs come from files picked in the explorer or from a cohort plan; every row's input files are checked before anything starts and a missing file is flagged on its row; the resolved steps sit behind a disclosure above one Run button. Outputs appear as file chips that open in the viewer.
- **Distillation**: writes one `recipe.yaml` per workflow and nothing else, with no model pass. A workflow is named after its chat; a taken name gets a numeric suffix instead of replacing another workflow, and a rename onto a taken name is refused.
- **Workflows**: the draft/active state, Promote, Refine and the generated `SKILL.md` are gone. Workflows live directly under `.vibe/workflows/`; existing `draft/` and `active/` folders are folded together on first use, keeping a draft shadowed by a promoted workflow of the same name under a `-draft` suffix. The share envelope is the recipe alone; files exported by earlier releases still import.

## Test plan
- [x] `just check`: ruff, format, pyright strict, 607 tests
- [x] `npm run build` and `npm run lint` in `frontend/`
- [x] Run records, attach/detach, cancel and interrupted-run reconciliation (`tests/test_runs.py`); per-item preview verdicts, reattach over `/ws/replay` and the rename conflict (`tests/test_server.py`)
- [x] Recipe schema round trip and the fold of `active/` + `draft/` into the root (`tests/test_workflow.py`); title-based naming, no overwrite on a name clash and the bare share envelope (`tests/test_distill.py`, `tests/test_share.py`)
- [x] Live on the containerized stack: a batch keeps running after its socket drops and the page reattaches on reload; a wrong input path is flagged on its row before Run is enabled; Stop cancels the in-flight tool step
- [x] Live in the compose container: a workflow stored under `active/` was folded into the root on first use and replayed on a new scan through `/ws/replay` (skull strip and MNI registration on the GPU stack, 54 s)

## Screenshots
No screenshots. The workflow panel loses the draft/active chips and the Promote and Refine actions; the run editor and run card use the panel's existing styles.

## Security & data handling
- New write path `.vibe/runs/<run_id>.json` (workflow name, bound input paths, step results, output paths). No patient data beyond the paths already in the recipe.
- New endpoints `GET /api/runs`, `GET|DELETE /api/runs/{id}`, `POST /api/runs/{id}/cancel`; removed `promote`, `unpromote`, `refine`. Loopback-only, behind the origin guard.
- A run continues without a browser attached. Replay still bypasses the permission flow by design; the editor's pre-flight and the Run button are the confirmation, and inputs remain confined to the workspace root.
- Distillation no longer calls the model. The one-time layout migration moves directories within `.vibe/workflows` and deletes the generated `SKILL.md` / `prose.json`; recipes are not modified. Nothing is loaded as an agent skill.

## Notes
- `medmcp promote`, `just promote` and `medmcp distill --no-llm` are gone.
- The layout migration is one-way: an earlier release will not list workflows saved or folded by this one.
- `medmcp replay` (CLI) still runs without writing a run record.
- After merging, tag `v0.2.3` to publish the release.
